### PR TITLE
Fix Sparkle update detection: bump build number + grant release workflow contents:write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ on:
       - 'v*'
   workflow_dispatch: {}
 
+# The reusable release workflow creates the GitHub Release and uploads assets,
+# which needs contents: write. This repo's default workflow token is read-only,
+# so grant write here or the reusable call is rejected at startup.
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v1

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -417,7 +417,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1124;
+				CURRENT_PROJECT_VERSION = 1125;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -433,7 +433,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.4.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -452,7 +452,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1124;
+				CURRENT_PROJECT_VERSION = 1125;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.4.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -433,7 +433,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 2.4.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;


### PR DESCRIPTION
## Why
Ice 2 2.3.0 users saw "you're up to date" instead of the newer release. Two root causes, plus a CI blocker found while fixing it:

1. **Build number stuck at 1124** across 2.3.0 and 2.4.0. Sparkle compares the build number (`CFBundleVersion` / appcast `sparkle:version`), not the marketing string, so `1124 == 1124` → no update offered.
2. **Release workflow `startup_failure`** — the shared `dragon-release-ci` reusable workflow requests `contents: write`, but this repo's default workflow token is read-only, so GitHub rejected the call at startup.

## Changes
- `043349e` bump `CURRENT_PROJECT_VERSION` 1124 → 1125
- `4f95773` set `MARKETING_VERSION` → 2.4.1
- `c815007` grant `permissions: contents: write` in `.github/workflows/release.yml`

## Verification
Shipped as `v2.4.1`: release run succeeded, published binary is build **1125**, and the live signed appcast at `www.dragonapp.com/ice-2/appcast.xml` now serves `sparkle:version 1125` / `2.4.1`. Installed 2.3.0 (build 1124) installs now detect the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)