### PR TITLE
Release 2.5.1: enable always-hidden section by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.1 - 2026-06-27
+
+### Changed
+
+- The always-hidden menu bar section is now enabled by default. You can still turn it off under Settings → Advanced → Menu Bar Sections.
+
 ## 2.5.0 - 2026-06-27
 
 This update makes Ice 2 an Apple Silicon–only app.

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1126;
+				CURRENT_PROJECT_VERSION = 1127;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1126;
+				CURRENT_PROJECT_VERSION = 1127;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.0;
+				MARKETING_VERSION = 2.5.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;

--- a/Ice/Settings/Models/AdvancedSettings.swift
+++ b/Ice/Settings/Models/AdvancedSettings.swift
@@ -13,7 +13,7 @@ import SwiftUI
 final class AdvancedSettings: ObservableObject {
     /// A Boolean value that indicates whether the always-hidden section
     /// is enabled.
-    @Published var enableAlwaysHiddenSection = false
+    @Published var enableAlwaysHiddenSection = true
 
     /// A Boolean value that indicates whether to show all sections when
     /// the user is dragging items in the menu bar.


### PR DESCRIPTION
## Summary

- Default the always-hidden menu bar section to **on** (`AdvancedSettings.enableAlwaysHiddenSection`). Users can still disable it under Settings → Advanced → Menu Bar Sections.
- Bugfix version bump: marketing version 2.5.0 → **2.5.1**, build 1126 → **1127** (build bump required for Sparkle to detect the update).
- CHANGELOG entry for 2.5.1.

## Verification

- `xcodebuild -scheme Ice -configuration Release` → **BUILD SUCCEEDED**
- Built app reports `CFBundleShortVersionString 2.5.1`, `CFBundleVersion 1127`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)