### PR TITLE
Back up & restore settings to a folder (sync-ready)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.0 - 2026-06-29
+
+### Added
+
+- **Back up & restore your settings.** A new **Backup & Restore** settings pane saves a snapshot of all your Ice 2 settings — layout profiles, item groups, spacers, triggers, hotkeys, and appearance — to a folder you choose. Ice 2 keeps the newest 10 backups, backs up automatically when you quit, and restores any backup in one click. Point the backup folder at Dropbox, iCloud Drive, or Google Drive to sync your settings across Macs or set up a new Mac.
+
 ## 2.5.3 - 2026-06-28
 
 ### Added

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1130;
+				CURRENT_PROJECT_VERSION = 1131;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.4;
+				MARKETING_VERSION = 2.6.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1130;
+				CURRENT_PROJECT_VERSION = 1131;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.5.4;
+				MARKETING_VERSION = 2.6.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;

--- a/Ice/Main/AppDelegate.swift
+++ b/Ice/Main/AppDelegate.swift
@@ -75,6 +75,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
+    func applicationWillTerminate(_ notification: Notification) {
+        // Keep the (possibly synced) backup folder current on quit. Best-effort:
+        // a failure here must never block termination.
+        guard SettingsBackup.automaticBackupEnabled() else {
+            return
+        }
+        do {
+            try SettingsBackup.performBackup(date: Date())
+        } catch {
+            Logger.default.error("Automatic backup on quit failed - \(error.localizedDescription)")
+        }
+    }
+
     // MARK: Other Methods
 
     /// Opens the settings window and activates the app.

--- a/Ice/Main/Navigation/NavigationIdentifiers/SettingsNavigationIdentifier.swift
+++ b/Ice/Main/Navigation/NavigationIdentifiers/SettingsNavigationIdentifier.swift
@@ -10,6 +10,7 @@ enum SettingsNavigationIdentifier: String, NavigationIdentifier {
     case menuBarAppearance = "Menu Bar Appearance"
     case hotkeys = "Hotkeys"
     case advanced = "Advanced"
+    case backup = "Backup & Restore"
     case about = "About"
 
     var iconResource: IconResource {
@@ -19,6 +20,7 @@ enum SettingsNavigationIdentifier: String, NavigationIdentifier {
         case .menuBarAppearance: .systemSymbol("swatchpalette")
         case .hotkeys: .systemSymbol("keyboard")
         case .advanced: .systemSymbol("gearshape.2")
+        case .backup: .systemSymbol("externaldrive.badge.timemachine")
         case .about: .assetCatalog(.iceCubeStroke)
         }
     }

--- a/Ice/Settings/Backup/SettingsBackup.swift
+++ b/Ice/Settings/Backup/SettingsBackup.swift
@@ -1,0 +1,228 @@
+//
+//  SettingsBackup.swift
+//  Ice
+//
+
+import Foundation
+
+/// Folder-based backup & restore of all of Ice's settings.
+///
+/// Ice keeps every user setting in `UserDefaults.standard` under the keys in
+/// `Defaults.Key` — including the Codable blobs (layout profiles, item groups,
+/// spacers, triggers, appearance config, hotkeys), which are stored as raw
+/// `Data`. A backup is therefore just a snapshot of those keys written to a
+/// property-list file; a restore writes them back and relaunches. This sidesteps
+/// decoding every Codable type and picks up any future key automatically.
+///
+/// Ice is distributed via Developer ID (not sandboxed), so it can read and write
+/// any folder the user picks — point the backup folder at Dropbox, iCloud Drive,
+/// or Google Drive to sync settings across Macs.
+///
+/// All of the logic here is pure / injectable (takes a `UserDefaults` and folder
+/// URL) so it can be exercised without the running app.
+enum SettingsBackup {
+    /// Bumped only if the on-disk format changes incompatibly.
+    static let schemaVersion = 1
+
+    /// File extension for backup files.
+    static let fileExtension = "icebackup"
+
+    /// Keys NOT included in a backup: deprecated keys (so a restore can't
+    /// resurrect state the app has migrated away from) and the backup feature's
+    /// own meta-settings (which are machine-specific and shouldn't travel).
+    static let excludedKeys: Set<Defaults.Key> = [
+        .showSectionDividers, .canToggleAlwaysHiddenSection, .sections,
+        .backupFolderPath, .automaticBackupEnabled,
+    ]
+
+    /// The settings keys carried in a backup.
+    static var backedUpKeys: [Defaults.Key] {
+        Defaults.Key.allCases.filter { !excludedKeys.contains($0) }
+    }
+
+    enum BackupError: Error, Equatable {
+        case malformed
+        case unsupportedVersion(Int)
+    }
+
+    private enum PayloadKey {
+        static let schemaVersion = "schemaVersion"
+        static let appVersion = "appVersion"
+        static let createdDate = "createdDate"
+        static let defaults = "defaults"
+    }
+
+    // MARK: - Snapshot / apply (pure)
+
+    /// Build a backup payload from the values currently stored under `keys`.
+    /// Only keys that actually have a stored value are included.
+    static func makePayload(
+        keys: [Defaults.Key] = backedUpKeys,
+        from defaults: UserDefaults,
+        appVersion: String,
+        createdDate: Date
+    ) -> [String: Any] {
+        var stored: [String: Any] = [:]
+        for key in keys {
+            if let value = defaults.object(forKey: key.rawValue) {
+                stored[key.rawValue] = value
+            }
+        }
+        return [
+            PayloadKey.schemaVersion: schemaVersion,
+            PayloadKey.appVersion: appVersion,
+            PayloadKey.createdDate: createdDate,
+            PayloadKey.defaults: stored,
+        ]
+    }
+
+    /// Apply a payload's stored values onto `defaults`. For every backed-up key
+    /// the stored value replaces the current one; a key absent from the backup is
+    /// removed, so a restore reproduces the backup exactly (a replace, not a
+    /// merge). Keys outside `keys` (unrelated app/global defaults) are untouched.
+    static func apply(
+        _ payload: [String: Any],
+        to defaults: UserDefaults,
+        keys: [Defaults.Key] = backedUpKeys
+    ) {
+        let stored = payload[PayloadKey.defaults] as? [String: Any] ?? [:]
+        for key in keys {
+            if let value = stored[key.rawValue] {
+                defaults.set(value, forKey: key.rawValue)
+            } else {
+                defaults.removeObject(forKey: key.rawValue)
+            }
+        }
+    }
+
+    /// The date a payload was created, if present.
+    static func createdDate(of payload: [String: Any]) -> Date? {
+        payload[PayloadKey.createdDate] as? Date
+    }
+
+    /// The app version recorded in a payload, if present.
+    static func appVersion(of payload: [String: Any]) -> String? {
+        payload[PayloadKey.appVersion] as? String
+    }
+
+    // MARK: - Serialize (pure)
+
+    static func serialize(_ payload: [String: Any]) throws -> Data {
+        try PropertyListSerialization.data(fromPropertyList: payload, format: .binary, options: 0)
+    }
+
+    /// Parse a backup file's data and validate its schema version.
+    static func deserialize(_ data: Data) throws -> [String: Any] {
+        let object = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+        guard let payload = object as? [String: Any] else {
+            throw BackupError.malformed
+        }
+        let version = payload[PayloadKey.schemaVersion] as? Int ?? 0
+        guard version <= schemaVersion else {
+            throw BackupError.unsupportedVersion(version)
+        }
+        return payload
+    }
+
+    // MARK: - Files & retention
+
+    /// Default backup folder when the user hasn't chosen one: ~/Documents/Ice Backups.
+    static func defaultFolder(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        home.appending(path: "Documents/Ice Backups", directoryHint: .isDirectory)
+    }
+
+    /// A lexically-sortable timestamp, e.g. "2026-06-29-013045".
+    static func timestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        return formatter.string(from: date)
+    }
+
+    /// Backup filename for a date, e.g. "Ice-Settings-2026-06-29-013045.icebackup".
+    static func fileName(for date: Date) -> String {
+        "Ice-Settings-\(timestamp(date)).\(fileExtension)"
+    }
+
+    /// Write a backup of `defaults` into `folder` (created if needed) and return
+    /// the file URL.
+    @discardableResult
+    static func writeBackup(
+        of defaults: UserDefaults,
+        to folder: URL,
+        appVersion: String,
+        date: Date
+    ) throws -> URL {
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let payload = makePayload(from: defaults, appVersion: appVersion, createdDate: date)
+        let data = try serialize(payload)
+        let url = folder.appending(path: fileName(for: date))
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    /// Restore the backup at `url` onto `defaults`. Throws on a malformed or
+    /// too-new file; the caller is responsible for relaunching afterwards.
+    static func restore(from url: URL, into defaults: UserDefaults) throws {
+        let data = try Data(contentsOf: url)
+        let payload = try deserialize(data)
+        apply(payload, to: defaults)
+    }
+
+    /// Existing backup files in `folder`, newest first (filenames sort
+    /// chronologically because the timestamp is zero-padded).
+    static func listBackups(in folder: URL) -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: folder, includingPropertiesForKeys: nil)) ?? []
+        return contents
+            .filter { $0.pathExtension == fileExtension }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+    }
+
+    /// Delete the oldest backups beyond `max`, keeping the newest `max`.
+    static func prune(in folder: URL, keeping max: Int) {
+        let all = listBackups(in: folder) // newest first
+        guard all.count > max else { return }
+        for url in all[max...] {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - App conveniences
+
+    /// The newest backups to retain by default.
+    static let defaultRetentionLimit = 10
+
+    /// The running app's marketing version, stamped into each backup.
+    static var currentAppVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    }
+
+    /// The user-configured backup folder, or `defaultFolder()` when unset.
+    static func configuredFolder(_ defaults: UserDefaults = .standard) -> URL {
+        if let path = defaults.string(forKey: Defaults.Key.backupFolderPath.rawValue), !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        return defaultFolder()
+    }
+
+    /// Whether automatic (on-quit) backups are enabled (default true).
+    static func automaticBackupEnabled(_ defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: Defaults.Key.automaticBackupEnabled.rawValue) as? Bool ?? true
+    }
+
+    /// Back up `defaults` to the configured folder and prune to the retention
+    /// limit. Returns the written file URL.
+    @discardableResult
+    static func performBackup(
+        defaults: UserDefaults = .standard,
+        appVersion: String = currentAppVersion,
+        date: Date,
+        keeping max: Int = defaultRetentionLimit
+    ) throws -> URL {
+        let folder = configuredFolder(defaults)
+        let url = try writeBackup(of: defaults, to: folder, appVersion: appVersion, date: date)
+        prune(in: folder, keeping: max)
+        return url
+    }
+}

--- a/Ice/Settings/SettingsPanes/BackupSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/BackupSettingsPane.swift
@@ -1,0 +1,203 @@
+//
+//  BackupSettingsPane.swift
+//  Ice
+//
+
+import SwiftUI
+
+struct BackupSettingsPane: View {
+    @EnvironmentObject var appState: AppState
+
+    /// Backup folder. Defaults to ~/Documents/Ice Backups; the user can point it
+    /// at a Dropbox / iCloud Drive / Google Drive folder to sync across Macs.
+    @AppStorage(Defaults.Key.backupFolderPath.rawValue) private var backupFolderPath = ""
+    @AppStorage(Defaults.Key.automaticBackupEnabled.rawValue) private var automaticBackup = true
+
+    @State private var backups: [BackupItem] = []
+    @State private var status: LocalizedStringKey?
+    @State private var errorMessage: String?
+    @State private var restoreCandidate: BackupItem?
+
+    private struct BackupItem: Identifiable {
+        let url: URL
+        let date: Date
+        var id: URL { url }
+    }
+
+    private var folderURL: URL {
+        if !backupFolderPath.isEmpty {
+            return URL(fileURLWithPath: backupFolderPath, isDirectory: true)
+        }
+        return SettingsBackup.defaultFolder()
+    }
+
+    var body: some View {
+        IceForm {
+            IceSection("Backup Folder") {
+                folderRow
+                automaticBackupToggle
+            }
+            IceSection("Backups") {
+                backupActions
+                backupList
+            }
+        }
+        .onAppear(perform: refresh)
+        .alert(
+            "Restore settings?",
+            isPresented: Binding(
+                get: { restoreCandidate != nil },
+                set: { if !$0 { restoreCandidate = nil } }
+            ),
+            presenting: restoreCandidate
+        ) { item in
+            Button("Restore and Relaunch", role: .destructive) {
+                restore(item)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { item in
+            Text("This replaces all current Ice 2 settings with the backup from \(Self.dateFormatter.string(from: item.date)), then relaunches Ice 2.")
+        }
+        .alert(
+            "Backup Error",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    // MARK: Folder
+
+    @ViewBuilder
+    private var folderRow: some View {
+        LabeledContent {
+            Button("Change…", action: chooseFolder)
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Location")
+                Text(folderURL.path(percentEncoded: false))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .annotation("Choose a folder inside Dropbox, iCloud Drive, or Google Drive to sync your settings across your Macs. Backups are also kept for restoring after a reinstall or on a new Mac.")
+    }
+
+    @ViewBuilder
+    private var automaticBackupToggle: some View {
+        Toggle("Automatically back up when quitting", isOn: $automaticBackup)
+            .annotation("Keeps the backup folder current so a synced copy is always up to date.")
+    }
+
+    // MARK: Backups
+
+    @ViewBuilder
+    private var backupActions: some View {
+        LabeledContent {
+            HStack {
+                Button("Reveal in Finder", action: revealFolder)
+                Button("Back Up Now", action: backUpNow)
+            }
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Manual backup")
+                if let status {
+                    Text(status)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .annotation("The newest \(SettingsBackup.defaultRetentionLimit) backups are kept; older ones are removed automatically.")
+    }
+
+    @ViewBuilder
+    private var backupList: some View {
+        if backups.isEmpty {
+            Text("No backups yet.")
+                .foregroundStyle(.secondary)
+        } else {
+            ForEach(backups) { item in
+                LabeledContent {
+                    HStack {
+                        Button("Restore") { restoreCandidate = item }
+                        Button("Delete", role: .destructive) { delete(item) }
+                    }
+                } label: {
+                    Text(Self.dateFormatter.string(from: item.date))
+                }
+                .frame(height: 22)
+            }
+        }
+    }
+
+    // MARK: Actions
+
+    private func refresh() {
+        backups = SettingsBackup.listBackups(in: folderURL).map { url in
+            let date = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            return BackupItem(url: url, date: date)
+        }
+    }
+
+    private func backUpNow() {
+        do {
+            _ = try SettingsBackup.performBackup(date: Date())
+            status = "Backed up just now."
+            refresh()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func restore(_ item: BackupItem) {
+        do {
+            try SettingsBackup.restore(from: item.url, into: .standard)
+            appState.relaunch()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func delete(_ item: BackupItem) {
+        try? FileManager.default.removeItem(at: item.url)
+        refresh()
+    }
+
+    private func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Choose"
+        panel.directoryURL = folderURL
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+        backupFolderPath = url.path(percentEncoded: false)
+        refresh()
+    }
+
+    private func revealFolder() {
+        try? FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        NSWorkspace.shared.activateFileViewerSelecting([folderURL])
+    }
+
+    // MARK: Helpers
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}

--- a/Ice/Settings/SettingsView.swift
+++ b/Ice/Settings/SettingsView.swift
@@ -124,6 +124,8 @@ struct SettingsView: View {
             HotkeysSettingsPane(settings: appState.settings.hotkeys)
         case .advanced:
             AdvancedSettingsPane(settings: appState.settings.advanced)
+        case .backup:
+            BackupSettingsPane()
         case .about:
             AboutSettingsPane(updatesManager: appState.updatesManager)
         }

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -136,7 +136,7 @@ enum Defaults {
 }
 
 extension Defaults {
-    enum Key: String {
+    enum Key: String, CaseIterable {
         // MARK: General Settings
         case showIceIcon = "ShowIceIcon"
         case iceIcon = "IceIcon"
@@ -174,6 +174,10 @@ extension Defaults {
 
         // MARK: Appearance Settings
         case menuBarAppearanceConfigurationV2 = "MenuBarAppearanceConfigurationV2"
+
+        // MARK: Backup & Restore (meta-settings; excluded from the backup payload)
+        case backupFolderPath = "BackupFolderPath"
+        case automaticBackupEnabled = "AutomaticBackupEnabled"
 
         // MARK: Deprecated (Advanced Settings)
         case showSectionDividers = "ShowSectionDividers"

--- a/README.md
+++ b/README.md
@@ -96,11 +96,18 @@ rm -rf ~/Library/Application\ Support/com.jordanbaird.Ice \
 
 - [x] Launch at login
 - [x] Automatic updates
+- [x] Back up & restore settings to a folder you choose (sync across Macs via Dropbox / iCloud Drive / Google Drive)
 - [ ] Menu bar widgets
 
 ## Why does Ice 2 only support macOS 14 and later?
 
 Ice 2 uses a number of system APIs that are available starting in macOS 14. As such, there are no plans to support earlier versions of macOS.
+
+## Can I back up, restore, or sync my settings?
+
+Yes. Open **Settings ▸ Backup & Restore** and choose a backup folder. Use **Back Up Now** to save a snapshot of all your Ice 2 settings (layout profiles, item groups, spacers, triggers, hotkeys, and appearance), and Ice 2 also backs up automatically when you quit. The newest 10 backups are kept; you can restore any of them with one click (Ice 2 relaunches to apply).
+
+To **sync across Macs** or move to a new Mac, point the backup folder at a synced location such as Dropbox, iCloud Drive, or Google Drive — your settings then appear on your other Macs, where you can restore them.
 
 ## Gallery
 


### PR DESCRIPTION
Adds a Backup & Restore settings pane: snapshots all UserDefaults-backed settings to a chosen folder as a timestamped .icebackup plist, keeps the newest 10, auto-backs-up on quit, restores in one click (relaunches). Point the folder at Dropbox / iCloud Drive / Google Drive to sync across Macs. Harness 18/18; xcodebuild BUILD SUCCEEDED; version 2.6.0 (build 1131).

🤖 Generated with [Claude Code](https://claude.com/claude-code)