### PR TITLE
style: fix SwiftLint multiline_arguments_brackets in SettingsBackup

### DIFF
--- a/Ice/Settings/Backup/SettingsBackup.swift
+++ b/Ice/Settings/Backup/SettingsBackup.swift
@@ -172,8 +172,7 @@ enum SettingsBackup {
     /// Existing backup files in `folder`, newest first (filenames sort
     /// chronologically because the timestamp is zero-padded).
     static func listBackups(in folder: URL) -> [URL] {
-        let contents = (try? FileManager.default.contentsOfDirectory(
-            at: folder, includingPropertiesForKeys: nil)) ?? []
+        let contents = (try? FileManager.default.contentsOfDirectory(at: folder, includingPropertiesForKeys: nil)) ?? []
         return contents
             .filter { $0.pathExtension == fileExtension }
             .sorted { $0.lastPathComponent > $1.lastPathComponent }


### PR DESCRIPTION
Collapses a multi-line contentsOfDirectory(...) call to one line to satisfy the multiline_arguments_brackets rule (the only lint violation introduced by the 2.6.0 backup feature). No behavior change; harness still 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)