### PR TITLE
test(layout): add Layout pane test coverage (IceTests target + manual plan)

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		175061912B1543DD003144CD /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 175061902B1543DD003144CD /* LaunchAtLogin */; };
 		1787C4272B16890B002F50DF /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1787C4262B16890B002F50DF /* AXSwift */; };
 		17F71BB52B880B4500905CBA /* CompactSlider in Frameworks */ = {isa = PBXBuildFile; productRef = 17F71BB42B880B4500905CBA /* CompactSlider */; };
+		1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */; };
+		532D0E5212D395B68CA7F31E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */; };
 		7127A9FF2C4886D100D99DEF /* IfritStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 7127A9FE2C4886D100D99DEF /* IfritStatic */; };
 		7168EE532E281CBC00FF9830 /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7168EE522E281CBC00FF9830 /* AXSwift */; };
 		7188A68C2E27F9ED008F131D /* MenuBarItemService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -19,6 +21,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		23AD04DAF4DBB158954FD5BB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 716683222A767E6A006ABF84 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 716683292A767E6A006ABF84;
+			remoteInfo = Ice;
+		};
 		7188A68A2E27F9ED008F131D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 716683222A767E6A006ABF84 /* Project object */;
@@ -45,17 +54,20 @@
 /* Begin PBXFileReference section */
 		7166832A2A767E6A006ABF84 /* Ice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = MenuBarItemService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+		76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
+		8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		7188A6912E27F9ED008F131D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		7188A6912E27F9ED008F131D /* Exceptions for "MenuBarItemService" folder in "MenuBarItemService" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Resources/Info.plist,
 			);
 			target = 7188A6822E27F9ED008F131D /* MenuBarItemService */;
 		};
-		71BDFC6C2C978E2A00EF145F /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		71BDFC6C2C978E2A00EF145F /* Exceptions for "Ice" folder in "Ice" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Resources/Acknowledgements.rtf,
@@ -66,9 +78,41 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		7188A6842E27F9ED008F131D /* MenuBarItemService */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (7188A6912E27F9ED008F131D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = MenuBarItemService; sourceTree = "<group>"; };
-		7188A69E2E280BB4008F131D /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
-		71BDFBE12C978E2A00EF145F /* Ice */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (71BDFC6C2C978E2A00EF145F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Ice; sourceTree = "<group>"; };
+		7188A6842E27F9ED008F131D /* MenuBarItemService */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				7188A6912E27F9ED008F131D /* Exceptions for "MenuBarItemService" folder in "MenuBarItemService" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = MenuBarItemService;
+			sourceTree = "<group>";
+		};
+		7188A69E2E280BB4008F131D /* Shared */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		71BDFBE12C978E2A00EF145F /* Ice */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				71BDFC6C2C978E2A00EF145F /* Exceptions for "Ice" folder in "Ice" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Ice;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,9 +138,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F197DBDE7DA5E6F963999383 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				532D0E5212D395B68CA7F31E /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		335AD6CA1CFB9CDBB28D7EDE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				38B49182F21DD70D0B575900 /* OS X */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		38B49182F21DD70D0B575900 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */,
+			);
+			name = "OS X";
+			sourceTree = "<group>";
+		};
 		716683212A767E6A006ABF84 = {
 			isa = PBXGroup;
 			children = (
@@ -104,6 +172,8 @@
 				71BDFBE12C978E2A00EF145F /* Ice */,
 				7188A6842E27F9ED008F131D /* MenuBarItemService */,
 				7166832B2A767E6A006ABF84 /* Products */,
+				335AD6CA1CFB9CDBB28D7EDE /* Frameworks */,
+				945A7FF5D94E83B9B4B02E37 /* IceTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -112,13 +182,41 @@
 			children = (
 				7166832A2A767E6A006ABF84 /* Ice.app */,
 				7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */,
+				8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		945A7FF5D94E83B9B4B02E37 /* IceTests */ = {
+			isa = PBXGroup;
+			children = (
+				76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */,
+			);
+			name = IceTests;
+			path = IceTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		09E0359DB70C83EEC505F6D2 /* IceTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AE69166CCA02F19A8602C8C8 /* Build configuration list for PBXNativeTarget "IceTests" */;
+			buildPhases = (
+				19DE591556D5C9FD0BD9ACA4 /* Sources */,
+				F197DBDE7DA5E6F963999383 /* Frameworks */,
+				38ED2621FB5F1EDF927BD19A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CAD6092B6FA97628816AA2F7 /* PBXTargetDependency */,
+			);
+			name = IceTests;
+			productName = IceTests;
+			productReference = 8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		716683292A767E6A006ABF84 /* Ice */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 716683392A767E6B006ABF84 /* Build configuration list for PBXNativeTarget "Ice" */;
@@ -218,11 +316,19 @@
 			targets = (
 				716683292A767E6A006ABF84 /* Ice */,
 				7188A6822E27F9ED008F131D /* MenuBarItemService */,
+				09E0359DB70C83EEC505F6D2 /* IceTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		38ED2621FB5F1EDF927BD19A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		716683282A767E6A006ABF84 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -262,6 +368,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		19DE591556D5C9FD0BD9ACA4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		716683262A767E6A006ABF84 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -284,9 +398,49 @@
 			target = 7188A6822E27F9ED008F131D /* MenuBarItemService */;
 			targetProxy = 7188A68A2E27F9ED008F131D /* PBXContainerItemProxy */;
 		};
+		CAD6092B6FA97628816AA2F7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Ice;
+			target = 716683292A767E6A006ABF84 /* Ice */;
+			targetProxy = 23AD04DAF4DBB158954FD5BB /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		42AC569B0930915B85770315 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = K2ATHQPJDP;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.IceTests;
+				PRODUCT_NAME = IceTests;
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Ice 2.app/Contents/MacOS/Ice 2";
+			};
+			name = Release;
+		};
+		61A0CFBACAF9869CB7AEAC42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = K2ATHQPJDP;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.IceTests;
+				PRODUCT_NAME = IceTests;
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Ice 2.app/Contents/MacOS/Ice 2";
+			};
+			name = Debug;
+		};
 		716683372A767E6B006ABF84 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -433,6 +587,8 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Ice/Resources/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
+				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -440,8 +596,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 2.9.1;
-				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
-				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -468,6 +622,8 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Ice/Resources/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
+				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -475,8 +631,6 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 2.9.1;
-				INFOPLIST_KEY_CFBundleDisplayName = "Ice 2";
-				INFOPLIST_KEY_CFBundleName = "Ice 2";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -561,6 +715,15 @@
 			buildConfigurations = (
 				7188A68E2E27F9ED008F131D /* Debug */,
 				7188A68F2E27F9ED008F131D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AE69166CCA02F19A8602C8C8 /* Build configuration list for PBXNativeTarget "IceTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				42AC569B0930915B85770315 /* Release */,
+				61A0CFBACAF9869CB7AEAC42 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1787C4272B16890B002F50DF /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1787C4262B16890B002F50DF /* AXSwift */; };
 		17F71BB52B880B4500905CBA /* CompactSlider in Frameworks */ = {isa = PBXBuildFile; productRef = 17F71BB42B880B4500905CBA /* CompactSlider */; };
 		1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */; };
+		35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */; };
 		532D0E5212D395B68CA7F31E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */; };
 		7127A9FF2C4886D100D99DEF /* IfritStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 7127A9FE2C4886D100D99DEF /* IfritStatic */; };
 		7168EE532E281CBC00FF9830 /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7168EE522E281CBC00FF9830 /* AXSwift */; };
@@ -53,6 +54,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarItemTagTests.swift; sourceTree = "<group>"; };
 		7166832A2A767E6A006ABF84 /* Ice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = MenuBarItemService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 			children = (
 				76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */,
 				83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */,
+				6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -377,6 +380,7 @@
 			files = (
 				1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */,
 				DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */,
+				35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7188A68C2E27F9ED008F131D /* MenuBarItemService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		71A065092E680C620087DB38 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = 71A065082E680C620087DB38 /* Semaphore */; };
 		883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */; };
+		986A47EC7057DE6842643937 /* SettingsBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */; };
 		DA6DC1703A2B3C4D5E6F7083 /* DragonKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA6DC1702A2B3C4D5E6F7082 /* DragonKit */; };
 		DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */; };
 /* End PBXBuildFile section */
@@ -55,6 +56,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsBackupTests.swift; sourceTree = "<group>"; };
 		4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarLayoutProfileTests.swift; sourceTree = "<group>"; };
 		6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarItemTagTests.swift; sourceTree = "<group>"; };
 		7166832A2A767E6A006ABF84 /* Ice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ice.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -200,6 +202,7 @@
 				83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */,
 				6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */,
 				4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */,
+				12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -385,6 +388,7 @@
 				DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */,
 				35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */,
 				883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */,
+				986A47EC7057DE6842643937 /* SettingsBackupTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		7168EE532E281CBC00FF9830 /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7168EE522E281CBC00FF9830 /* AXSwift */; };
 		7188A68C2E27F9ED008F131D /* MenuBarItemService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		71A065092E680C620087DB38 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = 71A065082E680C620087DB38 /* Semaphore */; };
+		883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */; };
 		DA6DC1703A2B3C4D5E6F7083 /* DragonKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA6DC1702A2B3C4D5E6F7082 /* DragonKit */; };
 		DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */; };
 /* End PBXBuildFile section */
@@ -54,6 +55,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarLayoutProfileTests.swift; sourceTree = "<group>"; };
 		6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarItemTagTests.swift; sourceTree = "<group>"; };
 		7166832A2A767E6A006ABF84 /* Ice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = MenuBarItemService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -197,6 +199,7 @@
 				76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */,
 				83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */,
 				6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */,
+				4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -381,6 +384,7 @@
 				1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */,
 				DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */,
 				35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */,
+				883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		7188A68C2E27F9ED008F131D /* MenuBarItemService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		71A065092E680C620087DB38 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = 71A065082E680C620087DB38 /* Semaphore */; };
 		DA6DC1703A2B3C4D5E6F7083 /* DragonKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA6DC1702A2B3C4D5E6F7082 /* DragonKit */; };
+		DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		7166832A2A767E6A006ABF84 /* Ice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = MenuBarItemService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
+		83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarSectionNameTests.swift; sourceTree = "<group>"; };
 		8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
@@ -191,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */,
+				83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -373,6 +376,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */,
+				DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ice.xcodeproj/xcshareddata/xcschemes/Ice.xcscheme
+++ b/Ice.xcodeproj/xcshareddata/xcschemes/Ice.xcscheme
@@ -28,6 +28,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "09E0359DB70C83EEC505F6D2"
+               BuildableName = "IceTests.xctest"
+               BlueprintName = "IceTests"
+               ReferencedContainer = "container:Ice.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Ice/Main/AppDelegate.swift
+++ b/Ice/Main/AppDelegate.swift
@@ -38,6 +38,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         #endif
 
+        // Don't perform setup when running unit tests. AppState is still
+        // constructed eagerly (a read-only, non-prompting permission probe),
+        // but this skips the heavy menu-bar wiring (status items, EventTaps,
+        // timers) so the test host stays inert. Mirrors the preview guard above.
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return
+        }
+
         // Depending on the permissions state, either perform setup
         // or prompt to grant permissions.
         switch appState.permissions.permissionsState {

--- a/IceTests/MenuBarItemTagTests.swift
+++ b/IceTests/MenuBarItemTagTests.swift
@@ -1,0 +1,81 @@
+//
+//  MenuBarItemTagTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct MenuBarItemTagTests {
+    private func ordinary() -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .string("com.example.Widget"), title: "Widget")
+    }
+
+    @Test func ordinaryItemIsMovableHideableNonControlNonSpacer() {
+        let tag = ordinary()
+        #expect(tag.isMovable)
+        #expect(tag.canBeHidden)
+        #expect(!tag.isControlItem)
+        #expect(!tag.isSpacerItem)
+        #expect(!tag.isBentoBox)
+        #expect(!tag.isSystemClone)
+    }
+
+    @Test func clockAndControlCenterAreImmovable() {
+        #expect(!MenuBarItemTag.clock.isMovable)
+        #expect(!MenuBarItemTag.controlCenter.isMovable)
+    }
+
+    @Test func nonHideableSystemItems() {
+        #expect(!MenuBarItemTag.faceTime.canBeHidden)
+        #expect(!MenuBarItemTag.audioVideoModule.canBeHidden)
+        #expect(!MenuBarItemTag.screenCaptureUI.canBeHidden)
+    }
+
+    @Test func controlItemsAreRecognized() {
+        #expect(MenuBarItemTag.visibleControlItem.isControlItem)
+        #expect(MenuBarItemTag.hiddenControlItem.isControlItem)
+        #expect(MenuBarItemTag.alwaysHiddenControlItem.isControlItem)
+    }
+
+    @Test func spacerItemIsRecognized() {
+        // .ice namespace resolves to the host bundle id under the Ice test host;
+        // prefix comes from MenuBarSpacer.
+        let spacer = MenuBarItemTag(namespace: .ice, title: "Ice.Spacer.ABCDEF")
+        #expect(spacer.isSpacerItem)
+        #expect(!ordinary().isSpacerItem)
+    }
+
+    @Test func bentoBoxIsRecognized() {
+        // MenuBarItemTag.controlCenter has title "BentoBox-0".
+        #expect(MenuBarItemTag.controlCenter.isBentoBox)
+    }
+
+    @Test func systemCloneIsRecognized() {
+        let clone = MenuBarItemTag(namespace: .uuid(UUID()), title: "System Status Item Clone")
+        #expect(clone.isSystemClone)
+    }
+
+    @Test func namespaceOptionalMapsNilToNull() {
+        #expect(MenuBarItemTag.Namespace.optional("x").isString)
+        #expect(MenuBarItemTag.Namespace.optional(nil).isNull)
+        #expect(!MenuBarItemTag.Namespace.optional("x").isNull)
+    }
+
+    @Test func codableRoundTripAcrossNamespaceKinds() throws {
+        let tags = [
+            ordinary(),
+            MenuBarItemTag(namespace: .null, title: ""),
+            MenuBarItemTag(namespace: .uuid(UUID()), title: "UUIDItem"),
+        ]
+        let data = try JSONEncoder().encode(tags)
+        let decoded = try JSONDecoder().decode([MenuBarItemTag].self, from: data)
+        #expect(decoded == tags)
+    }
+
+    @Test func descriptionFormatting() {
+        #expect(ordinary().description == "com.example.Widget:Widget")
+        #expect(MenuBarItemTag(namespace: .string("ns"), title: "").description == "ns")
+    }
+}

--- a/IceTests/MenuBarLayoutProfileTests.swift
+++ b/IceTests/MenuBarLayoutProfileTests.swift
@@ -1,0 +1,67 @@
+//
+//  MenuBarLayoutProfileTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct MenuBarLayoutProfileTests {
+    private func tag(_ title: String) -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .string("com.example"), title: title)
+    }
+
+    private func sampleProfile() -> MenuBarLayoutProfile {
+        MenuBarLayoutProfile(
+            id: UUID(),
+            name: "Work",
+            createdAt: Date(timeIntervalSince1970: 1000),
+            updatedAt: Date(timeIntervalSince1970: 2000),
+            sections: [
+                .init(section: .visible, itemTags: [tag("A"), tag("B")]),
+                .init(section: .hidden, itemTags: [tag("C")]),
+                .init(section: .alwaysHidden, itemTags: []),
+            ]
+        )
+    }
+
+    @Test func itemTagsAndCountsPerSection() {
+        let profile = sampleProfile()
+        #expect(profile.itemTags(for: .visible) == [tag("A"), tag("B")])
+        #expect(profile.itemCount(for: .visible) == 2)
+        #expect(profile.itemTags(for: .hidden) == [tag("C")])
+        #expect(profile.itemCount(for: .alwaysHidden) == 0)
+    }
+
+    @Test func missingSectionReturnsEmpty() {
+        let profile = MenuBarLayoutProfile(
+            id: UUID(), name: "Empty",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            sections: []
+        )
+        #expect(profile.itemTags(for: .visible).isEmpty)
+        #expect(profile.itemCount(for: .hidden) == 0)
+    }
+
+    @Test func profileCodableRoundTrip() throws {
+        let profile = sampleProfile()
+        let data = try JSONEncoder().encode(profile)
+        let decoded = try JSONDecoder().decode(MenuBarLayoutProfile.self, from: data)
+        #expect(decoded == profile)
+    }
+
+    @Test func groupCountAndCodableRoundTrip() throws {
+        let group = MenuBarItemGroup(
+            id: UUID(), name: "G",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            itemTags: [tag("A"), tag("B")]
+        )
+        #expect(group.itemCount == 2)
+        let data = try JSONEncoder().encode(group)
+        let decoded = try JSONDecoder().decode(MenuBarItemGroup.self, from: data)
+        #expect(decoded == group)
+    }
+}

--- a/IceTests/MenuBarSectionNameTests.swift
+++ b/IceTests/MenuBarSectionNameTests.swift
@@ -1,0 +1,24 @@
+//
+//  MenuBarSectionNameTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct MenuBarSectionNameTests {
+    // Profile snapshots iterate allCases in order; order is load-bearing.
+    @Test func allCasesInDeclaredOrder() {
+        #expect(MenuBarSection.Name.allCases == [.visible, .hidden, .alwaysHidden])
+    }
+
+    // Raw values must stay stable so profiles saved by older builds decode.
+    @Test func rawValuesAreStable() throws {
+        let data = try JSONEncoder().encode(
+            [MenuBarSection.Name.visible, .hidden, .alwaysHidden]
+        )
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(json == #"["visible","hidden","alwaysHidden"]"#)
+    }
+}

--- a/IceTests/SettingsBackupTests.swift
+++ b/IceTests/SettingsBackupTests.swift
@@ -1,0 +1,150 @@
+//
+//  SettingsBackupTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct SettingsBackupTests {
+    /// A throwaway UserDefaults suite. Caller must clean it up (see `defer`).
+    private func makeScratch() -> (defaults: UserDefaults, suite: String) {
+        let suite = "IceTests." + UUID().uuidString
+        return (UserDefaults(suiteName: suite)!, suite)
+    }
+
+    @Test func payloadRoundTripReproducesValues() {
+        let (source, sSuite) = makeScratch()
+        let (target, tSuite) = makeScratch()
+        defer {
+            UserDefaults.standard.removePersistentDomain(forName: sSuite)
+            UserDefaults.standard.removePersistentDomain(forName: tSuite)
+        }
+        source.set("hello", forKey: Defaults.Key.iceIcon.rawValue)
+        source.set(42, forKey: Defaults.Key.showOnHoverDelay.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "9.9", createdDate: Date(timeIntervalSince1970: 1000)
+        )
+        SettingsBackup.apply(payload, to: target)
+
+        #expect(target.string(forKey: Defaults.Key.iceIcon.rawValue) == "hello")
+        #expect(target.integer(forKey: Defaults.Key.showOnHoverDelay.rawValue) == 42)
+    }
+
+    @Test func applyIsReplaceNotMerge() {
+        let (source, sSuite) = makeScratch()
+        let (target, tSuite) = makeScratch()
+        defer {
+            UserDefaults.standard.removePersistentDomain(forName: sSuite)
+            UserDefaults.standard.removePersistentDomain(forName: tSuite)
+        }
+        source.set("keep", forKey: Defaults.Key.iceIcon.rawValue)
+        // A backed-up key present in target but absent from the payload must be removed.
+        target.set(true, forKey: Defaults.Key.useIceBar.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "1", createdDate: Date(timeIntervalSince1970: 0)
+        )
+        SettingsBackup.apply(payload, to: target)
+
+        #expect(target.string(forKey: Defaults.Key.iceIcon.rawValue) == "keep")
+        #expect(target.object(forKey: Defaults.Key.useIceBar.rawValue) == nil)
+    }
+
+    @Test func excludedKeysNeverTravel() {
+        let (source, sSuite) = makeScratch()
+        defer { UserDefaults.standard.removePersistentDomain(forName: sSuite) }
+        source.set("/tmp/x", forKey: Defaults.Key.backupFolderPath.rawValue)
+        source.set(true, forKey: Defaults.Key.automaticBackupEnabled.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "1", createdDate: Date(timeIntervalSince1970: 0)
+        )
+        // PayloadKey is private -> inspect via the raw string key.
+        let stored = payload["defaults"] as? [String: Any] ?? [:]
+        #expect(stored[Defaults.Key.backupFolderPath.rawValue] == nil)
+        #expect(stored[Defaults.Key.automaticBackupEnabled.rawValue] == nil)
+    }
+
+    @Test func serializeDeserializeRoundTrip() throws {
+        let (source, sSuite) = makeScratch()
+        defer { UserDefaults.standard.removePersistentDomain(forName: sSuite) }
+        source.set("v", forKey: Defaults.Key.iceIcon.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "2.0", createdDate: Date(timeIntervalSince1970: 5)
+        )
+        let data = try SettingsBackup.serialize(payload)
+        let back = try SettingsBackup.deserialize(data)
+
+        #expect(SettingsBackup.appVersion(of: back) == "2.0")
+        #expect(SettingsBackup.createdDate(of: back) == Date(timeIntervalSince1970: 5))
+    }
+
+    @Test func deserializeRejectsNewerSchema() throws {
+        let payload: [String: Any] = [
+            "schemaVersion": SettingsBackup.schemaVersion + 1,
+            "defaults": [String: Any](),
+        ]
+        let data = try SettingsBackup.serialize(payload)
+        #expect(throws: SettingsBackup.BackupError.unsupportedVersion(SettingsBackup.schemaVersion + 1)) {
+            _ = try SettingsBackup.deserialize(data)
+        }
+    }
+
+    @Test func deserializeRejectsValidNonDictionaryPlist() throws {
+        // A VALID plist that is an array, not a dictionary — exercises the
+        // `as? [String: Any]` guard (random bytes would fail parsing first).
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["a", "b"], format: .binary, options: 0
+        )
+        #expect(throws: SettingsBackup.BackupError.malformed) {
+            _ = try SettingsBackup.deserialize(data)
+        }
+    }
+
+    @Test func fileNameShapeIsTimezoneRobust() {
+        // timestamp() sets no timeZone, so only assert the SHAPE, not an
+        // exact value from an absolute Date.
+        let name = SettingsBackup.fileName(for: Date(timeIntervalSince1970: 0))
+        let matched = name.range(
+            of: #"^Ice-Settings-\d{4}-\d{2}-\d{2}-\d{6}\.icebackup$"#,
+            options: .regularExpression
+        )
+        #expect(matched != nil)
+    }
+
+    @Test func listBackupsFiltersAndSortsNewestFirst() throws {
+        let folder = FileManager.default.temporaryDirectory
+            .appending(path: "IceTests-" + UUID().uuidString)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        for stamp in ["2026-01-01-000000", "2026-01-02-000000", "2026-01-03-000000"] {
+            try Data("x".utf8).write(to: folder.appending(path: "Ice-Settings-\(stamp).icebackup"))
+        }
+        try Data("y".utf8).write(to: folder.appending(path: "notes.txt")) // must be ignored
+
+        let list = SettingsBackup.listBackups(in: folder)
+        #expect(list.count == 3)
+        #expect(list.first?.lastPathComponent == "Ice-Settings-2026-01-03-000000.icebackup")
+    }
+
+    @Test func pruneKeepsNewest() throws {
+        let folder = FileManager.default.temporaryDirectory
+            .appending(path: "IceTests-" + UUID().uuidString)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        for stamp in ["2026-01-01-000000", "2026-01-02-000000", "2026-01-03-000000"] {
+            try Data("x".utf8).write(to: folder.appending(path: "Ice-Settings-\(stamp).icebackup"))
+        }
+        SettingsBackup.prune(in: folder, keeping: 1)
+
+        let remaining = SettingsBackup.listBackups(in: folder)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.lastPathComponent == "Ice-Settings-2026-01-03-000000.icebackup")
+    }
+}

--- a/IceTests/SmokeTests.swift
+++ b/IceTests/SmokeTests.swift
@@ -1,0 +1,16 @@
+//
+//  SmokeTests.swift
+//  IceTests
+//
+
+import Testing
+// The Ice app target's product name is "Ice 2", so its Swift module is `Ice_2`.
+@testable import Ice_2
+
+/// Proves the test target links against the Ice app host and that
+/// `@testable import Ice_2` resolves the app's internal types.
+struct SmokeTests {
+    @Test func iceModuleIsImportable() {
+        #expect(MenuBarSection.Name.allCases.count == 3)
+    }
+}

--- a/docs/superpowers/plans/2026-07-06-layout-pane-tests.md
+++ b/docs/superpowers/plans/2026-07-06-layout-pane-tests.md
@@ -1,0 +1,760 @@
+# Layout Pane Test Coverage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an automated Swift Testing suite for the Layout pane's pure logic (menu-bar item tag classification, layout-profile & group serialization, settings-backup save/restore, section-name stability), plus a written manual test plan for the real menu-bar behavior that needs TCC permissions.
+
+**Architecture:** A new `IceTests` unit-test target is added to `Ice.xcodeproj`, hosted by the `Ice` app so `@testable import Ice` can reach its `internal` types. A ~3-line guard in `AppDelegate` short-circuits app setup under tests so the host doesn't boot the real menu bar. Tests exercise only pure, permission-free code paths; everything requiring live `NSStatusItem`s / EventTaps / TCC is captured in a manual checklist doc.
+
+**Tech Stack:** Swift Testing (`import Testing`, `@Test`, `#expect`), Xcode 26.6, macOS 26 deployment target, Swift 5.0, `xcodebuild test`. Target creation via the Ruby `xcodeproj` gem (with an Xcode-UI fallback, since only system Ruby 2.6 is present and the gem is not installed).
+
+**Spec:** [docs/superpowers/specs/2026-07-06-layout-pane-tests-design.md](../specs/2026-07-06-layout-pane-tests-design.md)
+
+---
+
+## File Structure
+
+Files created / modified across the plan:
+
+- **Create** `scripts/add-icetests-target.rb` — idempotent Ruby script (uses the `xcodeproj` gem) that creates the `IceTests` target if missing, wires `TEST_HOST`/`BUNDLE_LOADER` to the `Ice` app, adds it to the shared `Ice` scheme's test action, and syncs every `IceTests/*.swift` file into the target. Re-run after adding each test file.
+- **Modify** `Ice/Main/AppDelegate.swift` — add the `XCTestConfigurationFilePath` guard (the only production-code change).
+- **Modify** `Ice.xcodeproj/project.pbxproj` + `Ice.xcodeproj/xcshareddata/xcschemes/Ice.xcscheme` — produced by the script; committed as generated output.
+- **Create** `IceTests/SmokeTests.swift` — proves the target links and `@testable import Ice` resolves.
+- **Create** `IceTests/MenuBarSectionNameTests.swift` — section-name order & raw-value stability.
+- **Create** `IceTests/MenuBarItemTagTests.swift` — movability/hideability/control/spacer/bento/clone classification, `Namespace`, Codable, description.
+- **Create** `IceTests/MenuBarLayoutProfileTests.swift` — profile & group accessors and Codable round-trip.
+- **Create** `IceTests/SettingsBackupTests.swift` — payload round-trip, replace-not-merge, excluded keys, serialize/deserialize, schema/malformed rejection, list/prune, filename shape.
+- **Create** `docs/testing/layout-pane-manual-tests.md` — the manual test plan.
+
+**Note on Task 1:** creating the Xcode target is the one step that may require an install (`gem install`) or, if that fails, a human in Xcode. Every task after Task 1 is pure Swift + `xcodebuild` and is fully agent-automatable. Do Task 1 first and confirm the smoke test passes before proceeding.
+
+---
+
+## Task 1: Create the `IceTests` target + AppDelegate guard + smoke test
+
+**Files:**
+- Create: `IceTests/SmokeTests.swift`
+- Create: `scripts/add-icetests-target.rb`
+- Modify: `Ice/Main/AppDelegate.swift` (after the preview guard, ~line 39)
+- Modify (generated): `Ice.xcodeproj/project.pbxproj`, `Ice.xcodeproj/xcshareddata/xcschemes/Ice.xcscheme`
+
+- [ ] **Step 1: Write the smoke test file**
+
+Create `IceTests/SmokeTests.swift`:
+
+```swift
+//
+//  SmokeTests.swift
+//  IceTests
+//
+
+import Testing
+@testable import Ice
+
+/// Proves the test target links against the Ice app host and that
+/// `@testable import Ice` resolves the app's internal types.
+struct SmokeTests {
+    @Test func iceModuleIsImportable() {
+        #expect(MenuBarSection.Name.allCases.count == 3)
+    }
+}
+```
+
+- [ ] **Step 2: Add the AppDelegate test guard**
+
+In `Ice/Main/AppDelegate.swift`, inside `applicationDidFinishLaunching`, immediately AFTER the existing `#if DEBUG … XCODE_RUNNING_FOR_PREVIEWS … #endif` block and BEFORE the `switch appState.permissions.permissionsState` line, insert:
+
+```swift
+        // Don't perform setup when running unit tests. AppState is still
+        // constructed eagerly (a read-only, non-prompting permission probe),
+        // but this skips the heavy menu-bar wiring (status items, EventTaps,
+        // timers) so the test host stays inert. Mirrors the preview guard above.
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return
+        }
+```
+
+- [ ] **Step 3: Write the target-creation script**
+
+Create `scripts/add-icetests-target.rb`:
+
+```ruby
+#!/usr/bin/env ruby
+# Idempotently add/refresh the IceTests unit-test target in Ice.xcodeproj.
+# Requires the `xcodeproj` gem. Re-run after adding any IceTests/*.swift file.
+require 'xcodeproj'
+
+PROJECT = 'Ice.xcodeproj'
+project = Xcodeproj::Project.open(PROJECT)
+
+ice = project.targets.find { |t| t.name == 'Ice' }
+abort 'Ice target not found' unless ice
+
+test = project.targets.find { |t| t.name == 'IceTests' }
+if test.nil?
+  test = project.new_target(:unit_test_bundle, 'IceTests', :osx, '26.0')
+  test.build_configurations.each do |config|
+    s = config.build_settings
+    s['PRODUCT_BUNDLE_IDENTIFIER'] = 'com.dragonapp.ice.IceTests'
+    s['SWIFT_VERSION'] = '5.0'
+    s['MACOSX_DEPLOYMENT_TARGET'] = '26.0'
+    s['GENERATE_INFOPLIST_FILE'] = 'YES'
+    s['TEST_HOST'] = '$(BUILT_PRODUCTS_DIR)/Ice.app/Contents/MacOS/Ice'
+    s['BUNDLE_LOADER'] = '$(TEST_HOST)'
+    s['DEVELOPMENT_TEAM'] = 'K2ATHQPJDP'
+    s['CODE_SIGN_STYLE'] = 'Automatic'
+    s['SWIFT_EMIT_LOC_STRINGS'] = 'NO'
+  end
+  test.add_dependency(ice)
+
+  # Register the target in the shared Ice scheme's Test action.
+  scheme_dir = Xcodeproj::XCScheme.shared_data_dir(PROJECT)
+  scheme_path = File.join(scheme_dir, 'Ice.xcscheme')
+  scheme = Xcodeproj::XCScheme.new(scheme_path)
+  ref = Xcodeproj::XCScheme::TestAction::TestableReference.new(test)
+  scheme.test_action.add_testable(ref)
+  scheme.save_as(PROJECT, 'Ice', true)
+end
+
+# Sync every IceTests/*.swift file into the target (add missing ones only).
+group = project.main_group['IceTests'] || project.main_group.new_group('IceTests', 'IceTests')
+already = test.source_build_phase.files_references.map { |r| r.real_path.to_s }
+Dir.glob('IceTests/*.swift').sort.each do |path|
+  abs = File.expand_path(path)
+  next if already.include?(abs)
+  file_ref = group.new_file(File.basename(path))
+  test.add_file_references([file_ref])
+end
+
+project.save
+puts "IceTests synced (#{test.source_build_phase.files.count} source files)"
+```
+
+- [ ] **Step 4: Install the gem and run the script**
+
+Prefer a no-sudo user install (the gem is pure Ruby — no native build):
+
+```bash
+gem install --user-install xcodeproj
+GEM_HOME="$(ruby -e 'puts Gem.user_dir')" ruby scripts/add-icetests-target.rb
+```
+
+Expected: `IceTests synced (1 source files)`.
+
+If the user install fails on Ruby 2.6, try `sudo gem install xcodeproj` (pin an older release if the version resolver complains, e.g. `sudo gem install xcodeproj -v 1.24.0`), then re-run the `ruby scripts/add-icetests-target.rb` line.
+
+**Fallback (only if the gem cannot be installed):** create the target manually in Xcode — File ▸ New ▸ Target ▸ *Unit Testing Bundle*, name `IceTests`, "Testing System" = Testing (Swift Testing), host application = `Ice`; add `IceTests/SmokeTests.swift` to it; then verify the `Ice` scheme's Test action lists `IceTests`. Commit the resulting `project.pbxproj`/scheme diff.
+
+- [ ] **Step 5: Run the smoke test to verify the target works**
+
+Run:
+
+```bash
+xcodebuild test -project Ice.xcodeproj -scheme Ice \
+  -destination 'platform=macOS' -only-testing:IceTests 2>&1 | tail -30
+```
+
+Expected: build succeeds and `SmokeTests.iceModuleIsImportable` passes (`** TEST SUCCEEDED **`). If code-signing blocks the host launch, confirm automatic signing with team `K2ATHQPJDP` is available on this machine.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/add-icetests-target.rb IceTests/SmokeTests.swift \
+  Ice/Main/AppDelegate.swift Ice.xcodeproj
+git commit -m "test(layout): add IceTests target, host guard, smoke test
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `MenuBarSectionNameTests`
+
+**Files:**
+- Create: `IceTests/MenuBarSectionNameTests.swift`
+- Under test: `Ice/MenuBar/MenuBarSection.swift` (`MenuBarSection.Name`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `IceTests/MenuBarSectionNameTests.swift`:
+
+```swift
+//
+//  MenuBarSectionNameTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice
+
+struct MenuBarSectionNameTests {
+    // Profile snapshots iterate allCases in order; order is load-bearing.
+    @Test func allCasesInDeclaredOrder() {
+        #expect(MenuBarSection.Name.allCases == [.visible, .hidden, .alwaysHidden])
+    }
+
+    // Raw values must stay stable so profiles saved by older builds decode.
+    @Test func rawValuesAreStable() throws {
+        let data = try JSONEncoder().encode(
+            [MenuBarSection.Name.visible, .hidden, .alwaysHidden]
+        )
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(json == #"["visible","hidden","alwaysHidden"]"#)
+    }
+}
+```
+
+- [ ] **Step 2: Add the file to the target and run**
+
+```bash
+GEM_HOME="$(ruby -e 'puts Gem.user_dir')" ruby scripts/add-icetests-target.rb
+xcodebuild test -project Ice.xcodeproj -scheme Ice \
+  -destination 'platform=macOS' -only-testing:IceTests/MenuBarSectionNameTests 2>&1 | tail -20
+```
+
+Expected: both tests PASS. (No implementation step — this exercises existing production code; the "failing" state would only appear if `Name` were reordered or its raw values changed.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add IceTests/MenuBarSectionNameTests.swift Ice.xcodeproj
+git commit -m "test(layout): cover MenuBarSection.Name order and raw values
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `MenuBarItemTagTests`
+
+**Files:**
+- Create: `IceTests/MenuBarItemTagTests.swift`
+- Under test: `Ice/MenuBar/MenuBarItems/MenuBarItemTag.swift`
+
+- [ ] **Step 1: Write the tests**
+
+Create `IceTests/MenuBarItemTagTests.swift`:
+
+```swift
+//
+//  MenuBarItemTagTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice
+
+struct MenuBarItemTagTests {
+    private func ordinary() -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .string("com.example.Widget"), title: "Widget")
+    }
+
+    @Test func ordinaryItemIsMovableHideableNonControlNonSpacer() {
+        let tag = ordinary()
+        #expect(tag.isMovable)
+        #expect(tag.canBeHidden)
+        #expect(!tag.isControlItem)
+        #expect(!tag.isSpacerItem)
+        #expect(!tag.isBentoBox)
+        #expect(!tag.isSystemClone)
+    }
+
+    @Test func clockAndControlCenterAreImmovable() {
+        #expect(!MenuBarItemTag.clock.isMovable)
+        #expect(!MenuBarItemTag.controlCenter.isMovable)
+    }
+
+    @Test func nonHideableSystemItems() {
+        #expect(!MenuBarItemTag.faceTime.canBeHidden)
+        #expect(!MenuBarItemTag.audioVideoModule.canBeHidden)
+        #expect(!MenuBarItemTag.screenCaptureUI.canBeHidden)
+    }
+
+    @Test func controlItemsAreRecognized() {
+        #expect(MenuBarItemTag.visibleControlItem.isControlItem)
+        #expect(MenuBarItemTag.hiddenControlItem.isControlItem)
+        #expect(MenuBarItemTag.alwaysHiddenControlItem.isControlItem)
+    }
+
+    @Test func spacerItemIsRecognized() {
+        // .ice namespace resolves to the host bundle id (com.dragonapp.ice)
+        // under the Ice test host; prefix comes from MenuBarSpacer.
+        let spacer = MenuBarItemTag(namespace: .ice, title: "Ice.Spacer.ABCDEF")
+        #expect(spacer.isSpacerItem)
+        #expect(!ordinary().isSpacerItem)
+    }
+
+    @Test func bentoBoxIsRecognized() {
+        // MenuBarItemTag.controlCenter has title "BentoBox-0".
+        #expect(MenuBarItemTag.controlCenter.isBentoBox)
+    }
+
+    @Test func systemCloneIsRecognized() {
+        let clone = MenuBarItemTag(namespace: .uuid(UUID()), title: "System Status Item Clone")
+        #expect(clone.isSystemClone)
+    }
+
+    @Test func namespaceOptionalMapsNilToNull() {
+        #expect(MenuBarItemTag.Namespace.optional("x").isString)
+        #expect(MenuBarItemTag.Namespace.optional(nil).isNull)
+        #expect(!MenuBarItemTag.Namespace.optional("x").isNull)
+    }
+
+    @Test func codableRoundTripAcrossNamespaceKinds() throws {
+        let tags = [
+            ordinary(),
+            MenuBarItemTag(namespace: .null, title: ""),
+            MenuBarItemTag(namespace: .uuid(UUID()), title: "UUIDItem"),
+        ]
+        let data = try JSONEncoder().encode(tags)
+        let decoded = try JSONDecoder().decode([MenuBarItemTag].self, from: data)
+        #expect(decoded == tags)
+    }
+
+    @Test func descriptionFormatting() {
+        #expect(ordinary().description == "com.example.Widget:Widget")
+        #expect(MenuBarItemTag(namespace: .string("ns"), title: "").description == "ns")
+    }
+}
+```
+
+- [ ] **Step 2: Add to target and run**
+
+```bash
+GEM_HOME="$(ruby -e 'puts Gem.user_dir')" ruby scripts/add-icetests-target.rb
+xcodebuild test -project Ice.xcodeproj -scheme Ice \
+  -destination 'platform=macOS' -only-testing:IceTests/MenuBarItemTagTests 2>&1 | tail -20
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add IceTests/MenuBarItemTagTests.swift Ice.xcodeproj
+git commit -m "test(layout): cover MenuBarItemTag classification and Codable
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `MenuBarLayoutProfileTests`
+
+**Files:**
+- Create: `IceTests/MenuBarLayoutProfileTests.swift`
+- Under test: `Ice/Settings/Models/MenuBarLayoutProfilesSettings.swift` (`MenuBarLayoutProfile`, `MenuBarItemGroup`)
+
+- [ ] **Step 1: Write the tests**
+
+Create `IceTests/MenuBarLayoutProfileTests.swift`:
+
+```swift
+//
+//  MenuBarLayoutProfileTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice
+
+struct MenuBarLayoutProfileTests {
+    private func tag(_ title: String) -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .string("com.example"), title: title)
+    }
+
+    private func sampleProfile() -> MenuBarLayoutProfile {
+        MenuBarLayoutProfile(
+            id: UUID(),
+            name: "Work",
+            createdAt: Date(timeIntervalSince1970: 1000),
+            updatedAt: Date(timeIntervalSince1970: 2000),
+            sections: [
+                .init(section: .visible, itemTags: [tag("A"), tag("B")]),
+                .init(section: .hidden, itemTags: [tag("C")]),
+                .init(section: .alwaysHidden, itemTags: []),
+            ]
+        )
+    }
+
+    @Test func itemTagsAndCountsPerSection() {
+        let profile = sampleProfile()
+        #expect(profile.itemTags(for: .visible) == [tag("A"), tag("B")])
+        #expect(profile.itemCount(for: .visible) == 2)
+        #expect(profile.itemTags(for: .hidden) == [tag("C")])
+        #expect(profile.itemCount(for: .alwaysHidden) == 0)
+    }
+
+    @Test func missingSectionReturnsEmpty() {
+        let profile = MenuBarLayoutProfile(
+            id: UUID(), name: "Empty",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            sections: []
+        )
+        #expect(profile.itemTags(for: .visible).isEmpty)
+        #expect(profile.itemCount(for: .hidden) == 0)
+    }
+
+    @Test func profileCodableRoundTrip() throws {
+        let profile = sampleProfile()
+        let data = try JSONEncoder().encode(profile)
+        let decoded = try JSONDecoder().decode(MenuBarLayoutProfile.self, from: data)
+        #expect(decoded == profile)
+    }
+
+    @Test func groupCountAndCodableRoundTrip() throws {
+        let group = MenuBarItemGroup(
+            id: UUID(), name: "G",
+            createdAt: Date(timeIntervalSince1970: 1),
+            updatedAt: Date(timeIntervalSince1970: 2),
+            itemTags: [tag("A"), tag("B")]
+        )
+        #expect(group.itemCount == 2)
+        let data = try JSONEncoder().encode(group)
+        let decoded = try JSONDecoder().decode(MenuBarItemGroup.self, from: data)
+        #expect(decoded == group)
+    }
+}
+```
+
+- [ ] **Step 2: Add to target and run**
+
+```bash
+GEM_HOME="$(ruby -e 'puts Gem.user_dir')" ruby scripts/add-icetests-target.rb
+xcodebuild test -project Ice.xcodeproj -scheme Ice \
+  -destination 'platform=macOS' -only-testing:IceTests/MenuBarLayoutProfileTests 2>&1 | tail -20
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add IceTests/MenuBarLayoutProfileTests.swift Ice.xcodeproj
+git commit -m "test(layout): cover layout profile & group accessors and Codable
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `SettingsBackupTests`
+
+**Files:**
+- Create: `IceTests/SettingsBackupTests.swift`
+- Under test: `Ice/Settings/Backup/SettingsBackup.swift`
+
+- [ ] **Step 1: Write the tests**
+
+Create `IceTests/SettingsBackupTests.swift`:
+
+```swift
+//
+//  SettingsBackupTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice
+
+struct SettingsBackupTests {
+    /// A throwaway UserDefaults suite. Caller must clean it up (see `defer`).
+    private func makeScratch() -> (defaults: UserDefaults, suite: String) {
+        let suite = "IceTests." + UUID().uuidString
+        return (UserDefaults(suiteName: suite)!, suite)
+    }
+
+    @Test func payloadRoundTripReproducesValues() {
+        let (source, sSuite) = makeScratch()
+        let (target, tSuite) = makeScratch()
+        defer {
+            UserDefaults.standard.removePersistentDomain(forName: sSuite)
+            UserDefaults.standard.removePersistentDomain(forName: tSuite)
+        }
+        source.set("hello", forKey: Defaults.Key.iceIcon.rawValue)
+        source.set(42, forKey: Defaults.Key.showOnHoverDelay.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "9.9", createdDate: Date(timeIntervalSince1970: 1000)
+        )
+        SettingsBackup.apply(payload, to: target)
+
+        #expect(target.string(forKey: Defaults.Key.iceIcon.rawValue) == "hello")
+        #expect(target.integer(forKey: Defaults.Key.showOnHoverDelay.rawValue) == 42)
+    }
+
+    @Test func applyIsReplaceNotMerge() {
+        let (source, sSuite) = makeScratch()
+        let (target, tSuite) = makeScratch()
+        defer {
+            UserDefaults.standard.removePersistentDomain(forName: sSuite)
+            UserDefaults.standard.removePersistentDomain(forName: tSuite)
+        }
+        source.set("keep", forKey: Defaults.Key.iceIcon.rawValue)
+        // A backed-up key present in target but absent from the payload must be removed.
+        target.set(true, forKey: Defaults.Key.useIceBar.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "1", createdDate: Date(timeIntervalSince1970: 0)
+        )
+        SettingsBackup.apply(payload, to: target)
+
+        #expect(target.string(forKey: Defaults.Key.iceIcon.rawValue) == "keep")
+        #expect(target.object(forKey: Defaults.Key.useIceBar.rawValue) == nil)
+    }
+
+    @Test func excludedKeysNeverTravel() {
+        let (source, sSuite) = makeScratch()
+        defer { UserDefaults.standard.removePersistentDomain(forName: sSuite) }
+        source.set("/tmp/x", forKey: Defaults.Key.backupFolderPath.rawValue)
+        source.set(true, forKey: Defaults.Key.automaticBackupEnabled.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "1", createdDate: Date(timeIntervalSince1970: 0)
+        )
+        // PayloadKey is private -> inspect via the raw string key.
+        let stored = payload["defaults"] as? [String: Any] ?? [:]
+        #expect(stored[Defaults.Key.backupFolderPath.rawValue] == nil)
+        #expect(stored[Defaults.Key.automaticBackupEnabled.rawValue] == nil)
+    }
+
+    @Test func serializeDeserializeRoundTrip() throws {
+        let (source, sSuite) = makeScratch()
+        defer { UserDefaults.standard.removePersistentDomain(forName: sSuite) }
+        source.set("v", forKey: Defaults.Key.iceIcon.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "2.0", createdDate: Date(timeIntervalSince1970: 5)
+        )
+        let data = try SettingsBackup.serialize(payload)
+        let back = try SettingsBackup.deserialize(data)
+
+        #expect(SettingsBackup.appVersion(of: back) == "2.0")
+        #expect(SettingsBackup.createdDate(of: back) == Date(timeIntervalSince1970: 5))
+    }
+
+    @Test func deserializeRejectsNewerSchema() throws {
+        let payload: [String: Any] = [
+            "schemaVersion": SettingsBackup.schemaVersion + 1,
+            "defaults": [String: Any](),
+        ]
+        let data = try SettingsBackup.serialize(payload)
+        #expect(throws: SettingsBackup.BackupError.unsupportedVersion(SettingsBackup.schemaVersion + 1)) {
+            _ = try SettingsBackup.deserialize(data)
+        }
+    }
+
+    @Test func deserializeRejectsValidNonDictionaryPlist() throws {
+        // A VALID plist that is an array, not a dictionary — exercises the
+        // `as? [String: Any]` guard (random bytes would fail parsing first).
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: ["a", "b"], format: .binary, options: 0
+        )
+        #expect(throws: SettingsBackup.BackupError.malformed) {
+            _ = try SettingsBackup.deserialize(data)
+        }
+    }
+
+    @Test func fileNameShapeIsTimezoneRobust() {
+        // timestamp() sets no timeZone, so only assert the SHAPE, not an
+        // exact value from an absolute Date.
+        let name = SettingsBackup.fileName(for: Date(timeIntervalSince1970: 0))
+        let matched = name.range(
+            of: #"^Ice-Settings-\d{4}-\d{2}-\d{2}-\d{6}\.icebackup$"#,
+            options: .regularExpression
+        )
+        #expect(matched != nil)
+    }
+
+    @Test func listBackupsFiltersAndSortsNewestFirst() throws {
+        let folder = FileManager.default.temporaryDirectory
+            .appending(path: "IceTests-" + UUID().uuidString)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        for stamp in ["2026-01-01-000000", "2026-01-02-000000", "2026-01-03-000000"] {
+            try Data("x".utf8).write(to: folder.appending(path: "Ice-Settings-\(stamp).icebackup"))
+        }
+        try Data("y".utf8).write(to: folder.appending(path: "notes.txt")) // must be ignored
+
+        let list = SettingsBackup.listBackups(in: folder)
+        #expect(list.count == 3)
+        #expect(list.first?.lastPathComponent == "Ice-Settings-2026-01-03-000000.icebackup")
+    }
+
+    @Test func pruneKeepsNewest() throws {
+        let folder = FileManager.default.temporaryDirectory
+            .appending(path: "IceTests-" + UUID().uuidString)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        for stamp in ["2026-01-01-000000", "2026-01-02-000000", "2026-01-03-000000"] {
+            try Data("x".utf8).write(to: folder.appending(path: "Ice-Settings-\(stamp).icebackup"))
+        }
+        SettingsBackup.prune(in: folder, keeping: 1)
+
+        let remaining = SettingsBackup.listBackups(in: folder)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.lastPathComponent == "Ice-Settings-2026-01-03-000000.icebackup")
+    }
+}
+```
+
+- [ ] **Step 2: Add to target and run**
+
+```bash
+GEM_HOME="$(ruby -e 'puts Gem.user_dir')" ruby scripts/add-icetests-target.rb
+xcodebuild test -project Ice.xcodeproj -scheme Ice \
+  -destination 'platform=macOS' -only-testing:IceTests/SettingsBackupTests 2>&1 | tail -25
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add IceTests/SettingsBackupTests.swift Ice.xcodeproj
+git commit -m "test(backup): cover payload round-trip, replace semantics, retention
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Manual test plan document
+
+**Files:**
+- Create: `docs/testing/layout-pane-manual-tests.md`
+
+- [ ] **Step 1: Write the manual test plan**
+
+Create `docs/testing/layout-pane-manual-tests.md` with exactly this content:
+
+````markdown
+# Layout Pane — Manual Test Plan
+
+The Layout pane's on-screen behavior (moving items, showing/hiding sections,
+applying profiles) is driven by real `NSStatusItem`s and the scromble EventTap
+barrier, which need **granted TCC permissions** and therefore cannot be
+covered by the automated `IceTests` suite. Run this checklist by hand.
+
+## Preconditions
+
+- [ ] Run a **TCC-permissioned build** — the release-identity build **or** the
+      installed app — **not** the isolated `com.jordanbaird.Ice.debug` build
+      (it cannot hold the grants).
+- [ ] **Accessibility** and **Screen Recording** are granted to that build.
+- [ ] Start from a known menu bar with at least two movable third-party items.
+- [ ] Open **Settings ▸ Layout**.
+
+## 1. Move items among sections
+
+- [ ] Drag a third-party item from the **Visible** bar to the **Hidden** bar.
+  - Expected (menu bar): the item disappears from the always-visible strip and
+    only appears when the Hidden section is revealed.
+  - Expected (Layout pane): the item now sits in the Hidden bar; Visible bar loses it.
+- [ ] Reveal the Hidden section (click the hidden control item / Ice icon).
+  - Expected (menu bar): the moved item becomes visible.
+- [ ] Drag the item from **Hidden** to **Always-Hidden**.
+  - Expected (menu bar): item hidden until the always-hidden section is revealed.
+  - Expected (Layout pane): item now in the Always-Hidden bar.
+- [ ] Drag it back to **Visible**.
+  - Expected (menu bar): item returns to the always-visible strip.
+  - Expected (Layout pane): item back in the Visible bar.
+- [ ] Attempt to drag the **Clock** and **Control Center** items.
+  - Expected: they cannot be moved (immovable).
+- [ ] Attempt to move a non-hideable system item (e.g. FaceTime) into Hidden.
+  - Expected: it refuses to hide.
+
+## 2. Backup / Update / Apply profile
+
+- [ ] With a known arrangement, enter a name and click **Save Current Layout**.
+  - Expected (Layout pane): a profile row appears with per-section counts.
+- [ ] Rearrange several items, then click **Apply** on the saved profile.
+  - Expected (menu bar): items snap back to the saved arrangement.
+  - Expected (Layout pane): the three bars match the saved profile.
+- [ ] Rearrange again, then click **Update** on the profile.
+  - Expected (Layout pane): the profile's counts update to the new arrangement.
+- [ ] Disable the Always-Hidden section (Advanced settings), then **Apply** a
+      profile that contains always-hidden items.
+  - Expected: the Always-Hidden section auto-enables, then items place correctly.
+- [ ] Full backup round-trip: export an `.icebackup`, change the layout,
+      restore the file, relaunch.
+  - Expected: the exact layout from the backup returns.
+
+## 3. Other important cases
+
+- [ ] **Item groups:** save a group of hidden items, click **Show**.
+  - Expected (menu bar): grouped items appear briefly, then auto-rehide.
+- [ ] **Spacers:** add a spacer and adjust its width slider.
+  - Expected (menu bar): the gap between items changes live.
+- [ ] Delete the spacer.
+  - Expected (menu bar): the gap disappears.
+- [ ] Save a profile/group while a spacer exists, then inspect the profile.
+  - Expected: the spacer is **not** captured into the profile or group.
+- [ ] **Relaunch persistence:** create a profile, quit Ice, relaunch.
+  - Expected: the profile still lists with correct counts.
+- [ ] **Empty-section edges:** apply a profile with an empty section; save a
+      profile with nothing hidden.
+  - Expected: no crash; bars reflect the empty sections.
+- [ ] **Permission gating:** revoke Screen Recording in System Settings.
+  - Expected (Layout pane): the pane disables with its explanation.
+- [ ] Re-grant Screen Recording and return to the app.
+  - Expected (Layout pane): the pane re-enables.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/testing/layout-pane-manual-tests.md
+git commit -m "docs(testing): add Layout pane manual test plan
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire IceTests suite**
+
+```bash
+xcodebuild test -project Ice.xcodeproj -scheme Ice \
+  -destination 'platform=macOS' -only-testing:IceTests 2>&1 | tail -40
+```
+
+Expected: `** TEST SUCCEEDED **` with all suites (`SmokeTests`, `MenuBarSectionNameTests`, `MenuBarItemTagTests`, `MenuBarLayoutProfileTests`, `SettingsBackupTests`) passing and zero failures.
+
+- [ ] **Step 2: Confirm no production behavior changed**
+
+Run:
+
+```bash
+git diff --stat main -- Ice/
+```
+
+Expected: the only non-test change under `Ice/` is the guard in `Ice/Main/AppDelegate.swift`.
+
+---
+
+## Self-Review (completed during planning)
+
+**Spec coverage:**
+- Automated target + host + guard → Task 1. ✅
+- `MenuBarItemTagTests` (isMovable/canBeHidden/isControlItem/isSpacerItem/isBentoBox/isSystemClone, Namespace.optional, Codable, description) → Task 3. ✅
+- `MenuBarLayoutProfileTests` (profile & group accessors, missing section, Codable) → Task 4. ✅
+- `SettingsBackupTests` (payload round-trip, replace-not-merge, excluded keys, serialize/deserialize, unsupportedVersion, malformed via valid non-dict plist, list/prune, filename shape) → Task 5. ✅
+- `MenuBarSectionNameTests` (order + raw-value stability) → Task 2. ✅
+- Manual test plan (all three scenario groups) → Task 6. ✅
+- Review fixes applied: `PayloadKey` accessed by string key; `.malformed` uses a valid non-dictionary plist; filename asserted by shape (timezone-robust); gem-not-installed handled with `--user-install` + Xcode-UI fallback; spacer-exclusion kept manual. ✅
+
+**Placeholder scan:** none — every code/command step has concrete content.
+
+**Type consistency:** `Defaults.Key` raw values, `MenuBarItemTag` initializer/statics, `MenuBarLayoutProfile`/`MenuBarItemGroup` fields, and `SettingsBackup` signatures all match the source read during planning.

--- a/docs/superpowers/specs/2026-07-06-layout-pane-tests-design.md
+++ b/docs/superpowers/specs/2026-07-06-layout-pane-tests-design.md
@@ -1,0 +1,136 @@
+# Layout Pane — Test Coverage Design
+
+**Date:** 2026-07-06
+**Status:** Approved (pending spec review)
+**Scope:** Add tests that verify the Layout settings pane behaves correctly — both the pure logic (automated) and the real menu-bar behavior (manual).
+
+## Problem
+
+The Layout pane ([`Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift`](../../../Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift)) lets the user move menu-bar items between **Visible / Hidden / Always-Hidden** sections, save/apply/update **layout profiles**, save **item groups**, add **spacers**, and back up / restore all settings. Today there is **no test coverage at all** — no test target exists in `Ice.xcodeproj`.
+
+We want confidence that:
+1. Moving an item among Active / Hidden / Always-Hidden updates the macOS menu bar and the pane correctly.
+2. Backup, Update, and Apply of a profile reflect in both the macOS menu bar and the Layout pane.
+3. Other important flows (groups, spacers, relaunch persistence, permission gating) work.
+
+## Constraint that shapes the whole design
+
+The part the user cares most about — *"the real macOS menu bar updates and shows correctly"* — is driven by real `NSStatusItem`s plus the **scromble EventTap barrier** in [`MenuBarItemManager.swift`](../../../Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift). That path is **not unit-testable**: it requires live menu-bar items and granted Screen Recording + Accessibility (TCC) permissions. The isolated debug build (`com.jordanbaird.Ice.debug`) cannot hold those grants.
+
+Therefore the request splits into two deliverables that live in different worlds:
+- **Automated tests** for the pure "brain" (serialization, classification, accessors) — CI-safe, no permissions.
+- **A written manual test plan** for the on-screen menu-bar behavior — run by a human on a real, permissioned build.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Test forms | Automated unit tests **+** written manual test plan (no in-app harness) |
+| Framework | **Swift Testing** (`@Test` / `#expect`) |
+| Refactoring appetite | **Minimal** — test what is already pure; do **not** restructure `MenuBarItemManager` or extract the profile-apply ordering out of the EventTap path |
+| Production code change | One ~3-line guard in `AppDelegate` (approved) |
+
+## A. Automated test target
+
+### Target setup
+- New **Swift Testing unit-test target `IceTests`** added to `Ice.xcodeproj`.
+- **Hosted by the `Ice` app** (`TEST_HOST` = the built app), because `Ice` is an app target (not a framework) and the types under test are `internal` — `@testable import Ice` requires a host. Extracting a framework/SPM package is explicitly out of scope (violates "minimal refactoring").
+- pbxproj is edited with the Ruby **`xcodeproj`** gem (deterministic) rather than by hand. If the gem is unavailable, fall back to adding the target via Xcode's project file with a documented manual step.
+- A new scheme/test action (or the existing `Ice` scheme's Test action) runs `IceTests`.
+
+### Production seam (the only prod change)
+In [`Ice/Main/AppDelegate.swift`](../../../Ice/Main/AppDelegate.swift) `applicationDidFinishLaunching`, add an early return when running under tests, directly beside the existing `XCODE_RUNNING_FOR_PREVIEWS` preview guard:
+
+```swift
+// Don't perform setup when running unit tests.
+if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+    return
+}
+```
+
+This prevents the full menu-bar app from booting (and touching TCC / status items) while the test bundle loads. It mirrors the preview guard already present, so it is consistent with existing style.
+
+### Coverage (pure logic only)
+
+All of the following are already pure/`internal` and need no refactoring:
+
+**1. `MenuBarItemTagTests`** — the rules that decide whether/how an item can move between sections:
+- `isMovable` — `false` for `clock` and `controlCenter` (and `siri` pre-macOS 26); `true` for an ordinary third-party tag.
+- `canBeHidden` — `false` for non-hideable items (`audioVideoModule`, `faceTime`, `screenCaptureUI`) and the `AudioVideoModule` UUID case; `true` for a normal item.
+- `isControlItem` — `true` for Ice's three control-item tags, `false` otherwise.
+- `isSpacerItem` — `true` for the Ice spacer namespace + autosave prefix; excluded from profiles/groups.
+- `isBentoBox`, `isSystemClone` — classification correctness.
+- `Namespace.optional(_:)` — non-nil → `.string`, nil → `.null`; `isNull` / `isString` / `isUUID` flags.
+- Codable round-trip of `MenuBarItemTag` and `Namespace` (null / string / uuid cases).
+- `description` formatting (`namespace` and `namespace:title`).
+
+**2. `MenuBarLayoutProfileTests`**:
+- `MenuBarLayoutProfile` Codable round-trip (with `SectionSnapshot`s).
+- `itemTags(for:)` returns the right section's tags; missing section → `[]`.
+- `itemCount(for:)` matches tag count; missing section → `0`.
+- `MenuBarItemGroup` Codable round-trip; `itemCount` == `itemTags.count`.
+
+**3. `SettingsBackupTests`** (the save/backup half of scenario 2):
+- `makePayload(from:)` includes only keys with stored values; stamps `schemaVersion` / `appVersion` / `createdDate`.
+- `makePayload → apply` round-trip on a scratch `UserDefaults(suiteName:)` reproduces the stored values.
+- **Apply is replace, not merge:** a key present in `defaults` but absent from the payload is *removed* by `apply`.
+- `excludedKeys` (e.g. `.sections`, `.backupFolderPath`) never appear in a payload.
+- `serialize → deserialize` round-trip is loss-free (binary plist).
+- `deserialize` throws `.unsupportedVersion` for a payload whose `schemaVersion` exceeds the current one; throws `.malformed` for non-dictionary data.
+- `listBackups(in:)` returns only `.icebackup` files, newest-first.
+- `prune(in:keeping:)` deletes only the oldest beyond the limit.
+- `fileName(for:)` / `timestamp(_:)` produce the documented `Ice-Settings-YYYY-MM-DD-HHmmss.icebackup` shape (fixed `Date`, POSIX locale).
+
+**4. `MenuBarSectionNameTests`**:
+- `allCases` == `[.visible, .hidden, .alwaysHidden]` (order matters — profile snapshots iterate it).
+- Raw values are the stable strings `"visible"` / `"hidden"` / `"alwaysHidden"` (profiles saved by older builds must still decode) — assert via Codable.
+
+### Explicitly NOT automated (documented as manual)
+- `MenuBarItemManager.move(...)`, `applyLayoutProfile(...)`, `scrombleEvent(...)` — need real EventTaps + TCC.
+- `MenuBarSection.show()/hide()`, control-item positioning — need real `NSStatusItem`s.
+- LayoutBar drag-and-drop — driven by AppKit drag delegation on the real window.
+- `MenuBarLayoutProfilesSettings.applyProfile`/`temporarilyShowGroup` — call into `itemManager` (real menu bar).
+
+## B. Manual test plan
+
+New document: `docs/testing/layout-pane-manual-tests.md`.
+
+**Preconditions block:** run the release-identity (or otherwise TCC-permissioned) build — **not** the isolated debug build — with Screen Recording + Accessibility granted; start from a known menu-bar arrangement.
+
+**Format:** numbered steps, each with an explicit **Expected (menu bar)** and **Expected (Layout pane)** line, and a checkbox.
+
+**Scenario groups:**
+
+1. **Move among sections**
+   - Drag a third-party item Visible→Hidden; expect it to leave the always-visible strip (revealed only when the Hidden section is shown) and the Hidden layout bar to gain it.
+   - Hidden→Always-Hidden and the reverse path back to Visible.
+   - Toggle the Hidden / Always-Hidden sections via their control items and confirm the moved item shows/hides on the real menu bar.
+   - Negative cases the code enforces: Clock and Control Center cannot be dragged (`isMovable == false`); non-hideable items refuse to move into Hidden.
+
+2. **Backup / Update / Apply profile**
+   - Save current layout as a profile; rearrange items; **Apply** → menu bar and layout bars snap back to the saved arrangement.
+   - **Update** an existing profile → re-snapshots the current layout (counts change in the profile row).
+   - Apply a profile that contains Always-Hidden items while that section is disabled → the section auto-enables first (per `applyProfile`), then items place correctly.
+   - Full settings backup: export `.icebackup`, change the layout, **restore**, relaunch → the exact layout returns (`SettingsBackup.restore`).
+
+3. **Other important cases**
+   - **Item groups:** save a group, "temporarily show" → the grouped hidden items appear briefly, then auto-rehide.
+   - **Spacers:** add a spacer, adjust its width slider → visible gap changes on the menu bar; delete it → gap disappears; confirm spacers are **not** captured into profiles/groups.
+   - **Relaunch persistence:** create a profile, quit, relaunch → the profile still lists with correct counts.
+   - **Empty-section edges:** apply a profile with an empty section; save a profile with nothing hidden.
+   - **Permission gating:** revoke Screen Recording → the Layout pane disables with its explanation; re-grant → it re-enables.
+
+## Success criteria
+
+- `IceTests` target builds and all Swift Testing cases pass locally via `xcodebuild test` (and are runnable in CI without TCC).
+- The four test suites cover every pure member listed in section A.
+- The AppDelegate guard is the only change to production code.
+- `docs/testing/layout-pane-manual-tests.md` exists with runnable, unambiguous steps and expected results for all three scenario groups.
+- No change to `MenuBarItemManager` / EventTap code.
+
+## Out of scope
+
+- In-app verification harness.
+- Extracting profile-apply ordering into a pure, testable unit.
+- Any framework/SPM extraction of the app target.
+- UI/snapshot tests of the SwiftUI panes.

--- a/docs/superpowers/specs/2026-07-06-layout-pane-tests-design.md
+++ b/docs/superpowers/specs/2026-07-06-layout-pane-tests-design.md
@@ -35,7 +35,9 @@ Therefore the request splits into two deliverables that live in different worlds
 ### Target setup
 - New **Swift Testing unit-test target `IceTests`** added to `Ice.xcodeproj`.
 - **Hosted by the `Ice` app** (`TEST_HOST` = the built app), because `Ice` is an app target (not a framework) and the types under test are `internal` — `@testable import Ice` requires a host. Extracting a framework/SPM package is explicitly out of scope (violates "minimal refactoring").
-- pbxproj is edited with the Ruby **`xcodeproj`** gem (deterministic) rather than by hand. If the gem is unavailable, fall back to adding the target via Xcode's project file with a documented manual step.
+- pbxproj is edited with the Ruby **`xcodeproj`** gem (deterministic) rather than by hand. **The gem is NOT installed on this machine** — `ruby -e 'require "xcodeproj"'` currently fails. The implementation checklist must therefore make this an explicit first step with a fallback path:
+  1. Try `gem install xcodeproj` (may need `sudo`) or a `bundler` install, then run a small Ruby script that adds the target, build phase, and `TEST_HOST` / `BUNDLE_LOADER` settings.
+  2. If the gem cannot be installed, fall back to creating the target through Xcode's UI (documented, manual) and commit the resulting `project.pbxproj` diff.
 - A new scheme/test action (or the existing `Ice` scheme's Test action) runs `IceTests`.
 
 ### Production seam (the only prod change)
@@ -48,7 +50,11 @@ if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
 }
 ```
 
-This prevents the full menu-bar app from booting (and touching TCC / status items) while the test bundle loads. It mirrors the preview guard already present, so it is consistent with existing style.
+**Scope of this guard (accurate):** `AppState` is created eagerly as a stored property of `AppDelegate` ([`AppDelegate.swift:12`](../../../Ice/Main/AppDelegate.swift)), and `IceApp` (`@main`) passes it into its scenes ([`IceApp.swift:13`](../../../Ice/Main/IceApp.swift)) — both happen *before* `applicationDidFinishLaunching`. `AppState()` constructs `AppPermissions`, whose `init()` performs a **read-only** Accessibility / Screen-Recording probe ([`AppPermissions.swift:56`](../../../Ice/Permissions/AppPermissions.swift)) and registers a couple of Combine / NotificationCenter observers.
+
+So this guard prevents the heavy `performSetup` work — creating `NSStatusItem` control items, installing the scromble EventTaps, timers, and menu-bar wiring — but it does **not** prevent the eager `AppState` construction or its permission probe.
+
+**Decision (accepted, keeps the seam minimal):** we accept the eager `AppState` construction. The permission probe is read-only and **non-prompting** (`AXIsProcessTrusted` / `CGPreflightScreenCaptureAccess`), so under the test host it simply returns `false` and does no harm; no status items or event taps are created. Widening the seam (e.g. lazy `AppState`, or a test-mode `AppState`) is deliberately *not* done — it would touch app startup and `IceApp` wiring, exceeding "minimal refactoring." This residual is documented rather than engineered away.
 
 ### Coverage (pure logic only)
 
@@ -72,14 +78,16 @@ All of the following are already pure/`internal` and need no refactoring:
 
 **3. `SettingsBackupTests`** (the save/backup half of scenario 2):
 - `makePayload(from:)` includes only keys with stored values; stamps `schemaVersion` / `appVersion` / `createdDate`.
+  - **`PayloadKey` is `private`** — tests must inspect payloads by their raw **string** keys (`"schemaVersion"`, `"appVersion"`, `"createdDate"`, `"defaults"`), not by referencing `PayloadKey`. Where possible, prefer the public accessors `createdDate(of:)` / `appVersion(of:)` instead of reaching into the dictionary.
 - `makePayload → apply` round-trip on a scratch `UserDefaults(suiteName:)` reproduces the stored values.
 - **Apply is replace, not merge:** a key present in `defaults` but absent from the payload is *removed* by `apply`.
 - `excludedKeys` (e.g. `.sections`, `.backupFolderPath`) never appear in a payload.
 - `serialize → deserialize` round-trip is loss-free (binary plist).
-- `deserialize` throws `.unsupportedVersion` for a payload whose `schemaVersion` exceeds the current one; throws `.malformed` for non-dictionary data.
+- `deserialize` throws `.unsupportedVersion` for a payload whose `schemaVersion` exceeds the current one.
+- `deserialize` throws `.malformed` for a **valid non-dictionary plist** (e.g. `serialize` an array or a top-level string via `PropertyListSerialization`), *not* random bytes — random bytes would throw `PropertyListSerialization`'s own parse error before the `as? [String: Any]` guard is reached, so they would not exercise `.malformed`.
 - `listBackups(in:)` returns only `.icebackup` files, newest-first.
 - `prune(in:keeping:)` deletes only the oldest beyond the limit.
-- `fileName(for:)` / `timestamp(_:)` produce the documented `Ice-Settings-YYYY-MM-DD-HHmmss.icebackup` shape (fixed `Date`, POSIX locale).
+- `fileName(for:)` / `timestamp(_:)` — **timezone caveat:** `timestamp(_:)` sets the POSIX locale but **no `timeZone`** ([`SettingsBackup.swift:135`](../../../Ice/Settings/Backup/SettingsBackup.swift)), so a fixed absolute `Date` renders differently across local/CI timezones. Do **not** assert an exact string from an absolute `Date`. Instead: assert the **shape** via regex (`^Ice-Settings-\d{4}-\d{2}-\d{2}-\d{6}\.icebackup$`), and if an exact value is wanted, build the expected string with a `DateFormatter` in the **current** timezone. (Changing production to pin a timezone is out of scope for this test task.)
 
 **4. `MenuBarSectionNameTests`**:
 - `allCases` == `[.visible, .hidden, .alwaysHidden]` (order matters — profile snapshots iterate it).
@@ -90,6 +98,7 @@ All of the following are already pure/`internal` and need no refactoring:
 - `MenuBarSection.show()/hide()`, control-item positioning — need real `NSStatusItem`s.
 - LayoutBar drag-and-drop — driven by AppKit drag delegation on the real window.
 - `MenuBarLayoutProfilesSettings.applyProfile`/`temporarilyShowGroup` — call into `itemManager` (real menu bar).
+- Spacer/control-item exclusion from profiles & groups — the filtering is inside `private` `makeProfile` / `uniqueItemTags` and needs a live `itemCache`; only the `isSpacerItem` / `isControlItem` primitives are unit-tested (suite 1).
 
 ## B. Manual test plan
 
@@ -115,16 +124,17 @@ New document: `docs/testing/layout-pane-manual-tests.md`.
 
 3. **Other important cases**
    - **Item groups:** save a group, "temporarily show" → the grouped hidden items appear briefly, then auto-rehide.
-   - **Spacers:** add a spacer, adjust its width slider → visible gap changes on the menu bar; delete it → gap disappears; confirm spacers are **not** captured into profiles/groups.
+   - **Spacers:** add a spacer, adjust its width slider → visible gap changes on the menu bar; delete it → gap disappears; confirm spacers are **not** captured into profiles/groups. (This end-to-end exclusion stays **manual**: the filtering lives in the `private` methods `makeProfile` / `uniqueItemTags` at [`MenuBarLayoutProfilesSettings.swift:168`](../../../Ice/Settings/Models/MenuBarLayoutProfilesSettings.swift) and [`:230`](../../../Ice/Settings/Models/MenuBarLayoutProfilesSettings.swift), so it can't be reached without either running the app or adding a pure helper — the latter is out of scope. The underlying `MenuBarItemTag.isSpacerItem` classification *is* covered automatically in suite 1, so the manual check only needs to confirm the wiring.)
    - **Relaunch persistence:** create a profile, quit, relaunch → the profile still lists with correct counts.
    - **Empty-section edges:** apply a profile with an empty section; save a profile with nothing hidden.
    - **Permission gating:** revoke Screen Recording → the Layout pane disables with its explanation; re-grant → it re-enables.
 
 ## Success criteria
 
-- `IceTests` target builds and all Swift Testing cases pass locally via `xcodebuild test` (and are runnable in CI without TCC).
+- `IceTests` target builds and all Swift Testing cases pass locally via `xcodebuild test`. Tests are CI-runnable: they rely only on read-only, non-prompting permission probes (no TCC grant required) and touch no `NSStatusItem`s or EventTaps.
 - The four test suites cover every pure member listed in section A.
-- The AppDelegate guard is the only change to production code.
+- The AppDelegate `XCTestConfigurationFilePath` guard is the only change to production code; the accepted eager-`AppState` residual is documented, not "fixed."
+- Backup timestamp assertions are timezone-robust (shape via regex, or expected built in the current timezone) — no exact-string assertion from an absolute `Date`.
 - `docs/testing/layout-pane-manual-tests.md` exists with runnable, unambiguous steps and expected results for all three scenario groups.
 - No change to `MenuBarItemManager` / EventTap code.
 

--- a/docs/testing/layout-pane-manual-tests.md
+++ b/docs/testing/layout-pane-manual-tests.md
@@ -1,0 +1,70 @@
+# Layout Pane — Manual Test Plan
+
+The Layout pane's on-screen behavior (moving items, showing/hiding sections,
+applying profiles) is driven by real `NSStatusItem`s and the scromble EventTap
+barrier, which need **granted TCC permissions** and therefore cannot be
+covered by the automated `IceTests` suite. Run this checklist by hand.
+
+## Preconditions
+
+- [ ] Run a **TCC-permissioned build** — the release-identity build **or** the
+      installed app — **not** the isolated `com.jordanbaird.Ice.debug` build
+      (it cannot hold the grants).
+- [ ] **Accessibility** and **Screen Recording** are granted to that build.
+- [ ] Start from a known menu bar with at least two movable third-party items.
+- [ ] Open **Settings ▸ Layout**.
+
+## 1. Move items among sections
+
+- [ ] Drag a third-party item from the **Visible** bar to the **Hidden** bar.
+  - Expected (menu bar): the item disappears from the always-visible strip and
+    only appears when the Hidden section is revealed.
+  - Expected (Layout pane): the item now sits in the Hidden bar; Visible bar loses it.
+- [ ] Reveal the Hidden section (click the hidden control item / Ice icon).
+  - Expected (menu bar): the moved item becomes visible.
+- [ ] Drag the item from **Hidden** to **Always-Hidden**.
+  - Expected (menu bar): item hidden until the always-hidden section is revealed.
+  - Expected (Layout pane): item now in the Always-Hidden bar.
+- [ ] Drag it back to **Visible**.
+  - Expected (menu bar): item returns to the always-visible strip.
+  - Expected (Layout pane): item back in the Visible bar.
+- [ ] Attempt to drag the **Clock** and **Control Center** items.
+  - Expected: they cannot be moved (immovable).
+- [ ] Attempt to move a non-hideable system item (e.g. FaceTime) into Hidden.
+  - Expected: it refuses to hide.
+
+## 2. Backup / Update / Apply profile
+
+- [ ] With a known arrangement, enter a name and click **Save Current Layout**.
+  - Expected (Layout pane): a profile row appears with per-section counts.
+- [ ] Rearrange several items, then click **Apply** on the saved profile.
+  - Expected (menu bar): items snap back to the saved arrangement.
+  - Expected (Layout pane): the three bars match the saved profile.
+- [ ] Rearrange again, then click **Update** on the profile.
+  - Expected (Layout pane): the profile's counts update to the new arrangement.
+- [ ] Disable the Always-Hidden section (Advanced settings), then **Apply** a
+      profile that contains always-hidden items.
+  - Expected: the Always-Hidden section auto-enables, then items place correctly.
+- [ ] Full backup round-trip: export an `.icebackup`, change the layout,
+      restore the file, relaunch.
+  - Expected: the exact layout from the backup returns.
+
+## 3. Other important cases
+
+- [ ] **Item groups:** save a group of hidden items, click **Show**.
+  - Expected (menu bar): grouped items appear briefly, then auto-rehide.
+- [ ] **Spacers:** add a spacer and adjust its width slider.
+  - Expected (menu bar): the gap between items changes live.
+- [ ] Delete the spacer.
+  - Expected (menu bar): the gap disappears.
+- [ ] Save a profile/group while a spacer exists, then inspect the profile.
+  - Expected: the spacer is **not** captured into the profile or group.
+- [ ] **Relaunch persistence:** create a profile, quit Ice, relaunch.
+  - Expected: the profile still lists with correct counts.
+- [ ] **Empty-section edges:** apply a profile with an empty section; save a
+      profile with nothing hidden.
+  - Expected: no crash; bars reflect the empty sections.
+- [ ] **Permission gating:** revoke Screen Recording in System Settings.
+  - Expected (Layout pane): the pane disables with its explanation.
+- [ ] Re-grant Screen Recording and return to the app.
+  - Expected (Layout pane): the pane re-enables.

--- a/docs/testing/layout-pane-manual-tests.md
+++ b/docs/testing/layout-pane-manual-tests.md
@@ -8,7 +8,7 @@ covered by the automated `IceTests` suite. Run this checklist by hand.
 ## Preconditions
 
 - [ ] Run a **TCC-permissioned build** — the release-identity build **or** the
-      installed app — **not** the isolated `com.jordanbaird.Ice.debug` build
+      installed app — **not** the isolated `com.dragonapp.ice.debug` build
       (it cannot hold the grants).
 - [ ] **Accessibility** and **Screen Recording** are granted to that build.
 - [ ] Start from a known menu bar with at least two movable third-party items.

--- a/scripts/add-icetests-target.rb
+++ b/scripts/add-icetests-target.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+# Idempotently add/refresh the IceTests unit-test target in Ice.xcodeproj.
+# Requires the `xcodeproj` gem. Re-run after adding any IceTests/*.swift file.
+require 'xcodeproj'
+
+PROJECT = 'Ice.xcodeproj'
+project = Xcodeproj::Project.open(PROJECT)
+
+ice = project.targets.find { |t| t.name == 'Ice' }
+abort 'Ice target not found' unless ice
+
+test = project.targets.find { |t| t.name == 'IceTests' }
+if test.nil?
+  test = project.new_target(:unit_test_bundle, 'IceTests', :osx, '26.0')
+  test.build_configurations.each do |config|
+    s = config.build_settings
+    # Explicit PRODUCT_NAME so the test bundle's Swift module name is valid.
+    s['PRODUCT_NAME'] = 'IceTests'
+    s['PRODUCT_BUNDLE_IDENTIFIER'] = 'com.dragonapp.ice.IceTests'
+    s['SWIFT_VERSION'] = '5.0'
+    s['MACOSX_DEPLOYMENT_TARGET'] = '26.0'
+    s['GENERATE_INFOPLIST_FILE'] = 'YES'
+    # The Ice app target's product is "Ice 2.app" (PRODUCT_NAME = "Ice 2"),
+    # so the host binary lives at "Ice 2.app/Contents/MacOS/Ice 2".
+    s['TEST_HOST'] = '$(BUILT_PRODUCTS_DIR)/Ice 2.app/Contents/MacOS/Ice 2'
+    s['BUNDLE_LOADER'] = '$(TEST_HOST)'
+    s['DEVELOPMENT_TEAM'] = 'K2ATHQPJDP'
+    s['CODE_SIGN_STYLE'] = 'Automatic'
+    s['SWIFT_EMIT_LOC_STRINGS'] = 'NO'
+  end
+  test.add_dependency(ice)
+
+  # Register the target in the shared Ice scheme's Test action.
+  scheme_dir = Xcodeproj::XCScheme.shared_data_dir(PROJECT)
+  scheme_path = File.join(scheme_dir, 'Ice.xcscheme')
+  scheme = Xcodeproj::XCScheme.new(scheme_path)
+  ref = Xcodeproj::XCScheme::TestAction::TestableReference.new(test)
+  scheme.test_action.add_testable(ref)
+  scheme.save_as(PROJECT, 'Ice', true)
+end
+
+# Sync every IceTests/*.swift file into the target (add missing ones only).
+group = project.main_group['IceTests'] || project.main_group.new_group('IceTests', 'IceTests')
+already = test.source_build_phase.files_references.map { |r| r.real_path.to_s }
+Dir.glob('IceTests/*.swift').sort.each do |path|
+  abs = File.expand_path(path)
+  next if already.include?(abs)
+  file_ref = group.new_file(File.basename(path))
+  test.add_file_references([file_ref])
+end
+
+project.save
+puts "IceTests synced (#{test.source_build_phase.files.count} source files)"


### PR DESCRIPTION
## Summary
Adds test coverage for the **Layout settings pane**, split into the two worlds the feature actually lives in:

- **New `IceTests` Swift Testing target** (hosted by the `Ice` app) covering the pure, permission-free logic — 26 tests across 5 suites:
  - `MenuBarSectionNameTests` — section order & raw-value stability (old profiles must still decode).
  - `MenuBarItemTagTests` — movable/hideable/control/spacer/bento/clone classification, `Namespace`, Codable, description.
  - `MenuBarLayoutProfileTests` — `MenuBarLayoutProfile`/`MenuBarItemGroup` accessors + Codable round-trip.
  - `SettingsBackupTests` — payload round-trip, replace-not-merge, excluded keys, serialize/deserialize, schema & malformed rejection, list/prune, timezone-robust filename.
- **Manual test plan** (`docs/testing/layout-pane-manual-tests.md`) for the real menu-bar behavior (moving items among sections, apply/update/backup profiles, groups/spacers/permission-gating) — this path needs granted TCC permissions and real `NSStatusItem`s/EventTaps, so it can't be unit-tested.
- **Design spec + implementation plan** under `docs/superpowers/`.

The menu-bar movement path (scromble EventTap barrier) is intentionally left to the manual plan; the spec documents why.

## Production impact
The **only** production-code change is a 3-line guard in `Ice/Main/AppDelegate.swift` that early-returns from `applicationDidFinishLaunching` under XCTest (`XCTestConfigurationFilePath`), mirroring the existing preview guard. Normal launches are unaffected.

## Test Plan
- [x] `xcodebuild test -only-testing:IceTests` → 26/26 pass (5 suites)
- [x] `xcodebuild build -scheme Ice` → BUILD SUCCEEDED (pbxproj/scheme edits don't break the app)
- [x] `git diff main` confirms the sole production Swift change is the AppDelegate guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)