### PR TITLE
Fix release CI: pin dragon-release-ci to @v2 for swiftpm_runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v1
+    uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v2
     secrets: inherit
     with:
       build_kind: xcodebuild


### PR DESCRIPTION
The v2.5.4 release run hit `startup_failure` because the caller pinned the reusable workflow at `@v1`, which predates the `swiftpm_runner` input — passing `swiftpm_runner: macos-26` to it is an unexpected input.

`@v2` defines `swiftpm_runner` (and drives `runs-on` for all build kinds) while retaining the `xcodebuild` archive path ice-2 uses (verified). Same ref clipmenu-2 uses.

After merge, the `v2.5.4` tag will be re-pointed to trigger a clean release on a `macos-26` runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)