### PR TITLE
release: v2.9.4 — canonical settings pane order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.9.4 - 2026-07-08
+
+### Changed
+
+- **Settings pane order.** Moved Updates below What's New so Ice's Settings sidebar follows the shared Dragon app order (General → the app's own panes → Permissions → Backup & Restore → What's New → Updates → About).
+
 ## 2.9.3 - 2026-07-07
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.3;
+				MARKETING_VERSION = 2.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -646,7 +646,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.3;
+				MARKETING_VERSION = 2.9.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -14,11 +14,11 @@ enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
             version: Constants.versionString,
-            date: "2026-07-07",
-            summary: "A fresh app icon — two ice cubes for Ice 2.",
+            date: "2026-07-08",
+            summary: "Settings panes are now in the standard Dragon order.",
             sections: [
                 ChangeSection(kind: .changed, entries: [
-                    "Refreshed the app icon: two ice cubes to represent Ice 2, keeping the familiar blue glass look.",
+                    "Moved Updates below What's New in Settings, so Ice's sidebar matches the other Dragon apps (ClipMenu, KeyKey, Spectacle).",
                 ]),
             ]
         )


### PR DESCRIPTION
Version bump to 2.9.4 shipping the settings-pane reorder (Updates now below What's New, matching the shared Dragon order — merged in #34). Refreshes What's New + CHANGELOG. Merging then tagging `v2.9.4` triggers the release CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)