### PR TITLE
chore: rebrand bundle id to com.dragonapp.ice (v2.8.1)

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.0;
+				MARKETING_VERSION = 2.8.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.0;
+				MARKETING_VERSION = 2.8.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				MARKETING_VERSION = 2.8.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
-				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -473,7 +473,7 @@
 				MARKETING_VERSION = 2.8.0;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
-				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -493,7 +493,7 @@
 				INFOPLIST_FILE = MenuBarItemService/Resources/Info.plist;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice.MenuBarItemService;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.MenuBarItemService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
@@ -519,7 +519,7 @@
 				INFOPLIST_FILE = MenuBarItemService/Resources/Info.plist;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice.MenuBarItemService;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.MenuBarItemService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -696,7 +696,7 @@ final class ControlItem {
         LaunchAtLogin.isEnabled = false
 
         // Remove the UserDefaults domain and preferences file.
-        let bundleIdentifier = "com.jordanbaird.Ice"
+        let bundleIdentifier = "com.dragonapp.ice"
         UserDefaults.standard.removePersistentDomain(forName: bundleIdentifier)
 
         let fileManager = FileManager.default

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ If you installed manually, delete `Ice 2.app` from your `Applications` folder.
 To also remove Ice 2 settings and cached data:
 
 ```sh
-rm -rf ~/Library/Application\ Support/com.jordanbaird.Ice \
-       ~/Library/Caches/com.jordanbaird.Ice \
-       ~/Library/HTTPStorages/com.jordanbaird.Ice \
-       ~/Library/Preferences/com.jordanbaird.Ice.plist \
-       ~/Library/Saved\ Application\ State/com.jordanbaird.Ice.savedState
+rm -rf ~/Library/Application\ Support/com.dragonapp.ice \
+       ~/Library/Caches/com.dragonapp.ice \
+       ~/Library/HTTPStorages/com.dragonapp.ice \
+       ~/Library/Preferences/com.dragonapp.ice.plist \
+       ~/Library/Saved\ Application\ State/com.dragonapp.ice.savedState
 ```
 
 ## Features/Roadmap

--- a/Shared/Services/MenuBarItemService.swift
+++ b/Shared/Services/MenuBarItemService.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 enum MenuBarItemService {
-    static let name = "com.jordanbaird.Ice.MenuBarItemService"
+    static let name = "com.dragonapp.ice.MenuBarItemService"
 }
 
 extension MenuBarItemService {

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,9 +39,9 @@ public repos get free Actions minutes, so no self-hosted runner is required. The
    - `spctl -a -t install` accepts the downloaded zip's app.
 
 ## Notes
-- The app bundle id is `com.jordanbaird.Ice` (inherited from upstream). Do not
-  change it — it preserves users' existing settings and matches the cask's
-  `uninstall`/`zap` paths.
+- The app bundle id is `com.dragonapp.ice` (rebranded from the upstream
+  `com.jordanbaird.Ice`). Keep the cask's `uninstall`/`zap` paths in sync with
+  this id.
 - The first tagged run validates the `xcodebuild` export-signing path. If
   `-exportArchive` errors on signing style, set `signingStyle` to `automatic` in
   `.github/release/exportOptions.plist` and drop the manual `CODE_SIGN_*`

--- a/scripts/run-debug.sh
+++ b/scripts/run-debug.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
 # run-debug.sh — build Ice, re-id the product as a standalone "Ice 2 Debug.app"
-# (bundle id com.jordanbaird.Ice.debug), ad-hoc sign it, and (re)launch it.
+# (bundle id com.dragonapp.ice.debug), ad-hoc sign it, and (re)launch it.
 #
-# Why: the debug build shares the installed app's bundle id (com.jordanbaird.Ice),
+# Why: the debug build shares the installed app's bundle id (com.dragonapp.ice),
 # which collides on TCC permissions, the menu-bar manager, and the UserDefaults
-# domain. Re-iding to com.jordanbaird.Ice.debug gives the debug build its own
+# domain. Re-iding to com.dragonapp.ice.debug gives the debug build its own
 # permissions and settings so it can run next to an installed Ice 2 without
 # conflict. The bundled MenuBarItemService XPC keeps its original id (the host
 # resolves it by that id from inside the bundle), so it must NOT be changed.
@@ -21,7 +21,7 @@ set -euo pipefail
 
 SCHEME="Ice"
 CONFIG="Debug"
-DEBUG_ID="com.jordanbaird.Ice.debug"
+DEBUG_ID="com.dragonapp.ice.debug"
 DEBUG_NAME="Ice 2 Debug"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
Rebrands Ice 2's bundle identifier to the Dragon-App scheme, per owner request.

- App: `com.jordanbaird.Ice` → **`com.dragonapp.ice`**
- Embedded XPC service: `com.jordanbaird.Ice.MenuBarItemService` → **`com.dragonapp.ice.MenuBarItemService`** (XPC `name` string kept == service bundle id, verified)
- Updated the uninstall handler's hardcoded id, README/RELEASING data-path docs, and `scripts/run-debug.sh` (`.debug` derivation). Upstream attribution / GitHub URLs left intact.
- `MARKETING_VERSION` → 2.8.1 (matches tag).

**Breaking (owner-accepted):** existing users must re-grant Accessibility/Screen Recording (TCC keyed by bundle id) and settings reset (new UserDefaults domain). No MAS listing exists for Ice, so no App Store impact.

## Verification
- `xcodebuild … CODE_SIGNING_ALLOWED=NO build` ✅ BUILD SUCCEEDED · SwiftLint 0 violations.
- `git grep com.jordanbaird.Ice` → only upstream URLs/attribution/historical docs remain.
- ⚠️ XPC connection + permission re-grant are runtime-unverified headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)