### PR TITLE
Reflect Teddy Chan as active maintainer; keep Jordan Baird credit

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: jordanbaird
-buy_me_a_coffee: jordanbaird

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Search for Similar Reports
       description: |
-        Please use the search feature on the repository's [Issues](https://github.com/jordanbaird/Ice/issues) page to see if a report already exists for the bug you encountered. Make sure to include both open and closed issues in your search.
+        Please use the search feature on the repository's [Issues](https://github.com/teddychan/ice-2/issues) page to see if a report already exists for the bug you encountered. Make sure to include both open and closed issues in your search.
 
         **Important**: Only submit a new issue if the bug you encountered hasn't been reported in an existing open issue, or if a regression has occurred with a previously closed issue.
       options:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Search for Similar Requests
       description: |
-        Please use the search feature on the repository's [Issues](https://github.com/jordanbaird/Ice/issues) page to see if this feature has already been requested. Make sure to include both open and closed issues in your search.
+        Please use the search feature on the repository's [Issues](https://github.com/teddychan/ice-2/issues) page to see if this feature has already been requested. Make sure to include both open and closed issues in your search.
 
         **Important**: Only submit a new issue if the feature you want hasn't been requested in another issue.
       options:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-jordanbaird.dev@gmail.com.
+teddychan@gmail.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Jordan Baird";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Jordan Baird · © 2026 Teddy Chan";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -399,7 +399,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Jordan Baird";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Jordan Baird · © 2026 Teddy Chan";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;

--- a/Ice/Settings/SettingsPanes/AboutSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AboutSettingsPane.swift
@@ -23,10 +23,6 @@ struct AboutSettingsPane: View {
         contributeURL.appendingPathComponent("issues")
     }
 
-    private var donateURL: URL {
-        URL(string: "https://icemenubar.app/Donate")!
-    }
-
     private var lastUpdateCheckString: String {
         if let date = updatesManager.lastUpdateCheckDate {
             date.formatted(date: .abbreviated, time: .standard)
@@ -155,9 +151,6 @@ struct AboutSettingsPane: View {
             }
             Button("Report a Bug") {
                 openURL(issuesURL)
-            }
-            Button("Support Ice 2", systemImage: "heart.circle.fill") {
-                openURL(donateURL)
             }
         }
         .padding(8)

--- a/README.md
+++ b/README.md
@@ -10,16 +10,11 @@ Ice 2 is a powerful menu bar management tool. While its primary function is hidi
 [![Download](https://img.shields.io/badge/download-latest-brightgreen?style=flat-square)](https://github.com/teddychan/ice-2/releases/latest)
 ![Platform](https://img.shields.io/badge/platform-macOS-blue?style=flat-square)
 ![Requirements](https://img.shields.io/badge/requirements-macOS%2014%2B-fa4e49?style=flat-square)
-[![Sponsor](https://img.shields.io/badge/Sponsor%20%E2%9D%A4%EF%B8%8F-8A2BE2?style=flat-square)](https://github.com/sponsors/jordanbaird)
-[![Website](https://img.shields.io/badge/Website-015FBA?style=flat-square)](https://icemenubar.app)
+[![Website](https://img.shields.io/badge/Website-015FBA?style=flat-square)](https://www.dragonapp.com/ice-2/)
 [![License](https://img.shields.io/github/license/teddychan/ice-2?style=flat-square)](LICENSE)
 
 > [!NOTE]
-> Ice 2 is currently in active development. Some features have not yet been implemented. Download the latest release [here](https://github.com/teddychan/ice-2/releases/latest) and see the roadmap below for upcoming features.
-
-<a href="https://www.buymeacoffee.com/jordanbaird" target="_blank">
-    <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;">
-</a>
+> Ice 2 is an independent, open-source fork of [Ice](https://github.com/jordanbaird/Ice) — the menu bar manager originally created by [Jordan Baird](https://github.com/jordanbaird) — now actively maintained by [Teddy Chan](https://github.com/teddychan) and carried forward to support modern macOS. Download the latest release [here](https://github.com/teddychan/ice-2/releases/latest) and see the roadmap below for upcoming features.
 
 ## Install
 
@@ -129,6 +124,10 @@ Ice 2 uses a number of system APIs that are available starting in macOS 14. As s
 
 ![Menu Bar Item Spacing](https://github.com/user-attachments/assets/b196aa7e-184a-4d4c-b040-502f4aae40a6)
 
+## Credits
+
+Ice 2 is a fork of [Ice](https://github.com/jordanbaird/Ice), created by [Jordan Baird](https://github.com/jordanbaird). All credit for the original app goes to him and its contributors. Ice 2 is currently maintained by [Teddy Chan](https://github.com/teddychan).
+
 ## License
 
-Ice 2 is available under the [GPL-3.0 license](LICENSE).
+Ice 2 is available under the [GPL-3.0 license](LICENSE), the same license as the original Ice.


### PR DESCRIPTION
Presents Teddy Chan as the active maintainer of Ice 2 while keeping full credit to original author Jordan Baird.

- About-screen copyright credits both Jordan Baird and Teddy Chan
- README: maintainer note + Credits section crediting original Ice; Website badge → dragonapp.com/ice-2; funding badges removed
- Issue templates link to teddychan/ice-2 issues; Code of Conduct contact updated
- Remove funding: delete FUNDING.yml and the in-app donate button

License stays GPL-3.0 (inherited from upstream Ice; not relicensable to MIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)