### PR TITLE
fix: reduce power/CPU use (mouse-moved tap + overlay AX poll); v2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.8.4 - 2026-07-05
+
+### Fixed
+
+- **Lower power use.** Ice 2 no longer wakes on every mouse movement when it doesn't need to. The mouse-tracking used for "show on hover" is now only active while a hover option is actually turned on, so with hover off the app stays idle as you move the pointer — noticeably reducing CPU and energy use in Activity Monitor.
+- **Lower CPU when switching apps (with a custom menu bar appearance).** The overlay that redraws the menu bar used to keep polling the macOS Accessibility API every 50 ms for up to 10 seconds after each app switch whenever the menu size hadn't changed. It now polls quickly only briefly while the menu settles, then backs off, cutting a CPU/energy spike that happened every time you changed apps.
+
 ## 2.8.2 - 2026-06-30
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1136;
+				CURRENT_PROJECT_VERSION = 1291;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.3;
+				MARKETING_VERSION = 2.8.4;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1136;
+				CURRENT_PROJECT_VERSION = 1291;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.3;
+				MARKETING_VERSION = 2.8.4;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;

--- a/Ice/Events/HIDEventManager.swift
+++ b/Ice/Events/HIDEventManager.swift
@@ -36,6 +36,7 @@ final class HIDEventManager: ObservableObject {
                     monitor.stop()
                 }
             }
+            updateMouseMovedTap()
         }
     }
 
@@ -111,13 +112,41 @@ final class HIDEventManager: ObservableObject {
     // MARK: All Monitors
 
     /// All monitors maintained by the manager.
+    ///
+    /// The mouse-moved tap is deliberately excluded here and managed
+    /// separately by ``updateMouseMovedTap()``, so it only runs when a
+    /// feature that needs per-movement tracking is actually enabled.
     private lazy var allMonitors: [any EventMonitorProtocol] = [
         mouseDownMonitor,
         mouseUpMonitor,
         mouseDraggedMonitor,
-        mouseMovedTap,
         scrollWheelMonitor,
     ]
+
+    /// A Boolean value that indicates whether any enabled feature relies on
+    /// tracking mouse movement.
+    private var needsMouseMovedTap: Bool {
+        guard let appState else {
+            return false
+        }
+        return appState.settings.general.showOnHoverEmptyMenuBar
+            || appState.settings.general.showOnHoverOverIceIcon
+    }
+
+    /// Enables the mouse-moved tap only when the manager is enabled and a
+    /// feature that needs per-movement tracking is active.
+    ///
+    /// A `.mouseMoved` event tap fires on every pointer movement, which wakes
+    /// the app constantly. Leaving it running when no "show on hover" feature
+    /// is enabled burns energy for no benefit, so the tap is toggled to match
+    /// the features that actually need it.
+    private func updateMouseMovedTap() {
+        if isEnabled && needsMouseMovedTap {
+            mouseMovedTap.start()
+        } else {
+            mouseMovedTap.stop()
+        }
+    }
 
     // MARK: Setup
 
@@ -149,6 +178,18 @@ final class HIDEventManager: ObservableObject {
                 if let screen = bestScreen(appState: appState) {
                     handleShowOnHover(appState: appState, screen: screen)
                 }
+            }
+            .store(in: &c)
+
+            // Toggle the mouse-moved tap whenever the features that depend on
+            // it change, so it never runs when no "show on hover" trigger is on.
+            Publishers.Merge(
+                appState.settings.general.$showOnHoverEmptyMenuBar.replace(with: ()),
+                appState.settings.general.$showOnHoverOverIceIcon.replace(with: ())
+            )
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.updateMouseMovedTap()
             }
             .store(in: &c)
         }

--- a/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -149,25 +149,28 @@ final class MenuBarOverlayPanel: NSPanel {
                 return
             }
             updateTaskContext.setTask(for: .applicationMenuFrame, timeout: .seconds(10)) {
-                var hasDoneInitialUpdate = false
+                // Poll the synchronous Accessibility API quickly only for a short
+                // window while the app menu settles after a switch, then back off
+                // to a slow poll. Previously the fast 50ms poll continued for the
+                // full 10s task timeout whenever the new frame matched the cached
+                // one (e.g. switching between apps with identical menu widths),
+                // constantly hammering the AX API and draining CPU/energy.
+                var fastPollsRemaining = 20 // ~1s of 50ms polls.
                 while true {
                     try Task.checkCancellation()
                     guard
                         let latestFrame = self.owningScreen.getApplicationMenuFrame(),
                         latestFrame != self.applicationMenuFrame
                     else {
-                        if hasDoneInitialUpdate {
-                            try await Task.sleep(for: .seconds(1))
-                        } else {
-                            // Poll briefly while the app menu settles after a switch.
-                            // 50ms stays responsive without hammering the synchronous
-                            // Accessibility API every millisecond.
+                        if fastPollsRemaining > 0 {
+                            fastPollsRemaining -= 1
                             try await Task.sleep(for: .milliseconds(50))
+                        } else {
+                            try await Task.sleep(for: .seconds(1))
                         }
                         continue
                     }
                     self.insertUpdateFlag(.applicationMenuFrame)
-                    hasDoneInitialUpdate = true
                 }
             }
             Task {


### PR DESCRIPTION
## Why

Reported: Ice 2 (v2.8.3) shows **high energy/CPU in Activity Monitor**. Investigation found two idle drains, both confirmed live for a config with **show-on-hover OFF** and a **custom menu bar appearance**.

## Fixes

**1. Mouse-moved event tap gated on hover features (always-on win)**
`HIDEventManager` installed a `.mouseMoved` event tap unconditionally at launch. Its only consumer is `handleShowOnHover`, which no-ops when both hover options are off — so the app was woken on *every pointer movement* to do nothing. The tap is now enabled only while `showOnHoverEmptyMenuBar` or `showOnHoverOverIceIcon` is on, and toggled reactively when those settings change. With hover off, there are **zero per-mouse-move wakeups**.

**2. Bounded Accessibility polling in the appearance overlay (per-app-switch spike)**
`MenuBarOverlayPanel` polled the synchronous Accessibility API every 50 ms and only backed off to 1 s *after* the menu frame changed. When a switched-to app's menu frame matched the cached one, it fast-polled for the full 10 s task timeout on **every app switch**. It now fast-polls ~1 s while the menu settles, then backs off. (Runs only when a custom menu bar appearance is configured.) This is the code path behind the upstream "excessive CPU when switching apps" reports.

## Verification

- `xcodebuild` Debug: **BUILD SUCCEEDED**.
- Isolated debug build (`com.dragonapp.ice.debug`) launches and settles to **<1% idle CPU** — no spin introduced.
- Fix #1 is a deterministic control-flow change (the tap's run-loop source is never added when hover is off). A full day-scale energy A/B was not run in this environment.

## Version

`MARKETING_VERSION` 2.8.3 → 2.8.4; `CURRENT_PROJECT_VERSION` 1136 → 1291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)