### PR TITLE
fix: stop perpetual 1s permission polling that churned idle CPU; bump 2.8.8

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1295;
+				CURRENT_PROJECT_VERSION = 1296;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -435,7 +435,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.7;
+				MARKETING_VERSION = 2.8.8;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
@@ -454,7 +454,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1295;
+				CURRENT_PROJECT_VERSION = 1296;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_APP_SANDBOX = NO;
@@ -470,7 +470,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.8.7;
+				MARKETING_VERSION = 2.8.8;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;

--- a/Ice/Permissions/AppPermissions.swift
+++ b/Ice/Permissions/AppPermissions.swift
@@ -3,6 +3,7 @@
 //  Ice
 //
 
+import AppKit
 import Combine
 import Foundation
 import OSLog
@@ -38,6 +39,9 @@ final class AppPermissions: ObservableObject {
     /// Storage for internal observers.
     private var cancellable: AnyCancellable?
 
+    /// Observer that re-checks permissions when the app becomes active.
+    private var activationCancellable: AnyCancellable?
+
     /// The permissions required for full app functionality.
     var allPermissions: [Permission] {
         [accessibility, screenRecording]
@@ -56,16 +60,30 @@ final class AppPermissions: ObservableObject {
             .sink { [weak self] _ in
                 self?.updatePermissionsState()
             }
+        // Re-check permissions when the app becomes active (e.g. the user
+        // returns after granting/revoking in System Settings). This replaces
+        // the old always-on per-permission 1s poll, so a granted app does no
+        // permission work while idle.
+        self.activationCancellable = NotificationCenter.default
+            .publisher(for: NSApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                self?.refreshAllPermissions()
+            }
     }
 
     /// Updates the current permissions state.
     private func updatePermissionsState() {
+        let newState: PermissionsState
         if allPermissions.allSatisfy({ $0.hasPermission }) {
-            permissionsState = .hasAll
+            newState = .hasAll
         } else if requiredPermissions.allSatisfy({ $0.hasPermission }) {
-            permissionsState = .hasRequired
+            newState = .hasRequired
         } else {
-            permissionsState = .missing
+            newState = .missing
+        }
+        // Only publish on an actual change, to avoid churning observers.
+        if permissionsState != newState {
+            permissionsState = newState
         }
     }
 

--- a/Ice/Permissions/Permission.swift
+++ b/Ice/Permissions/Permission.swift
@@ -74,6 +74,13 @@ class Permission: ObservableObject, Identifiable {
 
     /// Sets up the internal observers for the permission.
     private func configureCancellables() {
+        // Only poll while the permission is missing (e.g. during onboarding).
+        // Once granted, the timer stops itself; later changes are picked up on
+        // app activation via `AppPermissions`. Permissions can only change in
+        // System Settings, so there's no reason to poll once we have the grant.
+        guard !hasPermission else {
+            return
+        }
         timerCancellable = Timer.publish(every: 1, on: .main, in: .default)
             .autoconnect()
             .merge(with: Just(.now))
@@ -89,7 +96,19 @@ class Permission: ObservableObject, Identifiable {
     @discardableResult
     func refresh() -> Bool {
         let hasPermission = check()
-        self.hasPermission = hasPermission
+        // Only publish on an actual change, to avoid waking observers (and
+        // churning SwiftUI) every time the check runs.
+        if self.hasPermission != hasPermission {
+            self.hasPermission = hasPermission
+        }
+        if hasPermission {
+            // Granted — stop polling.
+            timerCancellable?.cancel()
+            timerCancellable = nil
+        } else if timerCancellable == nil {
+            // Missing again (e.g. revoked) — resume polling to catch the grant.
+            configureCancellables()
+        }
         return hasPermission
     }
 


### PR DESCRIPTION
## What
Both permission checks (accessibility, screen recording) ran a **1s repeating timer for the app's entire lifetime** — `stopCheck()` was never called anywhere — and `refresh()` reassigned `@Published hasPermission` **unconditionally** every second, cascading into a SwiftUI transaction commit ~2x/sec even when nothing changed and no permissions UI was shown.

## Why
Idle profiling of 2.8.7 (verified hands-off, HID idle >500s) showed ~1% CPU while doing nothing. ~0.34% traced to `AppGraph.updateGraph → NSPerformVisuallyAtomicChange` (SwiftUI churn) driven by the ~2 publishes/sec, plus the timer wakeups.

## Fix
- Poll only while a permission is **missing** (onboarding); stop the timer once granted.
- Re-check on `NSApplication.didBecomeActiveNotification` — covers the user granting/revoking in System Settings and returning. Same UX, ~zero idle cost.
- Publish `hasPermission` and `permissionsState` **only on change**.

## Verification
- Idle profile attribution (see above).
- `BUILD SUCCEEDED` (Debug). Full idle-CPU confirmation to follow on the installed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)