### PR TITLE
docs: add top-level CLAUDE.md (orientation + release pointer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Ice 2
+
+macOS menu bar manager. Built with Xcode (`Ice.xcodeproj`, scheme `Ice`).
+
+## Release
+Tag `vX.Y.Z` → CI builds, signs (Developer ID), notarizes, publishes the binary
+here, pushes the Sparkle appcast to www.dragonapp.com, and bumps the Homebrew
+cask. (Owner Claude sessions: the shared build/sign/release SOP is in the
+`dragon-mac-ops` skill.)


### PR DESCRIPTION
## Add a top-level CLAUDE.md

This repo had no top-level `CLAUDE.md`, so Claude Code re-discovered the layout
each session. Adds a short orientation file: project one-liner, the Xcode
project/scheme, and a release summary. Includes a parenthetical pointer to the
owner's local `dragon-mac-ops` skill for build/sign/release SOP (harmless no-op
for other contributors).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
