### PR TITLE
Drop Intel support: Apple Silicon only, bump to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.5.0 - 2026-06-27
+
+This update makes Ice 2 an Apple Silicon–only app.
+
+### Changed
+
+- **Ice 2 now runs only on Apple Silicon Macs** (the M1, M2, M3, M4 chips and newer). Support for older Intel-based Macs has been removed. If your Mac was made in late 2020 or later, it almost certainly has an Apple Silicon chip and you're all set. (You can check under  → About This Mac — look for a "Chip" line that says "Apple M…".)
+- The app is now built just for Apple Silicon, so the download is a bit smaller and runs natively on your Mac with no Intel compatibility layer.
+
+### Note
+
+- If you're on an older Intel Mac, please stay on version 2.4.1, which remains available and continues to work.
+
 ## 2.3.0 - 2026-06-26
 
 This release focuses on stability fixes for Tahoe/macOS 26 and early macOS 27 behavior reported upstream in `jordanbaird/Ice`.

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -287,6 +287,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -353,6 +354,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -417,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1125;
+				CURRENT_PROJECT_VERSION = 1126;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -433,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -452,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1125;
+				CURRENT_PROJECT_VERSION = 1126;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -468,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.1;
+				MARKETING_VERSION = 2.5.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;


### PR DESCRIPTION
## What

Makes Ice 2 an Apple Silicon–only app and bumps the version to **2.5.0**.

## Changes

- **Apple Silicon only:** pinned `ARCHS = arm64` at the project level. Both the `Ice` app and the `MenuBarItemService` XPC helper now build for Apple Silicon (M-series) instead of a universal arm64 + x86_64 binary. There was **no Intel-specific source code** to remove — the universal build came purely from Xcode's default architecture setting.
- **Version bump:** `MARKETING_VERSION` 2.4.1 → **2.5.0**, `CURRENT_PROJECT_VERSION` 1125 → **1126** (the build-number bump is required so Sparkle detects the update).
- **Changelog:** added a plain-language 2.5.0 entry explaining the Apple Silicon requirement, how to check your Mac's chip, and a note that Intel users should stay on 2.4.1.

## Verification

xcodebuild -showBuildSettings resolves to ARCHS = arm64, MARKETING_VERSION = 2.5.0, CURRENT_PROJECT_VERSION = 1126. Changes are config + docs only; no source logic touched.

## Note

No tag pushed — release CI is intentionally **not** triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)