### PR TITLE
Native Form Settings redesign + menu action fixes (Ice 2 2.8.0)

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1132;
+				CURRENT_PROJECT_VERSION = 1133;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.7.1;
+				MARKETING_VERSION = 2.8.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1132;
+				CURRENT_PROJECT_VERSION = 1133;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.7.1;
+				MARKETING_VERSION = 2.8.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;

--- a/Ice/Main/Navigation/NavigationIdentifiers/SettingsNavigationIdentifier.swift
+++ b/Ice/Main/Navigation/NavigationIdentifiers/SettingsNavigationIdentifier.swift
@@ -6,9 +6,9 @@
 /// The navigation identifier type for the "Settings" interface.
 enum SettingsNavigationIdentifier: String, NavigationIdentifier {
     case general = "General"
-    case menuBarLayout = "Menu Bar Layout"
-    case menuBarAppearance = "Menu Bar Appearance"
+    case appearance = "Appearance"
     case hotkeys = "Hotkeys"
+    case updates = "Updates"
     case advanced = "Advanced"
     case backup = "Backup & Restore"
     case about = "About"
@@ -16,9 +16,9 @@ enum SettingsNavigationIdentifier: String, NavigationIdentifier {
     var iconResource: IconResource {
         switch self {
         case .general: .systemSymbol("gearshape")
-        case .menuBarLayout: .systemSymbol("rectangle.topthird.inset.filled")
-        case .menuBarAppearance: .systemSymbol("swatchpalette")
+        case .appearance: .systemSymbol("paintpalette")
         case .hotkeys: .systemSymbol("keyboard")
+        case .updates: .systemSymbol("arrow.triangle.2.circlepath")
         case .advanced: .systemSymbol("gearshape.2")
         case .backup: .systemSymbol("externaldrive.badge.timemachine")
         case .about: .assetCatalog(.iceCubeStroke)

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -578,10 +578,11 @@ final class ControlItem {
         let settingsItem = menuItem(
             title: "Settings…",
             symbolName: "gearshape",
-            action: #selector(AppDelegate.openSettingsWindow),
+            action: #selector(openSettings),
             keyEquivalent: ","
         )
         settingsItem.keyEquivalentModifierMask = .command
+        settingsItem.target = self
         menu.addItem(settingsItem)
 
         menu.addItem(.separator())
@@ -628,22 +629,39 @@ final class ControlItem {
         appState?.menuBarManager.searchPanel.show()
     }
 
-    /// Opens the settings window and checks for app updates.
+    /// Brings the app to the front and checks for app updates.
     @objc private func checkForUpdates() {
         guard let appState else {
             return
         }
+        // Activate first so Sparkle's update dialog appears in front, not
+        // behind the previously active app.
+        appState.activate(withPolicy: .regular)
         appState.updatesManager.checkForUpdates()
+    }
+
+    /// Opens the settings window navigated to the General pane.
+    @objc private func openSettings() {
+        presentSettings(navigatingTo: .general)
     }
 
     /// Opens the settings window navigated to the About pane.
     @objc private func openAbout() {
+        presentSettings(navigatingTo: .about)
+    }
+
+    /// Opens the settings window at the given pane, bringing the app to the front.
+    private func presentSettings(navigatingTo identifier: SettingsNavigationIdentifier) {
         guard let appState else {
             return
         }
-        appState.navigationState.settingsNavigationIdentifier = .about
-        appState.activate(withPolicy: .regular)
-        appState.openWindow(.settings)
+        appState.navigationState.settingsNavigationIdentifier = identifier
+        // A short delay makes activating and opening the window reliable for an
+        // accessory (LSUIElement) app — matches `AppDelegate.openSettingsWindow`.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            appState.activate(withPolicy: .regular)
+            appState.openWindow(.settings)
+        }
     }
 
     /// Confirms and performs a clean uninstall of the app.

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -318,7 +318,7 @@ final class MenuBarItemImageCache: ObservableObject {
             guard
                 await appState.navigationState.isAppFrontmost,
                 await appState.navigationState.isSettingsPresented,
-                await appState.navigationState.settingsNavigationIdentifier == .menuBarLayout
+                await appState.navigationState.settingsNavigationIdentifier == .appearance
             else {
                 return
             }

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -71,7 +71,7 @@ final class MenuBarItemManager: ObservableObject {
 
         appState.navigationState.$settingsNavigationIdentifier
             .sink { [weak self] identifier in
-                guard let self, identifier == .menuBarLayout else {
+                guard let self, identifier == .appearance else {
                     return
                 }
                 Task {

--- a/Ice/Settings/SettingsPanes/AboutSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AboutSettingsPane.swift
@@ -6,8 +6,6 @@
 import SwiftUI
 
 struct AboutSettingsPane: View {
-    @EnvironmentObject var appState: AppState
-    @ObservedObject var updatesManager: UpdatesManager
     @Environment(\.openURL) private var openURL
 
     private var acknowledgementsURL: URL {
@@ -23,159 +21,61 @@ struct AboutSettingsPane: View {
         contributeURL.appendingPathComponent("issues")
     }
 
-    private var lastUpdateCheckString: String {
-        if let date = updatesManager.lastUpdateCheckDate {
-            date.formatted(date: .abbreviated, time: .standard)
-        } else {
-            "Never"
-        }
-    }
-
     var body: some View {
-        contentForm(cornerStyle: .continuous)
-    }
-
-    @ViewBuilder
-    private func contentForm(cornerStyle: RoundedCornerStyle) -> some View {
-        IceForm(spacing: 0) {
-            mainContent(containerShape: RoundedRectangle(cornerRadius: 20, style: cornerStyle))
-            Spacer(minLength: 10)
-            bottomBar(containerShape: Capsule(style: cornerStyle))
-        }
-    }
-
-    @ViewBuilder
-    private func mainContent(containerShape: some InsettableShape) -> some View {
-        IceSection(spacing: 0, options: .plain) {
-            appIconAndCopyrightSection
-                .layoutPriority(1)
-
-            Spacer(minLength: 0)
-                .frame(maxHeight: 20)
-
-            updatesSection
-                .layoutPriority(1)
-        }
-        .padding(.top, 5)
-        .padding([.horizontal, .bottom], 30)
-        .frame(maxHeight: 500)
-        .background(.quinary, in: containerShape)
-        .containerShape(containerShape)
-    }
-
-    @ViewBuilder
-    private var appIconAndCopyrightSection: some View {
-        IceSection(options: .plain) {
-            HStack(spacing: 10) {
-                if let nsImage = NSImage(named: NSImage.applicationIconName) {
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 230)
-                }
-
-                VStack(alignment: .leading) {
-                    Text("Ice 2")
-                        .font(.system(size: 80))
-                        .foregroundStyle(.primary)
-
-                    Text("Version \(Constants.versionString)")
-                        .font(.system(size: 15))
-                        .foregroundStyle(.secondary)
-
-                    Text(Constants.copyrightString)
-                        .font(.system(size: 14))
-                        .foregroundStyle(.secondary.opacity(0.67))
-                }
-                .fontWeight(.medium)
+        IceForm {
+            IceSection(options: .plain) {
+                appIconAndCopyright
+            }
+            IceSection {
+                linkRows
             }
         }
     }
 
     @ViewBuilder
-    private var updatesSection: some View {
-        IceSection(options: .hasDividers) {
-            automaticallyCheckForUpdates
-            automaticallyDownloadUpdates
-            if updatesManager.canCheckForUpdates {
-                checkForUpdates
+    private var appIconAndCopyright: some View {
+        VStack(spacing: 6) {
+            if let nsImage = NSImage(named: NSImage.applicationIconName) {
+                Image(nsImage: nsImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 128, height: 128)
             }
-        }
-        .frame(maxWidth: 600)
-    }
 
-    @ViewBuilder
-    private var automaticallyCheckForUpdates: some View {
-        Toggle(
-            "Automatically check for updates",
-            isOn: $updatesManager.automaticallyChecksForUpdates
-        )
-    }
+            Text("Ice 2")
+                .font(.largeTitle)
+                .fontWeight(.semibold)
 
-    @ViewBuilder
-    private var automaticallyDownloadUpdates: some View {
-        Toggle(
-            "Automatically download updates",
-            isOn: $updatesManager.automaticallyDownloadsUpdates
-        )
-    }
+            Text("Version \(Constants.versionString)")
+                .font(.callout)
+                .foregroundStyle(.secondary)
 
-    @ViewBuilder
-    private var checkForUpdates: some View {
-        HStack {
-            Button("Check for Updates") {
-                updatesManager.checkForUpdates()
-            }
-            Spacer()
-            Text("Last checked: \(lastUpdateCheckString)")
+            Text(Constants.copyrightString)
                 .font(.caption)
+                .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
     }
 
     @ViewBuilder
-    private func bottomBar(containerShape: some InsettableShape) -> some View {
-        HStack {
-            Button("Quit Ice 2") {
-                NSApp.terminate(nil)
-            }
-            Spacer()
-            Button("Acknowledgements") {
-                NSWorkspace.shared.open(acknowledgementsURL)
-            }
-            Button("Contribute") {
-                openURL(contributeURL)
-            }
-            Button("Report a Bug") {
-                openURL(issuesURL)
-            }
+    private var linkRows: some View {
+        Button {
+            openURL(contributeURL)
+        } label: {
+            Label("Support on GitHub", systemImage: "link")
         }
-        .padding(8)
-        .buttonStyle(BottomBarButtonStyle())
-        .background(.quinary, in: containerShape)
-        .containerShape(containerShape)
-        .frame(height: 40)
-    }
-}
 
-private struct BottomBarButtonStyle: ButtonStyle {
-    @State private var isHovering = false
+        Button {
+            openURL(issuesURL)
+        } label: {
+            Label("Report a Bug", systemImage: "ladybug")
+        }
 
-    private var borderShape: some InsettableShape {
-        ContainerRelativeShape()
-    }
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .padding(.horizontal, 10)
-            .padding(.vertical, 4)
-            .background {
-                borderShape
-                    .fill(configuration.isPressed ? .tertiary : .quaternary)
-                    .opacity(isHovering ? 1 : 0)
-            }
-            .contentShape([.focusEffect, .interaction], borderShape)
-            .onHover { hovering in
-                isHovering = hovering
-            }
+        Button {
+            NSWorkspace.shared.open(acknowledgementsURL)
+        } label: {
+            Label("Acknowledgements", systemImage: "doc.text")
+        }
     }
 }

--- a/Ice/Settings/SettingsPanes/AppearanceSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AppearanceSettingsPane.swift
@@ -1,0 +1,49 @@
+//
+//  AppearanceSettingsPane.swift
+//  Ice
+//
+
+import SwiftUI
+
+/// Combines the menu bar's visual style and its item layout into a single
+/// "Appearance" pane, switched between with a segmented control.
+struct AppearanceSettingsPane: View {
+    @ObservedObject var appearanceManager: MenuBarAppearanceManager
+    @ObservedObject var itemManager: MenuBarItemManager
+    @ObservedObject var profileSettings: MenuBarLayoutProfilesSettings
+    @ObservedObject var spacerManager: MenuBarSpacerManager
+
+    @State private var section: Section = .style
+
+    private enum Section: String, CaseIterable, Identifiable {
+        case style = "Style"
+        case layout = "Layout"
+
+        var id: String { rawValue }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Appearance section", selection: $section) {
+                ForEach(Section.allCases) { section in
+                    Text(section.rawValue).tag(section)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+
+            switch section {
+            case .style:
+                MenuBarAppearanceSettingsPane(appearanceManager: appearanceManager)
+            case .layout:
+                MenuBarLayoutSettingsPane(
+                    itemManager: itemManager,
+                    profileSettings: profileSettings,
+                    spacerManager: spacerManager
+                )
+            }
+        }
+    }
+}

--- a/Ice/Settings/SettingsPanes/UpdatesSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/UpdatesSettingsPane.swift
@@ -1,0 +1,50 @@
+//
+//  UpdatesSettingsPane.swift
+//  Ice
+//
+
+import SwiftUI
+
+/// Update preferences, split out of the About pane to match the shared
+/// app settings taxonomy (General · Appearance · Hotkeys · Updates · About).
+struct UpdatesSettingsPane: View {
+    @ObservedObject var updatesManager: UpdatesManager
+
+    private var lastUpdateCheckString: String {
+        if let date = updatesManager.lastUpdateCheckDate {
+            date.formatted(date: .abbreviated, time: .standard)
+        } else {
+            "Never"
+        }
+    }
+
+    var body: some View {
+        IceForm {
+            IceSection {
+                Toggle(
+                    "Automatically check for updates",
+                    isOn: $updatesManager.automaticallyChecksForUpdates
+                )
+                Toggle(
+                    "Automatically download updates",
+                    isOn: $updatesManager.automaticallyDownloadsUpdates
+                )
+            }
+            IceSection {
+                LabeledContent {
+                    Button("Check for Updates…") {
+                        updatesManager.checkForUpdates()
+                    }
+                    .disabled(!updatesManager.canCheckForUpdates)
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Check for updates now")
+                        Text("Last checked: \(lastUpdateCheckString)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Ice/Settings/SettingsView.swift
+++ b/Ice/Settings/SettingsView.swift
@@ -112,22 +112,23 @@ struct SettingsView: View {
         switch navigationState.settingsNavigationIdentifier {
         case .general:
             GeneralSettingsPane(settings: appState.settings.general)
-        case .menuBarLayout:
-            MenuBarLayoutSettingsPane(
+        case .appearance:
+            AppearanceSettingsPane(
+                appearanceManager: appState.appearanceManager,
                 itemManager: appState.itemManager,
                 profileSettings: appState.settings.layoutProfiles,
                 spacerManager: appState.spacerManager
             )
-        case .menuBarAppearance:
-            MenuBarAppearanceSettingsPane(appearanceManager: appState.appearanceManager)
         case .hotkeys:
             HotkeysSettingsPane(settings: appState.settings.hotkeys)
+        case .updates:
+            UpdatesSettingsPane(updatesManager: appState.updatesManager)
         case .advanced:
             AdvancedSettingsPane(settings: appState.settings.advanced)
         case .backup:
             BackupSettingsPane()
         case .about:
-            AboutSettingsPane(updatesManager: appState.updatesManager)
+            AboutSettingsPane()
         }
     }
 }

--- a/Ice/UI/IceUI/IceForm.swift
+++ b/Ice/UI/IceUI/IceForm.swift
@@ -5,12 +5,12 @@
 
 import SwiftUI
 
+/// A settings form built on the system's grouped `Form`, so panes adopt the
+/// standard macOS inset-grouped appearance, fonts, and control sizing.
+///
+/// The `alignment`, `padding`, and `spacing` parameters are retained for source
+/// compatibility with existing call sites; layout is now driven by `Form`.
 struct IceForm<Content: View>: View {
-    @State private var contentFrame = CGRect.zero
-
-    private let alignment: HorizontalAlignment
-    private let padding: EdgeInsets
-    private let spacing: CGFloat
     private let content: Content
 
     init(
@@ -19,9 +19,6 @@ struct IceForm<Content: View>: View {
         spacing: CGFloat = .iceFormDefaultSpacing,
         @ViewBuilder content: () -> Content
     ) {
-        self.alignment = alignment
-        self.padding = padding
-        self.spacing = spacing
         self.content = content()
     }
 
@@ -31,62 +28,16 @@ struct IceForm<Content: View>: View {
         spacing: CGFloat = .iceFormDefaultSpacing,
         @ViewBuilder content: () -> Content
     ) {
-        self.init(
-            alignment: alignment,
-            padding: EdgeInsets(all: padding),
-            spacing: spacing
-        ) {
-            content()
-        }
+        self.content = content()
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            ScrollView {
-                contentLayout.frame(
-                    maxWidth: geometry.size.width,
-                    minHeight: geometry.size.height,
-                    alignment: .top
-                )
-            }
-            .scrollContentBackground(.hidden)
-            .scrollIndicatorsFlash(onAppear: true)
-            .scrollDisabled(contentFrame.height > 0 && contentFrame.height <= geometry.size.height)
+        Form {
+            content
         }
+        .formStyle(.grouped)
         .focusSection()
         .accessibilityElement(children: .contain)
-    }
-
-    @ViewBuilder
-    private var contentLayout: some View {
-        VStack(alignment: alignment, spacing: spacing) {
-            content
-                .labeledContentStyle(IceFormLabeledContentStyle())
-                .toggleStyle(IceFormToggleStyle())
-        }
-        .padding(padding)
-        .onFrameChange(update: $contentFrame)
-    }
-}
-
-private struct IceFormLabeledContentStyle: LabeledContentStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        LabeledContent {
-            configuration.content
-                .layoutPriority(1)
-        } label: {
-            configuration.label
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .layoutPriority(0)
-        }
-    }
-}
-
-private struct IceFormToggleStyle: ToggleStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        Toggle(configuration)
-            .toggleStyle(.switch)
-            .controlSize(.mini)
     }
 }
 

--- a/Ice/UI/IceUI/IceSection.swift
+++ b/Ice/UI/IceUI/IceSection.swift
@@ -15,15 +15,15 @@ struct IceSectionOptions: OptionSet {
     static let `default`: IceSectionOptions = [.isBordered, .hasDividers]
 }
 
+/// A settings section built on the system's `Section`, so it adopts the
+/// standard grouped `Form` appearance (inset box, row separators, header style).
+///
+/// The `spacing` and `options` parameters are retained for source compatibility;
+/// grouping and dividers are now provided by the system grouped `Form`.
 struct IceSection<Header: View, Content: View, Footer: View>: View {
     private let header: Header
     private let content: Content
     private let footer: Footer
-    private let spacing: CGFloat
-    private let options: IceSectionOptions
-
-    private var isBordered: Bool { options.contains(.isBordered) }
-    private var hasDividers: Bool { options.contains(.hasDividers) }
 
     init(
         spacing: CGFloat = .iceSectionDefaultSpacing,
@@ -32,8 +32,6 @@ struct IceSection<Header: View, Content: View, Footer: View>: View {
         @ViewBuilder content: () -> Content,
         @ViewBuilder footer: () -> Footer
     ) {
-        self.spacing = spacing
-        self.options = options
         self.header = header()
         self.content = content()
         self.footer = footer()
@@ -90,7 +88,7 @@ struct IceSection<Header: View, Content: View, Footer: View>: View {
         @ViewBuilder content: () -> Content
     ) where Header == Text, Footer == EmptyView {
         self.init(spacing: spacing, options: options) {
-            Text(title).font(.headline)
+            Text(title)
         } content: {
             content()
         }
@@ -98,73 +96,12 @@ struct IceSection<Header: View, Content: View, Footer: View>: View {
 
     var body: some View {
         Section {
-            if isBordered {
-                IceGroupBox {
-                    header
-                } content: {
-                    contentLayout
-                } footer: {
-                    footer
-                }
-            } else {
-                VStack(alignment: .leading) {
-                    header
-                        .accessibilityAddTraits(.isHeader)
-                        .padding([.top, .leading], 8)
-                        .padding(.bottom, 2)
-
-                    contentLayout
-
-                    footer
-                        .padding([.bottom, .leading], 8)
-                        .padding(.top, 2)
-                }
-                .focusSection()
-                .accessibilityElement(children: .contain)
-            }
+            content
+        } header: {
+            header
+        } footer: {
+            footer
         }
-        .focusSection()
-        .accessibilityElement(children: .contain)
-    }
-
-    @ViewBuilder
-    private var contentLayout: some View {
-        if hasDividers {
-            _VariadicView.Tree(IceSectionLayout(spacing: spacing)) {
-                content.frame(maxWidth: .infinity)
-            }
-        } else {
-            content.frame(maxWidth: .infinity)
-        }
-    }
-}
-
-// MARK: - IceSectionLayout
-
-private struct IceSectionLayout: _VariadicView_UnaryViewRoot {
-    let spacing: CGFloat
-
-    @ViewBuilder
-    func body(children: _VariadicView.Children) -> some View {
-        let last = children.last?.id
-        VStack(alignment: .leading, spacing: spacing) {
-            ForEach(children) { child in
-                child
-                if child.id != last {
-                    IceSectionDivider()
-                }
-            }
-        }
-    }
-}
-
-// MARK: - IceSectionDivider
-
-private struct IceSectionDivider: View {
-    var body: some View {
-        Rectangle()
-            .fill(.separator.quinary)
-            .frame(height: 1)
     }
 }
 


### PR DESCRIPTION
Redesigns the Settings panes and fixes menu-bar dropdown actions to follow the Liquid Glass UI/UX guideline.

## Settings
- Migrate every pane onto the system grouped `Form` (standard fonts, control sizing, inset-grouped sections) by re-basing `IceForm`/`IceSection` on `Form`/`Section`; drop the `.mini` toggle style and custom group-box.
- Merge **Menu Bar Layout** + **Menu Bar Appearance** into a single **Appearance** pane with a Style/Layout segmented switch.
- Split a dedicated **Updates** pane out of About; slim **About** to system text styles + standard controls.

## Menu-bar dropdown
- **Settings…** now opens the **General** pane.
- Settings/About activate and come to the front reliably.
- **Check for updates…** activates the app first so Sparkle's dialog is frontmost.

## Release
- Bump to **2.8.0** (build 1133).

Verified: `xcodebuild -scheme Ice` Debug + Release → BUILD SUCCEEDED, SwiftLint 0 violations. Manually tested in an isolated re-id'd debug build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)