### PR TITLE
fix: bump to 2.9.2 so update checks detect the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.9.2 - 2026-07-06
+
+### Fixed
+
+- **"Check for Updates" now finds new releases.** The build number is now derived from the git commit count each release, so Sparkle correctly detects newer versions (previous releases all shared the same build number, which made update checks report "up to date"). No functional changes otherwise — same as 2.9.1.
+
 ## 2.9.1 - 2026-07-06
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.1;
+				MARKETING_VERSION = 2.9.2;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
@@ -474,7 +474,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.1;
+				MARKETING_VERSION = 2.9.2;
 				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
 				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;


### PR DESCRIPTION
2.9.1 shipped with `CFBundleVersion=1296` — the same build number as 2.9.0 (and 2.8.8), because ice-2's xcodebuild release path never stamped the git commit count. Sparkle compares `CFBundleVersion`, so "Check for Updates" reported "up to date" even though the marketing version changed.

Root cause fixed in dragon-release-ci ([#11](https://github.com/teddychan/dragon-release-ci/pull/11), now on `@v5`): the xcodebuild path now bakes `CURRENT_PROJECT_VERSION=<git commit count>` into the signed bundle, like the swiftpm/script paths.

This PR just bumps the marketing version 2.9.1 → 2.9.2 so a new, discoverable release goes out. No functional changes vs 2.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)