### PR TITLE
ci: pin release workflow to dragon-release-ci floating major @v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v2
+    uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v5
     secrets: inherit
     with:
       build_kind: xcodebuild


### PR DESCRIPTION
## What

Repoint the release caller in `release.yml:26` from the shared workflow's `@v2` → floating major **`@v5`**.

## Why

`@v2` is an old shared-workflow commit still on `actions/checkout@v4`, which GitHub flags as *"Node.js 20 is deprecated"*. `@v5` tracks the latest v5.x.y of the shared reusable workflow (currently `v5.0.1` = teddychan/dragon-release-ci@e7dc870), which carries the `actions/checkout@v5` (Node 24) fix plus the backward-compatible improvements since v2.

Part of moving all Dragon apps' free releases onto the shared workflow's floating `v5` major.

## Verification

- YAML validates; single-line diff.
- Not run end-to-end. The deprecation annotation should clear on the next release, since `@v5` runs checkout on Node 24.

## Related

- Shared-workflow fix: teddychan/dragon-release-ci#8 (tagged `v5.0.1`; floating `v5` points to it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>