### PR TITLE
fix: order settings panes to the canonical Dragon convention

### DIFF
--- a/.claire/worktrees/wonderful-burnell-bc28c9/Ice2Core/Tests/Ice2CoreTests/RehideStrategyTests.swift
+++ b/.claire/worktrees/wonderful-burnell-bc28c9/Ice2Core/Tests/Ice2CoreTests/RehideStrategyTests.swift
@@ -1,0 +1,1 @@
+placeholder

--- a/Ice/Main/Navigation/NavigationIdentifiers/SettingsNavigationIdentifier.swift
+++ b/Ice/Main/Navigation/NavigationIdentifiers/SettingsNavigationIdentifier.swift
@@ -5,15 +5,18 @@
 
 /// The navigation identifier type for the "Settings" interface.
 enum SettingsNavigationIdentifier: String, NavigationIdentifier {
+    // Sidebar order follows the shared Dragon convention (see dragon-kit README):
+    // General → the app's own panes → Permissions → Sync & Backup → What's New →
+    // Updates → About. (Ice has no Uninstall pane — uninstall lives in the menu-bar menu.)
     case general = "General"
     case appearance = "Appearance"
     case layout = "Layout"
     case hotkeys = "Hotkeys"
-    case updates = "Updates"
     case advanced = "Advanced"
     case permissions = "Permissions"
     case backup = "Backup & Restore"
     case whatsNew = "What's New"
+    case updates = "Updates"
     case about = "About"
 
     var iconResource: IconResource {


### PR DESCRIPTION
## What

Ice's settings sidebar listed **Updates** up at position 5 (right after Hotkeys), which breaks the shared Dragon settings-pane order documented in [dragon-kit's README](https://github.com/teddychan/dragon-kit#settings-pane-order):

```
General → the app's own panes → Permissions → Sync & Backup → What's New → Updates → About
```

This moves `Updates` to sit **after What's New, before About**, so Ice's sidebar matches ClipMenu / KeyKey / Spectacle / the sample app.

| Before | After |
|---|---|
| General, Appearance, Layout, Hotkeys, **Updates**, Advanced, Permissions, Backup, What's New, About | General, Appearance, Layout, Hotkeys, Advanced, Permissions, Backup, What's New, **Updates**, About |

(Ice has no Uninstall *pane* — uninstall lives in the menu-bar dropdown, which already matches the canonical menu.)

## How

Sidebar order is driven by `SettingsNavigationIdentifier.allCases` (`SettingsView` iterates it). Only the enum **case order** changes — the detail-view `switch` stays exhaustive and order-independent, so there's no behavior change.

## Verification

`xcodebuild -scheme Ice -configuration Debug build` → **BUILD SUCCEEDED** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
