### PR TITLE
fix: enforce backup retention limit when viewing the pane (2.8.3)

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1135;
+				CURRENT_PROJECT_VERSION = 1136;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.2;
+				MARKETING_VERSION = 2.8.3;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1135;
+				CURRENT_PROJECT_VERSION = 1136;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.2;
+				MARKETING_VERSION = 2.8.3;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;

--- a/Ice/Settings/SettingsPanes/BackupSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/BackupSettingsPane.swift
@@ -141,6 +141,9 @@ struct BackupSettingsPane: View {
     // MARK: Actions
 
     private func refresh() {
+        // Enforce the retention limit on view, so a folder that already holds more
+        // than the limit (e.g. synced from another Mac) is reconciled down to it.
+        SettingsBackup.prune(in: folderURL, keeping: SettingsBackup.defaultRetentionLimit)
         backups = SettingsBackup.listBackups(in: folderURL).map { url in
             let date = (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
                 .contentModificationDate ?? .distantPast


### PR DESCRIPTION
## Bug
The "keep newest 10 backups" limit was only enforced as a side-effect of writing a new backup (`performBackup` → `prune`). A folder that already held more than 10 — synced from another Mac into the shared iCloud/Dropbox folder, or accumulated while auto-backup was off — was never trimmed just by viewing it (see the 11-row Backup & Restore pane).

## Fix
`BackupSettingsPane.refresh()` now calls `SettingsBackup.prune(in:keeping:)` before listing, so the folder is reconciled to the newest 10 (oldest deleted first) whenever the pane appears or is interacted with. The existing `prune` arithmetic was already correct — only *when* it ran was the gap.

Also bumps `MARKETING_VERSION` 2.8.2 → 2.8.3 and `CURRENT_PROJECT_VERSION` 1135 → 1136.

Verified with a Debug build (`BUILD SUCCEEDED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)