### PR TITLE
release: v2.9.5 — simpler, cleaner Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.9.5 - 2026-07-08
+
+### Changed
+
+- **Simpler, cleaner Settings.** The General pane is reorganized into clear sections (Show Hidden Items, Rehide, Ice 2 Bar) so the most-used options are front and center. Advanced extras — automatic Ice 2 Bar and menu bar item spacing — now sit behind expandable "Automatic Ice 2 Bar" and "Advanced" rows, out of the way until you need them.
+- **Grouped sidebar.** The Settings sidebar now groups What's New, Updates, and About together, separated from the functional panes above.
+- **Removed a duplicate.** The Advanced pane no longer repeats the Permissions list — Permissions still has its own dedicated pane.
+
 ## 2.9.4 - 2026-07-08
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.4;
+				MARKETING_VERSION = 2.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -646,7 +646,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.4;
+				MARKETING_VERSION = 2.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -39,9 +39,6 @@ struct AdvancedSettingsPane: View {
                 enableSecondaryContextMenu
                 tempShowInterval
             }
-            IceSection("Permissions") {
-                allPermissions
-            }
         }
     }
 
@@ -186,36 +183,5 @@ struct AdvancedSettingsPane: View {
                 }
         }
         .annotation("The amount of time to wait before hiding temporarily shown menu bar items.")
-    }
-
-    @ViewBuilder
-    private var allPermissions: some View {
-        ForEach(appState.permissions.allPermissions) { permission in
-            LabeledContent {
-                if permission.hasPermission {
-                    Label {
-                        Text("Permission Granted")
-                    } icon: {
-                        Image(systemName: "checkmark.circle")
-                            .foregroundStyle(.green)
-                    }
-                } else {
-                    VStack(alignment: .trailing, spacing: 4) {
-                        Button("Grant Permission") {
-                            permission.performRequest()
-                        }
-
-                        if permission.mayRequireRelaunch {
-                            Button("Relaunch Ice 2") {
-                                appState.relaunch()
-                            }
-                        }
-                    }
-                }
-            } label: {
-                Text(permission.title)
-            }
-            .frame(height: 22)
-        }
     }
 }

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -37,19 +37,19 @@ struct GeneralSettingsPane: View {
         IceForm {
             IceSection {
                 appOptions
-            }
-            IceSection {
                 iceIconOptions
             }
-            IceSection {
+            IceSection("Show Hidden Items") {
+                showOptions
+            }
+            IceSection("Rehide") {
+                rehideOptions
+            }
+            IceSection("Ice 2 Bar") {
                 iceBarOptions
             }
             IceSection {
-                showOptions
-                rehideOptions
-            }
-            IceSection {
-                spacingOptions
+                advancedOptions
             }
         }
     }
@@ -173,15 +173,30 @@ struct GeneralSettingsPane: View {
     @ViewBuilder
     private var iceBarOptions: some View {
         useIceBar
-        autoEnableIceBar
-        if settings.autoEnableIceBar {
-            iceBarAutoEnableModePicker
-            if settings.iceBarAutoEnableMode == .screenWidth {
-                iceBarDisplayWidthThreshold
-            }
-        }
         if settings.useIceBar {
             iceBarLocationPicker
+        }
+        DisclosureGroup {
+            autoEnableIceBar
+            if settings.autoEnableIceBar {
+                iceBarAutoEnableModePicker
+                if settings.iceBarAutoEnableMode == .screenWidth {
+                    iceBarDisplayWidthThreshold
+                }
+            }
+        } label: {
+            Text("Automatic Ice 2 Bar")
+        }
+    }
+
+    // MARK: Advanced Options
+
+    @ViewBuilder
+    private var advancedOptions: some View {
+        DisclosureGroup {
+            spacingOptions
+        } label: {
+            Text("Advanced")
         }
     }
 

--- a/Ice/Settings/SettingsView.swift
+++ b/Ice/Settings/SettingsView.swift
@@ -40,11 +40,19 @@ struct SettingsView: View {
         .navigationTitle(navigationTitle)
     }
 
+    /// The "meta" panes, grouped separately at the bottom of the sidebar.
+    private let metaIdentifiers: [SettingsNavigationIdentifier] = [.whatsNew, .updates, .about]
+
+    /// The functional panes, shown at the top of the sidebar.
+    private var primaryIdentifiers: [SettingsNavigationIdentifier] {
+        SettingsNavigationIdentifier.allCases.filter { !metaIdentifiers.contains($0) }
+    }
+
     @ViewBuilder
     private var sidebar: some View {
         List(selection: $navigationState.settingsNavigationIdentifier) {
             Section {
-                ForEach(SettingsNavigationIdentifier.allCases) { identifier in
+                ForEach(primaryIdentifiers) { identifier in
                     sidebarItem(for: identifier)
                 }
             } header: {
@@ -54,6 +62,13 @@ struct SettingsView: View {
                     .foregroundStyle(sidebarTextStyle)
                     .padding(.leading, sidebarPadding)
                     .padding(.bottom, 8)
+            }
+            .collapsible(false)
+
+            Section {
+                ForEach(metaIdentifiers) { identifier in
+                    sidebarItem(for: identifier)
+                }
             }
             .collapsible(false)
         }

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -15,10 +15,13 @@ enum WhatsNewConfig {
         WhatsNewContent(
             version: Constants.versionString,
             date: "2026-07-08",
-            summary: "Settings panes are now in the standard Dragon order.",
+            summary: "A simpler, cleaner Settings window.",
             sections: [
                 ChangeSection(kind: .changed, entries: [
-                    "Moved Updates below What's New in Settings, so Ice's sidebar matches the other Dragon apps (ClipMenu, KeyKey, Spectacle).",
+                    "General settings are decluttered into clear sections — Show Hidden Items, Rehide, and Ice 2 Bar — so the options you use most are front and center.",
+                    "Advanced extras now tuck away behind expandable rows: automatic Ice 2 Bar and menu bar item spacing stay out of the way until you need them.",
+                    "The Settings sidebar groups What's New, Updates, and About together, separated from the functional panes above.",
+                    "Removed a duplicate Permissions list from the Advanced pane — Permissions still has its own dedicated pane.",
                 ]),
             ]
         )


### PR DESCRIPTION
## Summary

Optimizes the Settings UI so a normal user gets the most direct, simple interface — reorganizing without removing any features (progressive disclosure, not deletion).

- **General pane** split into clear titled sections: **Show Hidden Items**, **Rehide**, **Ice 2 Bar**. The Beta *automatic Ice 2 Bar* cluster and the *menu bar item spacing* control now sit behind expandable **"Automatic Ice 2 Bar"** and **"Advanced"** disclosure rows — out of the way until needed.
- **Sidebar** groups the meta panes (**What's New / Updates / About**) into a separate section, divided from the functional panes above.
- **Advanced pane** drops the duplicate **Permissions** list (Permissions keeps its own dedicated pane).

Bumps `MARKETING_VERSION` to **2.9.5** and updates the What's New pane + CHANGELOG. Build number is stamped from the git commit count by release CI.

## Testing

- `xcodebuild` Debug **and** Release builds succeed (`CODE_SIGNING_ALLOWED=NO`).
- Verified hands-on in an isolated `Ice 2 Debug` build: new layout confirmed better by the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)