### PR TITLE
Show hidden items on hover over the Ice 2 icon (v2.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.5.3 - 2026-06-28
+
+### Added
+
+- New option to show hidden menu bar items by hovering over the Ice 2 icon. Turn it on under Settings → General → "Show on hover over Ice 2 icon" (off by default). Each hover option now has its own delay slider shown right beneath it.
+
+### Changed
+
+- The existing "Show on hover" option is now labelled "Show on hover over empty menu bar" to make clear it reacts to empty areas of the menu bar, and its delay slider moved from Advanced settings to sit directly beneath the option in General settings. The "Automatically rehide" options now sit in the same section as the show options.
+
 ## 2.5.2 - 2026-06-27
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1128;
+				CURRENT_PROJECT_VERSION = 1129;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1128;
+				CURRENT_PROJECT_VERSION = 1129;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.2;
+				MARKETING_VERSION = 2.5.3;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;

--- a/Ice/Events/HIDEventManager.swift
+++ b/Ice/Events/HIDEventManager.swift
@@ -362,9 +362,13 @@ extension HIDEventManager {
     // MARK: Handle Show On Hover
 
     private func handleShowOnHover(appState: AppState, screen: NSScreen) {
-        // Make sure the "ShowOnHover" feature is enabled and allowed.
+        let showOnHoverEmptyMenuBar = appState.settings.general.showOnHoverEmptyMenuBar
+        let showOnHoverOverIceIcon = appState.settings.general.showOnHoverOverIceIcon
+
+        // Make sure at least one "ShowOnHover" trigger is enabled and the
+        // feature is allowed.
         guard
-            appState.settings.general.showOnHoverEmptyMenuBar,
+            showOnHoverEmptyMenuBar || showOnHoverOverIceIcon,
             appState.menuBarManager.showOnHoverAllowed
         else {
             return
@@ -375,19 +379,37 @@ extension HIDEventManager {
             return
         }
 
-        let delay = appState.settings.general.showOnHoverEmptyMenuBarDelay
+        let emptyMenuBarDelay = appState.settings.general.showOnHoverEmptyMenuBarDelay
+        let iceIconDelay = appState.settings.general.showOnHoverOverIceIconDelay
 
         if hiddenSection.isHidden {
-            guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
-                return
-            }
-            Task {
-                try await Task.sleep(for: .seconds(delay))
-                // Make sure the mouse is still inside.
-                guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
-                    return
+            // The Ice icon is a menu bar item, so it is never inside the
+            // "empty menu bar space"; the two triggers are mutually exclusive
+            // positions.
+            if
+                showOnHoverEmptyMenuBar,
+                isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen)
+            {
+                Task {
+                    try await Task.sleep(for: .seconds(emptyMenuBarDelay))
+                    // Make sure the mouse is still inside.
+                    guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
+                        return
+                    }
+                    hiddenSection.show()
                 }
-                hiddenSection.show()
+            } else if
+                showOnHoverOverIceIcon,
+                isMouseInsideIceIcon(appState: appState)
+            {
+                Task {
+                    try await Task.sleep(for: .seconds(iceIconDelay))
+                    // Make sure the mouse is still inside the Ice icon.
+                    guard isMouseInsideIceIcon(appState: appState) else {
+                        return
+                    }
+                    hiddenSection.show()
+                }
             }
         } else {
             guard
@@ -397,8 +419,14 @@ extension HIDEventManager {
             else {
                 return
             }
+            // Use the larger of the enabled delays as the rehide debounce so
+            // items never vanish faster than the slowest trigger reacts.
+            let rehideDelay = max(
+                showOnHoverEmptyMenuBar ? emptyMenuBarDelay : 0,
+                showOnHoverOverIceIcon ? iceIconDelay : 0
+            )
             Task {
-                try await Task.sleep(for: .seconds(delay))
+                try await Task.sleep(for: .seconds(rehideDelay))
                 // Make sure the mouse is still outside.
                 guard
                     !isMouseInsideMenuBar(appState: appState, screen: screen),
@@ -416,7 +444,8 @@ extension HIDEventManager {
 
     private func handlePreventShowOnHover(with event: NSEvent, appState: AppState, screen: NSScreen) {
         guard
-            appState.settings.general.showOnHoverEmptyMenuBar,
+            appState.settings.general.showOnHoverEmptyMenuBar
+                || appState.settings.general.showOnHoverOverIceIcon,
             !appState.settings.general.useIceBar
         else {
             return

--- a/Ice/Events/HIDEventManager.swift
+++ b/Ice/Events/HIDEventManager.swift
@@ -364,7 +364,7 @@ extension HIDEventManager {
     private func handleShowOnHover(appState: AppState, screen: NSScreen) {
         // Make sure the "ShowOnHover" feature is enabled and allowed.
         guard
-            appState.settings.general.showOnHover,
+            appState.settings.general.showOnHoverEmptyMenuBar,
             appState.menuBarManager.showOnHoverAllowed
         else {
             return
@@ -375,7 +375,7 @@ extension HIDEventManager {
             return
         }
 
-        let delay = appState.settings.advanced.showOnHoverDelay
+        let delay = appState.settings.general.showOnHoverEmptyMenuBarDelay
 
         if hiddenSection.isHidden {
             guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
@@ -416,7 +416,7 @@ extension HIDEventManager {
 
     private func handlePreventShowOnHover(with event: NSEvent, appState: AppState, screen: NSScreen) {
         guard
-            appState.settings.general.showOnHover,
+            appState.settings.general.showOnHoverEmptyMenuBar,
             !appState.settings.general.useIceBar
         else {
             return

--- a/Ice/Settings/Models/AdvancedSettings.swift
+++ b/Ice/Settings/Models/AdvancedSettings.swift
@@ -30,9 +30,6 @@ final class AdvancedSettings: ObservableObject {
     /// when the user right-clicks the menu bar.
     @Published var enableSecondaryContextMenu = true
 
-    /// The delay before showing on hover.
-    @Published var showOnHoverDelay: TimeInterval = 0.2
-
     /// Time interval to temporarily show items for.
     @Published var tempShowInterval: TimeInterval = 15
 
@@ -55,7 +52,6 @@ final class AdvancedSettings: ObservableObject {
         Defaults.ifPresent(key: .showAllSectionsOnUserDrag, assign: &showAllSectionsOnUserDrag)
         Defaults.ifPresent(key: .hideApplicationMenus, assign: &hideApplicationMenus)
         Defaults.ifPresent(key: .enableSecondaryContextMenu, assign: &enableSecondaryContextMenu)
-        Defaults.ifPresent(key: .showOnHoverDelay, assign: &showOnHoverDelay)
         Defaults.ifPresent(key: .tempShowInterval, assign: &tempShowInterval)
 
         Defaults.ifPresent(key: .sectionDividerStyle) { rawValue in
@@ -101,13 +97,6 @@ final class AdvancedSettings: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { enable in
                 Defaults.set(enable, forKey: .enableSecondaryContextMenu)
-            }
-            .store(in: &c)
-
-        $showOnHoverDelay
-            .receive(on: DispatchQueue.main)
-            .sink { delay in
-                Defaults.set(delay, forKey: .showOnHoverDelay)
             }
             .store(in: &c)
 

--- a/Ice/Settings/Models/GeneralSettings.swift
+++ b/Ice/Settings/Models/GeneralSettings.swift
@@ -60,6 +60,14 @@ final class GeneralSettings: ObservableObject {
     @Published var showOnHoverEmptyMenuBarDelay: TimeInterval = 0.2
 
     /// A Boolean value that indicates whether the hidden section
+    /// should be shown when the mouse pointer hovers over the Ice icon.
+    @Published var showOnHoverOverIceIcon = false
+
+    /// The delay before showing the hidden section when hovering over
+    /// the Ice icon.
+    @Published var showOnHoverOverIceIconDelay: TimeInterval = 0.2
+
+    /// A Boolean value that indicates whether the hidden section
     /// should be shown or hidden when the user scrolls in the
     /// menu bar.
     @Published var showOnScroll = true
@@ -107,6 +115,8 @@ final class GeneralSettings: ObservableObject {
         Defaults.ifPresent(key: .showOnClick, assign: &showOnClick)
         Defaults.ifPresent(key: .showOnHover, assign: &showOnHoverEmptyMenuBar)
         Defaults.ifPresent(key: .showOnHoverDelay, assign: &showOnHoverEmptyMenuBarDelay)
+        Defaults.ifPresent(key: .showOnHoverOverIceIcon, assign: &showOnHoverOverIceIcon)
+        Defaults.ifPresent(key: .showOnHoverOverIceIconDelay, assign: &showOnHoverOverIceIconDelay)
         Defaults.ifPresent(key: .showOnScroll, assign: &showOnScroll)
         Defaults.ifPresent(key: .itemSpacingOffset, assign: &itemSpacingOffset)
         Defaults.ifPresent(key: .autoRehide, assign: &autoRehide)
@@ -230,8 +240,8 @@ final class GeneralSettings: ObservableObject {
 
         $showOnHoverEmptyMenuBar
             .receive(on: DispatchQueue.main)
-            .sink { showOnHover in
-                Defaults.set(showOnHover, forKey: .showOnHover)
+            .sink { showOnHoverEmptyMenuBar in
+                Defaults.set(showOnHoverEmptyMenuBar, forKey: .showOnHover)
             }
             .store(in: &c)
 
@@ -239,6 +249,20 @@ final class GeneralSettings: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { delay in
                 Defaults.set(delay, forKey: .showOnHoverDelay)
+            }
+            .store(in: &c)
+
+        $showOnHoverOverIceIcon
+            .receive(on: DispatchQueue.main)
+            .sink { showOnHoverOverIceIcon in
+                Defaults.set(showOnHoverOverIceIcon, forKey: .showOnHoverOverIceIcon)
+            }
+            .store(in: &c)
+
+        $showOnHoverOverIceIconDelay
+            .receive(on: DispatchQueue.main)
+            .sink { delay in
+                Defaults.set(delay, forKey: .showOnHoverOverIceIconDelay)
             }
             .store(in: &c)
 

--- a/Ice/Settings/Models/GeneralSettings.swift
+++ b/Ice/Settings/Models/GeneralSettings.swift
@@ -53,7 +53,11 @@ final class GeneralSettings: ObservableObject {
     /// A Boolean value that indicates whether the hidden section
     /// should be shown when the mouse pointer hovers over an
     /// empty area of the menu bar.
-    @Published var showOnHover = false
+    @Published var showOnHoverEmptyMenuBar = false
+
+    /// The delay before showing the hidden section when hovering over
+    /// an empty area of the menu bar.
+    @Published var showOnHoverEmptyMenuBarDelay: TimeInterval = 0.2
 
     /// A Boolean value that indicates whether the hidden section
     /// should be shown or hidden when the user scrolls in the
@@ -101,7 +105,8 @@ final class GeneralSettings: ObservableObject {
         Defaults.ifPresent(key: .autoEnableIceBar, assign: &autoEnableIceBar)
         Defaults.ifPresent(key: .iceBarDisplayWidthThreshold, assign: &iceBarDisplayWidthThreshold)
         Defaults.ifPresent(key: .showOnClick, assign: &showOnClick)
-        Defaults.ifPresent(key: .showOnHover, assign: &showOnHover)
+        Defaults.ifPresent(key: .showOnHover, assign: &showOnHoverEmptyMenuBar)
+        Defaults.ifPresent(key: .showOnHoverDelay, assign: &showOnHoverEmptyMenuBarDelay)
         Defaults.ifPresent(key: .showOnScroll, assign: &showOnScroll)
         Defaults.ifPresent(key: .itemSpacingOffset, assign: &itemSpacingOffset)
         Defaults.ifPresent(key: .autoRehide, assign: &autoRehide)
@@ -223,10 +228,17 @@ final class GeneralSettings: ObservableObject {
             }
             .store(in: &c)
 
-        $showOnHover
+        $showOnHoverEmptyMenuBar
             .receive(on: DispatchQueue.main)
             .sink { showOnHover in
                 Defaults.set(showOnHover, forKey: .showOnHover)
+            }
+            .store(in: &c)
+
+        $showOnHoverEmptyMenuBarDelay
+            .receive(on: DispatchQueue.main)
+            .sink { delay in
+                Defaults.set(delay, forKey: .showOnHoverDelay)
             }
             .store(in: &c)
 

--- a/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -37,7 +37,6 @@ struct AdvancedSettingsPane: View {
             IceSection("Other") {
                 hideApplicationMenus
                 enableSecondaryContextMenu
-                showOnHoverDelay
                 tempShowInterval
             }
             IceSection("Permissions") {
@@ -168,25 +167,6 @@ struct AdvancedSettingsPane: View {
             )
             .padding(.trailing, 75)
         }
-    }
-
-    @ViewBuilder
-    private var showOnHoverDelay: some View {
-        LabeledContent {
-            IceSlider(
-                formattedToSeconds(settings.showOnHoverDelay),
-                value: $settings.showOnHoverDelay,
-                in: 0...1,
-                step: 0.1
-            )
-        } label: {
-            Text("Show on hover delay")
-                .frame(minWidth: maxSliderLabelWidth, alignment: .leading)
-                .onFrameChange { frame in
-                    maxSliderLabelWidth = max(maxSliderLabelWidth, frame.width)
-                }
-        }
-        .annotation("The amount of time to wait before showing on hover.")
     }
 
     @ViewBuilder

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -283,17 +283,20 @@ struct GeneralSettingsPane: View {
             .annotation("The amount of time to wait before showing hidden items.")
         }
 
-        Toggle("Show on hover over Ice 2 icon", isOn: $settings.showOnHoverOverIceIcon)
-            .annotation("Hover over the Ice 2 icon to show hidden menu bar items.")
-        if settings.showOnHoverOverIceIcon {
-            IceSlider(
-                formattedToSeconds(settings.showOnHoverOverIceIconDelay),
-                value: $settings.showOnHoverOverIceIconDelay,
-                in: 0...1,
-                step: 0.1
-            )
-            .annotation("The amount of time to wait before showing hidden items.")
+        VStack(alignment: .leading, spacing: 6) {
+            Toggle("Show on hover over Ice 2 icon", isOn: $settings.showOnHoverOverIceIcon)
+                .annotation("Hover over the Ice 2 icon to show hidden menu bar items. Requires the Ice 2 icon to be shown.")
+            if settings.showOnHoverOverIceIcon {
+                IceSlider(
+                    formattedToSeconds(settings.showOnHoverOverIceIconDelay),
+                    value: $settings.showOnHoverOverIceIconDelay,
+                    in: 0...1,
+                    step: 0.1
+                )
+                .annotation("The amount of time to wait before showing hidden items.")
+            }
         }
+        .disabled(!settings.showIceIcon)
 
         Toggle("Show on scroll", isOn: $settings.showOnScroll)
             .annotation("Scroll or swipe in the menu bar to show hidden menu bar items.")

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -46,8 +46,6 @@ struct GeneralSettingsPane: View {
             }
             IceSection {
                 showOptions
-            }
-            IceSection {
                 rehideOptions
             }
             IceSection {
@@ -282,6 +280,19 @@ struct GeneralSettingsPane: View {
                 in: 0...1,
                 step: 0.1
             )
+            .annotation("The amount of time to wait before showing hidden items.")
+        }
+
+        Toggle("Show on hover over Ice 2 icon", isOn: $settings.showOnHoverOverIceIcon)
+            .annotation("Hover over the Ice 2 icon to show hidden menu bar items.")
+        if settings.showOnHoverOverIceIcon {
+            IceSlider(
+                formattedToSeconds(settings.showOnHoverOverIceIconDelay),
+                value: $settings.showOnHoverOverIceIconDelay,
+                in: 0...1,
+                step: 0.1
+            )
+            .annotation("The amount of time to wait before showing hidden items.")
         }
 
         Toggle("Show on scroll", isOn: $settings.showOnScroll)

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -259,12 +259,31 @@ struct GeneralSettingsPane: View {
 
     // MARK: Show Options
 
+    private func formattedToSeconds(_ interval: TimeInterval) -> LocalizedStringKey {
+        let formatted = interval.formatted()
+        return if interval == 1 {
+            LocalizedStringKey(formatted + " second")
+        } else {
+            LocalizedStringKey(formatted + " seconds")
+        }
+    }
+
     @ViewBuilder
     private var showOptions: some View {
         Toggle("Show on click", isOn: $settings.showOnClick)
             .annotation("Click inside an empty area of the menu bar to show hidden menu bar items.")
-        Toggle("Show on hover", isOn: $settings.showOnHover)
+
+        Toggle("Show on hover over empty menu bar", isOn: $settings.showOnHoverEmptyMenuBar)
             .annotation("Hover over an empty area of the menu bar to show hidden menu bar items.")
+        if settings.showOnHoverEmptyMenuBar {
+            IceSlider(
+                formattedToSeconds(settings.showOnHoverEmptyMenuBarDelay),
+                value: $settings.showOnHoverEmptyMenuBarDelay,
+                in: 0...1,
+                step: 0.1
+            )
+        }
+
         Toggle("Show on scroll", isOn: $settings.showOnScroll)
             .annotation("Scroll or swipe in the menu bar to show hidden menu bar items.")
     }

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -148,6 +148,9 @@ extension Defaults {
         case iceBarLocation = "IceBarLocation"
         case showOnClick = "ShowOnClick"
         case showOnHover = "ShowOnHover"
+        case showOnHoverDelay = "ShowOnHoverDelay"
+        case showOnHoverOverIceIcon = "ShowOnHoverOverIceIcon"
+        case showOnHoverOverIceIconDelay = "ShowOnHoverOverIceIconDelay"
         case showOnScroll = "ShowOnScroll"
         case autoRehide = "AutoRehide"
         case rehideStrategy = "RehideStrategy"
@@ -167,7 +170,6 @@ extension Defaults {
         case sectionDividerStyle = "SectionDividerStyle"
         case hideApplicationMenus = "HideApplicationMenus"
         case enableSecondaryContextMenu = "EnableSecondaryContextMenu"
-        case showOnHoverDelay = "ShowOnHoverDelay"
         case tempShowInterval = "TempShowInterval"
 
         // MARK: Appearance Settings


### PR DESCRIPTION
## Summary

- Adds an opt-in feature (**default off**): hovering the mouse over the Ice 2 icon reveals the hidden menu bar section after a configurable delay. New toggle: Settings → General → "Show on hover over Ice 2 icon".
- Renames the existing "Show on hover" (empty-gap) option to **"Show on hover over empty menu bar"** for clarity (persisted UserDefaults key kept for backward compatibility).
- Splits the single show-on-hover delay into a **per-toggle delay**, moved from the Advanced pane to sit directly beneath each hover option in General.
- Groups the **"Automatically rehide"** controls into the same section as the show options.
- Bumps version 2.5.2 → **2.5.3** (build 1128 → 1129) + CHANGELOG.

## Implementation notes

- Reuses the existing `HIDEventManager.handleShowOnHover` and the `isMouseInsideIceIcon` helper — no new event monitors/timers. The two triggers are mutually exclusive positions (the Ice icon is a menu bar item, "empty space" excludes items).
- The icon-hover toggle is disabled when "Show Ice 2 icon" is off (the feature can't work without a visible icon).

## Test Plan

No automated test target exists for this live-mouse-event/UI code; verified by build + manual smoke test:

- [ ] Build succeeds (`xcodebuild ... -scheme Ice build`) — verified locally (`** BUILD SUCCEEDED **`)
- [ ] Existing users keep their "Show on hover" setting (migrated to the renamed option) and delay value
- [ ] Toggle on → hovering the Ice 2 icon shows hidden items after the delay; moving away rehides
- [ ] The two hover delays act independently
- [ ] "Show Ice 2 icon" off → the icon-hover option greys out
- [ ] "Show on hover delay" no longer appears in the Advanced pane
- [ ] "Automatically rehide" now sits in the show-options section

🤖 Generated with [Claude Code](https://claude.com/claude-code)