### PR TITLE
release: v2.9.6 — consolidate reveal toggles, move icon chooser to Appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.9.6 - 2026-07-08
+
+### Changed
+
+- **Simpler show options.** The two separate hover settings in General ("Show on hover over empty menu bar" and "Show on hover over Ice 2 icon") are now a single **Show on hover** that reacts to both, with one shared delay. Your existing hover preference is preserved.
+- **Icon chooser moved to Appearance.** The menu bar icon chooser — icon, custom image, and dynamic appearance — now lives in the **Appearance** pane alongside the other menu bar look-and-feel options. General keeps the simple **Show Ice 2 icon** switch.
+
 ## 2.9.5 - 2026-07-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.9.5 - 2026-07-08
+
+### Changed
+
+- **Simpler, cleaner Settings.** The General pane is reorganized into clear sections (Show Hidden Items, Rehide, Ice 2 Bar) so the most-used options are front and center. Advanced extras — automatic Ice 2 Bar and menu bar item spacing — now sit behind expandable "Automatic Ice 2 Bar" and "Advanced" rows, out of the way until you need them.
+- **Grouped sidebar.** The Settings sidebar now groups What's New, Updates, and About together, separated from the functional panes above.
+- **Removed a duplicate.** The Advanced pane no longer repeats the Permissions list — Permissions still has its own dedicated pane.
+
 ## 2.9.4 - 2026-07-08
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.5;
+				MARKETING_VERSION = 2.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -646,7 +646,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.5;
+				MARKETING_VERSION = 2.9.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.4;
+				MARKETING_VERSION = 2.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -646,7 +646,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.4;
+				MARKETING_VERSION = 2.9.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
+++ b/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
@@ -54,6 +54,9 @@ struct MenuBarAppearanceEditor: View {
                     systemImage: "lightbulb"
                 )
             }
+            if case .settings = location, appState.settings.general.showIceIcon {
+                MenuBarIconSettings(settings: appState.settings.general)
+            }
             IceSection {
                 isDynamicToggle
                 removesMenuBarBackgroundToggle
@@ -136,6 +139,112 @@ struct MenuBarAppearanceEditor: View {
                 "Use inset shape on screens with notch",
                 isOn: $appearanceManager.configuration.isInset
             )
+        }
+    }
+}
+
+/// The "Menu Bar Icon" chooser, shown in the Appearance settings pane when the Ice 2 icon is visible.
+private struct MenuBarIconSettings: View {
+    @EnvironmentObject var appState: AppState
+    @ObservedObject var settings: GeneralSettings
+    @State private var isImportingCustomIceIcon = false
+    @State private var isPresentingError = false
+    @State private var presentedError: LocalizedErrorWrapper?
+
+    var body: some View {
+        IceSection("Menu Bar Icon") {
+            iceIconPicker
+        }
+    }
+
+    @ViewBuilder
+    private var iceIconPicker: some View {
+        let labelKey = LocalizedStringKey("Ice 2 icon")
+
+        IceMenu(labelKey) {
+            Picker(labelKey, selection: $settings.iceIcon) {
+                ForEach(ControlItemImageSet.userSelectableIceIcons) { imageSet in
+                    Button {
+                        settings.iceIcon = imageSet
+                    } label: {
+                        iceIconMenuItem(for: imageSet)
+                    }
+                    .tag(imageSet)
+                }
+                if let lastCustomIceIcon = settings.lastCustomIceIcon {
+                    Button {
+                        settings.iceIcon = lastCustomIceIcon
+                    } label: {
+                        iceIconMenuItem(for: lastCustomIceIcon)
+                    }
+                    .tag(lastCustomIceIcon)
+                }
+            }
+            .pickerStyle(.inline)
+            .labelsHidden()
+
+            Divider()
+
+            Button("Choose image…") {
+                isImportingCustomIceIcon = true
+            }
+        } title: {
+            iceIconMenuItem(for: settings.iceIcon)
+        }
+        .annotation("Choose a custom icon to show in the menu bar.")
+        .fileImporter(
+            isPresented: $isImportingCustomIceIcon,
+            allowedContentTypes: [.image]
+        ) { result in
+            do {
+                let url = try result.get()
+                if url.startAccessingSecurityScopedResource() {
+                    defer { url.stopAccessingSecurityScopedResource() }
+                    let data = try Data(contentsOf: url)
+                    settings.iceIcon = ControlItemImageSet(name: .custom, image: .data(data))
+                }
+            } catch {
+                presentedError = LocalizedErrorWrapper(error)
+                isPresentingError = true
+            }
+        }
+        .alert(isPresented: $isPresentingError, error: presentedError) {
+            Button("OK") {
+                presentedError = nil
+                isPresentingError = false
+            }
+        }
+
+        if case .custom = settings.iceIcon.name {
+            Toggle("Custom icon uses dynamic appearance", isOn: $settings.customIceIconIsTemplate)
+                .annotation {
+                    Text(
+                        """
+                        Display the icon as a monochrome image that dynamically adjusts to match \
+                        the menu bar's appearance. This setting removes all color from the icon, \
+                        but ensures consistent rendering with both light and dark backgrounds.
+                        """
+                    )
+                    .padding(.trailing, 50)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func iceIconMenuItem(for imageSet: ControlItemImageSet) -> some View {
+        Label {
+            Text(imageSet.name.rawValue)
+        } icon: {
+            if let nsImage = imageSet.hidden.nsImage(for: appState) {
+                switch imageSet.name {
+                case .custom:
+                    Image(size: CGSize(width: 18, height: 18)) { context in
+                        context.draw(Image(nsImage: nsImage), in: context.clipBoundingRect)
+                    }
+                default:
+                    Image(nsImage: nsImage)
+                }
+            }
         }
     }
 }

--- a/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -39,9 +39,6 @@ struct AdvancedSettingsPane: View {
                 enableSecondaryContextMenu
                 tempShowInterval
             }
-            IceSection("Permissions") {
-                allPermissions
-            }
         }
     }
 
@@ -186,36 +183,5 @@ struct AdvancedSettingsPane: View {
                 }
         }
         .annotation("The amount of time to wait before hiding temporarily shown menu bar items.")
-    }
-
-    @ViewBuilder
-    private var allPermissions: some View {
-        ForEach(appState.permissions.allPermissions) { permission in
-            LabeledContent {
-                if permission.hasPermission {
-                    Label {
-                        Text("Permission Granted")
-                    } icon: {
-                        Image(systemName: "checkmark.circle")
-                            .foregroundStyle(.green)
-                    }
-                } else {
-                    VStack(alignment: .trailing, spacing: 4) {
-                        Button("Grant Permission") {
-                            permission.performRequest()
-                        }
-
-                        if permission.mayRequireRelaunch {
-                            Button("Relaunch Ice 2") {
-                                appState.relaunch()
-                            }
-                        }
-                    }
-                }
-            } label: {
-                Text(permission.title)
-            }
-            .frame(height: 22)
-        }
     }
 }

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -37,19 +37,19 @@ struct GeneralSettingsPane: View {
         IceForm {
             IceSection {
                 appOptions
-            }
-            IceSection {
                 iceIconOptions
             }
-            IceSection {
+            IceSection("Show Hidden Items") {
+                showOptions
+            }
+            IceSection("Rehide") {
+                rehideOptions
+            }
+            IceSection("Ice 2 Bar") {
                 iceBarOptions
             }
             IceSection {
-                showOptions
-                rehideOptions
-            }
-            IceSection {
-                spacingOptions
+                advancedOptions
             }
         }
     }
@@ -173,15 +173,30 @@ struct GeneralSettingsPane: View {
     @ViewBuilder
     private var iceBarOptions: some View {
         useIceBar
-        autoEnableIceBar
-        if settings.autoEnableIceBar {
-            iceBarAutoEnableModePicker
-            if settings.iceBarAutoEnableMode == .screenWidth {
-                iceBarDisplayWidthThreshold
-            }
-        }
         if settings.useIceBar {
             iceBarLocationPicker
+        }
+        DisclosureGroup {
+            autoEnableIceBar
+            if settings.autoEnableIceBar {
+                iceBarAutoEnableModePicker
+                if settings.iceBarAutoEnableMode == .screenWidth {
+                    iceBarDisplayWidthThreshold
+                }
+            }
+        } label: {
+            Text("Automatic Ice 2 Bar")
+        }
+    }
+
+    // MARK: Advanced Options
+
+    @ViewBuilder
+    private var advancedOptions: some View {
+        DisclosureGroup {
+            spacingOptions
+        } label: {
+            Text("Advanced")
         }
     }
 

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -9,11 +9,30 @@ import SwiftUI
 struct GeneralSettingsPane: View {
     @EnvironmentObject var appState: AppState
     @ObservedObject var settings: GeneralSettings
-    @State private var isImportingCustomIceIcon = false
-    @State private var isPresentingError = false
-    @State private var presentedError: LocalizedErrorWrapper?
     @State private var isApplyingItemSpacingOffset = false
     @State private var tempItemSpacingOffset: CGFloat = 0
+
+    /// A single toggle backing both hover-to-show triggers (empty menu bar and Ice 2 icon).
+    private var showOnHover: Binding<Bool> {
+        Binding(
+            get: { settings.showOnHoverEmptyMenuBar || settings.showOnHoverOverIceIcon },
+            set: { newValue in
+                settings.showOnHoverEmptyMenuBar = newValue
+                settings.showOnHoverOverIceIcon = newValue
+            }
+        )
+    }
+
+    /// A single delay shared by both hover-to-show triggers.
+    private var hoverDelay: Binding<TimeInterval> {
+        Binding(
+            get: { settings.showOnHoverEmptyMenuBarDelay },
+            set: { newValue in
+                settings.showOnHoverEmptyMenuBarDelay = newValue
+                settings.showOnHoverOverIceIconDelay = newValue
+            }
+        )
+    }
 
     private var itemSpacingOffsetKey: LocalizedStringKey {
         switch tempItemSpacingOffset {
@@ -65,107 +84,8 @@ struct GeneralSettingsPane: View {
 
     @ViewBuilder
     private var iceIconOptions: some View {
-        showIceIcon
-        if settings.showIceIcon {
-            iceIconPicker
-        }
-    }
-
-    @ViewBuilder
-    private var showIceIcon: some View {
         Toggle("Show Ice 2 icon", isOn: $settings.showIceIcon)
-            .annotation("Click to show hidden menu bar items. Right-click to access Ice 2's settings.")
-    }
-
-    @ViewBuilder
-    private var iceIconPicker: some View {
-        let labelKey = LocalizedStringKey("Ice 2 icon")
-
-        IceMenu(labelKey) {
-            Picker(labelKey, selection: $settings.iceIcon) {
-                ForEach(ControlItemImageSet.userSelectableIceIcons) { imageSet in
-                    Button {
-                        settings.iceIcon = imageSet
-                    } label: {
-                        iceIconMenuItem(for: imageSet)
-                    }
-                    .tag(imageSet)
-                }
-                if let lastCustomIceIcon = settings.lastCustomIceIcon {
-                    Button {
-                        settings.iceIcon = lastCustomIceIcon
-                    } label: {
-                        iceIconMenuItem(for: lastCustomIceIcon)
-                    }
-                    .tag(lastCustomIceIcon)
-                }
-            }
-            .pickerStyle(.inline)
-            .labelsHidden()
-
-            Divider()
-
-            Button("Choose image…") {
-                isImportingCustomIceIcon = true
-            }
-        } title: {
-            iceIconMenuItem(for: settings.iceIcon)
-        }
-        .annotation("Choose a custom icon to show in the menu bar.")
-        .fileImporter(
-            isPresented: $isImportingCustomIceIcon,
-            allowedContentTypes: [.image]
-        ) { result in
-            do {
-                let url = try result.get()
-                if url.startAccessingSecurityScopedResource() {
-                    defer { url.stopAccessingSecurityScopedResource() }
-                    let data = try Data(contentsOf: url)
-                    settings.iceIcon = ControlItemImageSet(name: .custom, image: .data(data))
-                }
-            } catch {
-                presentedError = LocalizedErrorWrapper(error)
-                isPresentingError = true
-            }
-        }
-        .alert(isPresented: $isPresentingError, error: presentedError) {
-            Button("OK") {
-                presentedError = nil
-                isPresentingError = false
-            }
-        }
-
-        if case .custom = settings.iceIcon.name {
-            Toggle("Custom icon uses dynamic appearance", isOn: $settings.customIceIconIsTemplate)
-                .annotation {
-                    Text(
-                        """
-                        Display the icon as a monochrome image that dynamically adjusts to match \
-                        the menu bar's appearance. This setting removes all color from the icon, \
-                        but ensures consistent rendering with both light and dark backgrounds.
-                        """
-                    )
-                    .padding(.trailing, 50)
-                }
-        }
-    }
-
-    @ViewBuilder
-    private func iceIconMenuItem(for imageSet: ControlItemImageSet) -> some View {
-        Label {
-            Text(imageSet.name.rawValue)
-        } icon: {
-            if let nsImage = imageSet.hidden.nsImage(for: appState) {
-                switch imageSet.name {
-                case .custom:
-                    Image(size: CGSize(width: 18, height: 18)) { context in
-                        context.draw(Image(nsImage: nsImage), in: context.clipBoundingRect)
-                    }
-                default:
-                    Image(nsImage: nsImage)
-                }
-            }
-        }
+            .annotation("Click to show hidden menu bar items. Right-click to access Ice 2's settings. Customize the icon in the Appearance settings.")
     }
 
     // MARK: Ice Bar Options
@@ -286,32 +206,17 @@ struct GeneralSettingsPane: View {
         Toggle("Show on click", isOn: $settings.showOnClick)
             .annotation("Click inside an empty area of the menu bar to show hidden menu bar items.")
 
-        Toggle("Show on hover over empty menu bar", isOn: $settings.showOnHoverEmptyMenuBar)
-            .annotation("Hover over an empty area of the menu bar to show hidden menu bar items.")
-        if settings.showOnHoverEmptyMenuBar {
+        Toggle("Show on hover", isOn: showOnHover)
+            .annotation("Hover over an empty area of the menu bar or the Ice 2 icon to show hidden menu bar items.")
+        if showOnHover.wrappedValue {
             IceSlider(
-                formattedToSeconds(settings.showOnHoverEmptyMenuBarDelay),
-                value: $settings.showOnHoverEmptyMenuBarDelay,
+                formattedToSeconds(hoverDelay.wrappedValue),
+                value: hoverDelay,
                 in: 0...1,
                 step: 0.1
             )
             .annotation("The amount of time to wait before showing hidden items.")
         }
-
-        VStack(alignment: .leading, spacing: 6) {
-            Toggle("Show on hover over Ice 2 icon", isOn: $settings.showOnHoverOverIceIcon)
-                .annotation("Hover over the Ice 2 icon to show hidden menu bar items. Requires the Ice 2 icon to be shown.")
-            if settings.showOnHoverOverIceIcon {
-                IceSlider(
-                    formattedToSeconds(settings.showOnHoverOverIceIconDelay),
-                    value: $settings.showOnHoverOverIceIconDelay,
-                    in: 0...1,
-                    step: 0.1
-                )
-                .annotation("The amount of time to wait before showing hidden items.")
-            }
-        }
-        .disabled(!settings.showIceIcon)
 
         Toggle("Show on scroll", isOn: $settings.showOnScroll)
             .annotation("Scroll or swipe in the menu bar to show hidden menu bar items.")

--- a/Ice/Settings/SettingsView.swift
+++ b/Ice/Settings/SettingsView.swift
@@ -40,11 +40,19 @@ struct SettingsView: View {
         .navigationTitle(navigationTitle)
     }
 
+    /// The "meta" panes, grouped separately at the bottom of the sidebar.
+    private let metaIdentifiers: [SettingsNavigationIdentifier] = [.whatsNew, .updates, .about]
+
+    /// The functional panes, shown at the top of the sidebar.
+    private var primaryIdentifiers: [SettingsNavigationIdentifier] {
+        SettingsNavigationIdentifier.allCases.filter { !metaIdentifiers.contains($0) }
+    }
+
     @ViewBuilder
     private var sidebar: some View {
         List(selection: $navigationState.settingsNavigationIdentifier) {
             Section {
-                ForEach(SettingsNavigationIdentifier.allCases) { identifier in
+                ForEach(primaryIdentifiers) { identifier in
                     sidebarItem(for: identifier)
                 }
             } header: {
@@ -54,6 +62,13 @@ struct SettingsView: View {
                     .foregroundStyle(sidebarTextStyle)
                     .padding(.leading, sidebarPadding)
                     .padding(.bottom, 8)
+            }
+            .collapsible(false)
+
+            Section {
+                ForEach(metaIdentifiers) { identifier in
+                    sidebarItem(for: identifier)
+                }
             }
             .collapsible(false)
         }

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -15,13 +15,11 @@ enum WhatsNewConfig {
         WhatsNewContent(
             version: Constants.versionString,
             date: "2026-07-08",
-            summary: "A simpler, cleaner Settings window.",
+            summary: "Fewer, clearer options in General.",
             sections: [
                 ChangeSection(kind: .changed, entries: [
-                    "General settings are decluttered into clear sections — Show Hidden Items, Rehide, and Ice 2 Bar — so the options you use most are front and center.",
-                    "Advanced extras now tuck away behind expandable rows: automatic Ice 2 Bar and menu bar item spacing stay out of the way until you need them.",
-                    "The Settings sidebar groups What's New, Updates, and About together, separated from the functional panes above.",
-                    "Removed a duplicate Permissions list from the Advanced pane — Permissions still has its own dedicated pane.",
+                    "Simpler show options: the two separate hover settings are now a single \"Show on hover\" that reacts to both the menu bar and the Ice 2 icon, with one delay.",
+                    "The menu bar icon chooser (icon, custom image, dynamic appearance) moved to the Appearance settings, alongside the other look-and-feel options. General keeps the simple \"Show Ice 2 icon\" switch.",
                 ]),
             ]
         )

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -15,10 +15,13 @@ enum WhatsNewConfig {
         WhatsNewContent(
             version: Constants.versionString,
             date: "2026-07-08",
-            summary: "Settings panes are now in the standard Dragon order.",
+            summary: "A simpler, cleaner Settings window.",
             sections: [
                 ChangeSection(kind: .changed, entries: [
-                    "Moved Updates below What's New in Settings, so Ice's sidebar matches the other Dragon apps (ClipMenu, KeyKey, Spectacle).",
+                    "General settings are decluttered into clear sections — Show Hidden Items, Rehide, and Ice 2 Bar — so the options you use most are front and center.",
+                    "Advanced extras now tuck away behind expandable rows: automatic Ice 2 Bar and menu bar item spacing stay out of the way until you need them.",
+                    "The Settings sidebar groups What's New, Updates, and About together, separated from the functional panes above.",
+                    "Removed a duplicate Permissions list from the Advanced pane — Permissions still has its own dedicated pane.",
                 ]),
             ]
         )


### PR DESCRIPTION
## Summary

Two optional follow-up simplifications after the v2.9.5 Settings reorg (both mocked up and approved by the owner):

**A — Consolidate reveal toggles.** The four "show hidden items" toggles become three: the two hover options ("empty menu bar" and "Ice 2 icon") merge into a single **Show on hover** with one shared delay. Implemented as a UI façade over the existing `GeneralSettings` hover flags — **no data migration**, no `HIDEventManager` changes, and hover no longer requires the Ice 2 icon to be shown.

**B — Move icon chooser to Appearance.** The menu bar icon chooser (icon dropdown, custom image, dynamic appearance) moves out of General into a settings-only **Menu Bar Icon** section in the Appearance pane. General keeps the **Show Ice 2 icon** switch. The popout appearance panel (`location: .panel`) is unaffected.

Bumps `MARKETING_VERSION` to **2.9.6** and updates the What's New pane + CHANGELOG.

## Testing

- `xcodebuild` Debug **and** Release builds succeed (`CODE_SIGNING_ALLOWED=NO`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)