### PR TITLE
chore: bump DragonKit to 1.3.0, adopt DragonAbout.versionString(), v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.9.1 - 2026-07-06
+
+### Changed
+
+- **Clearer "up to date" update message.** The dialog shown when you check for updates and you're already on the latest version has been reworded for clarity.
+- **Richer version in About.** The About pane now shows the version as `v<version> (<build>) · <UTC build time>`, so it's easier to tell exactly which build you're running.
+
 ## 2.9.0 - 2026-07-06
 
 ### Fixed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.0;
+				MARKETING_VERSION = 2.9.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
@@ -474,7 +474,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.0;
+				MARKETING_VERSION = 2.9.1;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
@@ -621,7 +621,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.1;
+				minimumVersion = 1.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "cae1bcb2b7eba65bb1af084c19d0d31306379f40",
-        "version" : "1.2.1"
+        "revision" : "fbc9ff884240e448f3f4c17dc1871eb68f84a029",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Ice/Settings/AboutConfig.swift
+++ b/Ice/Settings/AboutConfig.swift
@@ -15,7 +15,7 @@ enum AboutConfig {
     static var content: AboutContent {
         AboutContent(
             appName: "Ice 2",
-            versionString: "Version \(Constants.versionString)",
+            versionString: DragonAbout.versionString(),
             copyright: Constants.copyrightString,
             links: [
                 // Primary link: the app's marketing page on dragonapp.com.


### PR DESCRIPTION
## Summary

- **DragonKit → 1.3.0.** Bumps the `dragon-kit` SwiftPM pin from `minimumVersion = 1.2.1` to `1.3.0` (still `upToNextMajor`) and regenerates `Package.resolved` (now resolves DragonKit at 1.3.0).
- **About version format.** `AboutConfig` now uses DragonKit's new `DragonAbout.versionString()` instead of `"Version \(Constants.versionString)"`. The About pane now shows the version as `v<version> (<build>) · <UTC build time>`, e.g. `v2.9.1 (1296) · 2026-Jul-06 13:34:56 UTC`.
- **Version bump 2.9.0 → 2.9.1.** Bugfix bump of the Ice app target's `MARKETING_VERSION` (Debug + Release). `CURRENT_PROJECT_VERSION` and the MenuBarItemService helper target are untouched.
- **CHANGELOG.** Adds a `## 2.9.1` section.

## Notes

- The reworded Sparkle "up to date" update dialog comes **for free** from DragonKit 1.3.0 — no app code change was needed for that; it's mentioned in the changelog for user visibility.

## Verification

- `xcodebuild -scheme Ice -configuration Release -destination 'generic/platform=macOS' -project Ice.xcodeproj build CODE_SIGNING_ALLOWED=NO` → **BUILD SUCCEEDED**.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)