### PR TITLE
fix(menu): flatten App menu items to the top level (v2.7.1)

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1131;
+				CURRENT_PROJECT_VERSION = 1132;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.7.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1131;
+				CURRENT_PROJECT_VERSION = 1132;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.7.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -557,19 +557,8 @@ final class ControlItem {
 
         menu.addItem(.separator())
 
-        // App menu (SKILL.md §5A): a grouping with the standard lifecycle items.
-        let appMenuItem = NSMenuItem(title: "Ice 2", action: nil, keyEquivalent: "")
-        appMenuItem.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: nil)
-        appMenuItem.submenu = createAppMenu()
-        menu.addItem(appMenuItem)
-
-        return menu
-    }
-
-    /// Creates the standard "App menu" grouping (SKILL.md §5A).
-    private func createAppMenu() -> NSMenu {
-        let menu = NSMenu(title: "Ice 2")
-
+        // Standard lifecycle items (SKILL.md §5A), flattened to the top level
+        // rather than nested in an "Ice 2" submenu.
         let aboutItem = menuItem(
             title: "About Ice 2",
             symbolName: "info.circle",


### PR DESCRIPTION
The standardized lifecycle items (About Ice 2, Check for updates, Settings, Uninstall Ice 2, Quit Ice 2) were nested inside an "Ice 2" submenu in the control-item menu. This flattens them to the top level so they sit alongside Search / Hide / Show — same level as the other items.

- Removed the `createAppMenu()` submenu wrapper; items are added directly in `createMenu`.
- Bumped version 2.7.0 → 2.7.1 (build 1131 → 1132).
- Verified: `xcodebuild ... -scheme Ice` **BUILD SUCCEEDED** (SwiftLint build phase clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)