### PR TITLE
Standardized About + Uninstall template (v2.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.8.1 - 2026-06-30
+
+### Changed
+
+- **Refined the About and Uninstall screens.** About now leads with a **Website** link (dragonapp.com/ice-2) and a **Support on GitHub** link that goes straight to the issues page, plus creator and license rows. **Uninstall** is now a clear confirmation sheet that lists exactly what gets removed, with the destructive **Uninstall** button on the left and **Cancel** as the default.
+
 ## 2.6.0 - 2026-06-29
 
 ### Added

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1133;
+				CURRENT_PROJECT_VERSION = 1134;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.0;
+				MARKETING_VERSION = 2.8.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1133;
+				CURRENT_PROJECT_VERSION = 1134;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.0;
+				MARKETING_VERSION = 2.8.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jordanbaird.Ice;

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -666,32 +666,16 @@ final class ControlItem {
 
     /// Confirms and performs a clean uninstall of the app.
     @objc private func performUninstall() {
-        guard let appState else {
-            return
+        appState?.activate(withPolicy: .regular)
+        // Standardized §5A confirmation sheet (checklist + destructive button).
+        UninstallWindowController.shared.present { [weak self] in
+            self?.runUninstall()
         }
-        appState.activate(withPolicy: .regular)
+    }
 
-        let alert = NSAlert()
-        alert.alertStyle = .critical
-        alert.messageText = "Uninstall Ice 2?"
-        alert.informativeText = """
-            This will quit Ice 2 and move it to the Trash, then remove its login \
-            item and saved settings.
-
-            Accessibility and Screen Recording permissions must be removed by you \
-            in System Settings ▸ Privacy & Security — macOS does not let the app \
-            revoke them.
-            """
-        // Destructive layout: Uninstall on the left, Cancel as the default on the right.
-        let uninstallButton = alert.addButton(withTitle: "Uninstall")
-        uninstallButton.hasDestructiveAction = true
-        let cancelButton = alert.addButton(withTitle: "Cancel")
-        alert.window.defaultButtonCell = cancelButton.cell as? NSButtonCell
-
-        guard alert.runModal() == .alertFirstButtonReturn else {
-            return
-        }
-
+    /// Tears down on-disk + system state, then quits. Called only after the user
+    /// confirms in the Uninstall sheet.
+    private func runUninstall() {
         // Unregister the login item.
         LaunchAtLogin.isEnabled = false
 

--- a/Ice/MenuBar/ControlItem/UninstallView.swift
+++ b/Ice/MenuBar/ControlItem/UninstallView.swift
@@ -1,0 +1,98 @@
+//
+//  UninstallView.swift
+//  Ice
+//
+
+import AppKit
+import SwiftUI
+
+// Standardized Uninstall confirmation (liquid-glass §5A): a destructive sheet that
+// names exactly what it removes, with Uninstall (red, destructive, LEFT) and Cancel
+// (the default, RIGHT) so Return/Esc both land on the safe choice. Ice keeps no
+// separate user data (its settings ARE its data, always removed), so there is no
+// "also delete data" toggle here — unlike ClipMenu.
+
+/// Hosts `UninstallView` in a small window (Ice is an LSUIElement agent).
+@MainActor
+final class UninstallWindowController {
+    static let shared = UninstallWindowController()
+    private var window: NSWindow?
+
+    func present(onConfirm: @escaping () -> Void) {
+        if let window {
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+            return
+        }
+        let view = UninstallView(
+            onCancel: { [weak self] in self?.window?.close() },
+            onUninstall: { [weak self] in
+                self?.window?.close()
+                onConfirm()
+            }
+        )
+        let win = NSWindow(contentViewController: NSHostingController(rootView: view))
+        win.styleMask = [.titled, .closable]
+        win.title = ""
+        win.isReleasedWhenClosed = false
+        win.center()
+        window = win
+
+        NSApp.activate(ignoringOtherApps: true)
+        win.makeKeyAndOrderFront(nil)
+    }
+}
+
+struct UninstallView: View {
+    let onCancel: () -> Void
+    let onUninstall: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                Image(systemName: "trash")
+                    .font(.title2)
+                    .foregroundStyle(.white)
+                    .frame(width: 40, height: 40)
+                    .background(Color.red, in: RoundedRectangle(cornerRadius: 9))
+                Text("Uninstall Ice 2?")
+                    .font(.title2).bold()
+            }
+
+            Text("Ice 2 will quit and remove itself completely. This will delete:")
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 8) {
+                checkRow("The app and its login item")
+                checkRow("Settings, layout profiles, and hotkeys")
+                checkRow("Saved application state")
+            }
+
+            Text("Accessibility and Screen Recording permissions must be removed by you in System Settings ▸ Privacy & Security — macOS does not let the app revoke them. This cannot be undone.")
+                .font(.caption).foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Button(role: .destructive) { onUninstall() } label: {
+                    Text("Uninstall").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+
+                Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.defaultAction)   // Return/Esc → the safe choice
+                    .frame(maxWidth: .infinity)
+            }
+            .controlSize(.large)
+        }
+        .padding(20)
+        .frame(width: 420)
+    }
+
+    private func checkRow(_ text: String) -> some View {
+        Label {
+            Text(text)
+        } icon: {
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
+        }
+    }
+}

--- a/Ice/Settings/SettingsPanes/AboutSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AboutSettingsPane.swift
@@ -13,12 +13,14 @@ struct AboutSettingsPane: View {
         Bundle.main.url(forResource: "Acknowledgements", withExtension: "pdf")!
     }
 
-    private var contributeURL: URL {
-        URL(string: "https://github.com/teddychan/ice-2")!
+    /// Primary link: the app's marketing page on dragonapp.com (SKILL.md §5A).
+    private var websiteURL: URL {
+        URL(string: "https://www.dragonapp.com/ice-2/")!
     }
 
+    /// Support link goes straight to the GitHub issues page.
     private var issuesURL: URL {
-        contributeURL.appendingPathComponent("issues")
+        URL(string: "https://github.com/teddychan/ice-2/issues")!
     }
 
     var body: some View {
@@ -28,6 +30,9 @@ struct AboutSettingsPane: View {
             }
             IceSection {
                 linkRows
+            }
+            IceSection {
+                creditRows
             }
         }
     }
@@ -60,16 +65,16 @@ struct AboutSettingsPane: View {
 
     @ViewBuilder
     private var linkRows: some View {
-        Button {
-            openURL(contributeURL)
+        LabeledContent {
+            Link("dragonapp.com/ice-2", destination: websiteURL)
         } label: {
-            Label("Support on GitHub", systemImage: "link")
+            Label("Website", systemImage: "globe")
         }
 
-        Button {
-            openURL(issuesURL)
+        LabeledContent {
+            Link("teddychan/ice-2", destination: issuesURL)
         } label: {
-            Label("Report a Bug", systemImage: "ladybug")
+            Label("Support on GitHub", systemImage: "lifepreserver")
         }
 
         Button {
@@ -77,5 +82,12 @@ struct AboutSettingsPane: View {
         } label: {
             Label("Acknowledgements", systemImage: "doc.text")
         }
+    }
+
+    @ViewBuilder
+    private var creditRows: some View {
+        LabeledContent("Created by") { Text("Teddy Chan") }
+        LabeledContent("Original Ice") { Text("Jordan Baird") }
+        LabeledContent("License") { Text("GPL-3.0") }
     }
 }


### PR DESCRIPTION
Applies the shared liquid-glass §5A template (matches ClipMenu 2):

- **About**: **Website → www.dragonapp.com/ice-2** (primary) + **Support on GitHub → the /issues page**, plus Created by / Original Ice / License rows. (About already opened the About pane.)
- **Uninstall**: now a SwiftUI confirmation **sheet** — checklist of exactly what's removed, **Uninstall (red, left) / Cancel (default, right)**. Ice keeps no separate user data, so no data toggle; teardown unchanged.

Version 2.8.1 (build 1134). Build + SwiftLint clean (0 violations). No marketing-site change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)