### PR TITLE
fix: "Update" on a layout profile now saves the current arrangement (v2.9.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.9.7 - 2026-07-09
+
+### Fixed
+
+- **"Update" on a layout profile now saves your latest arrangement.** After dragging menu bar items between sections, clicking **Update** on a saved profile could record the previous layout instead of the current one, so the profile looked unchanged (deleting and re-saving worked around it). Ice 2 now refreshes the menu bar layout before capturing, so both **Update** and **Save Current Layout** always store what's actually in your menu bar.
+
 ## 2.9.6 - 2026-07-08
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.6;
+				MARKETING_VERSION = 2.9.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -646,7 +646,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.6;
+				MARKETING_VERSION = 2.9.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -412,6 +412,44 @@ extension MenuBarItemManager {
             await cacheItemsRegardless(itemWindowIDs)
         }
     }
+
+    /// Refreshes the item cache so it reflects the user's current menu bar
+    /// layout, then returns.
+    ///
+    /// Rearranging items in the layout bar posts move events but does not
+    /// itself update the cache; the cache is otherwise only refreshed by
+    /// debounced system events, and `cacheItemsRegardless` intentionally
+    /// skips for one second after a move. This method waits out that window
+    /// (so the forced cache below is not skipped and reads settled item
+    /// positions) and then forces a cache. Callers use it before capturing a
+    /// layout profile so the snapshot reflects the latest arrangement rather
+    /// than a stale cache.
+    func refreshCacheForLayoutCapture() async {
+        let sinceLastMove = lastMoveOperationTimestamp?.duration(to: .now)
+        let delay = Self.layoutCaptureRefreshDelay(sinceLastMove: sinceLastMove)
+        if delay > .zero {
+            try? await Task.sleep(for: delay)
+        }
+        await cacheItemsRegardless()
+    }
+
+    /// Returns how long to wait before force-caching for a layout capture,
+    /// given how long ago the most recent move operation occurred (`nil` if
+    /// there has been no move).
+    ///
+    /// The wait ensures that, once elapsed, more than one second has passed
+    /// since the last move, so the subsequent cache is not skipped by the
+    /// post-move guard in `cacheItemsRegardless`. Returns zero when the last
+    /// move is already old enough or never happened.
+    nonisolated static func layoutCaptureRefreshDelay(sinceLastMove: Duration?) -> Duration {
+        guard let sinceLastMove else {
+            return .zero
+        }
+        // Slightly longer than the one-second post-move skip window so the
+        // guard is guaranteed to have elapsed, not merely reached.
+        let window = Duration.seconds(1) + .milliseconds(50)
+        return max(window - sinceLastMove, .zero)
+    }
 }
 
 // MARK: - Event Helpers

--- a/Ice/Settings/Models/MenuBarLayoutProfilesSettings.swift
+++ b/Ice/Settings/Models/MenuBarLayoutProfilesSettings.swift
@@ -26,6 +26,26 @@ struct MenuBarLayoutProfile: Codable, Hashable, Identifiable {
     func itemCount(for section: MenuBarSection.Name) -> Int {
         itemTags(for: section).count
     }
+
+    /// Builds the per-section snapshots for a layout profile from the current
+    /// menu bar layout, expressed as item tags keyed by section.
+    ///
+    /// There is exactly one snapshot per section, in canonical section order,
+    /// even for sections with no items. Ice's own spacer items are excluded:
+    /// they are positioned by AppKit via their status-item autosave names, not
+    /// by the layout system, so capturing them would have profile-apply
+    /// synthetically move them (and surface phantom "Spacer" entries to the
+    /// user).
+    static func makeSectionSnapshots(
+        from tagsBySection: [MenuBarSection.Name: [MenuBarItemTag]]
+    ) -> [SectionSnapshot] {
+        MenuBarSection.Name.allCases.map { section in
+            SectionSnapshot(
+                section: section,
+                itemTags: (tagsBySection[section] ?? []).filter { !$0.isSpacerItem }
+            )
+        }
+    }
 }
 
 struct MenuBarItemGroup: Codable, Hashable, Identifiable {
@@ -52,8 +72,35 @@ final class MenuBarLayoutProfilesSettings: ObservableObject {
 
     private(set) weak var appState: AppState?
 
+    /// Returns the user's current menu bar layout as item tags per section,
+    /// refreshing the underlying item cache first so the result reflects the
+    /// latest arrangement rather than a stale cache.
+    ///
+    /// This is the single source of truth for capturing a layout profile, and
+    /// is injectable so the capture, create, and update logic can be
+    /// unit-tested without a live menu bar. The default implementation is
+    /// installed in `performSetup(with:)`.
+    var captureCurrentLayout: () async -> [MenuBarSection.Name: [MenuBarItemTag]] = { [:] }
+
     func performSetup(with appState: AppState) {
         self.appState = appState
+        captureCurrentLayout = { [weak appState] in
+            guard let appState else {
+                return [:]
+            }
+            // Refresh first: rearranging items in the layout bar does not
+            // update the item cache on its own, so without this the capture
+            // would read the pre-rearrangement layout (the "Update doesn't
+            // save my changes" bug).
+            await appState.itemManager.refreshCacheForLayoutCapture()
+            var tagsBySection = [MenuBarSection.Name: [MenuBarItemTag]]()
+            for section in MenuBarSection.Name.allCases {
+                tagsBySection[section] = appState.itemManager.itemCache
+                    .managedItems(for: section)
+                    .map(\.tag)
+            }
+            return tagsBySection
+        }
         loadInitialState()
         configureCancellables()
     }
@@ -108,25 +155,22 @@ final class MenuBarLayoutProfilesSettings: ObservableObject {
             .store(in: &cancellables)
     }
 
-    func createProfile(named name: String) {
-        guard let profile = makeProfile(name: name) else {
-            return
-        }
-        profiles.append(profile)
+    func createProfile(named name: String) async {
+        let tagsBySection = await captureCurrentLayout()
+        profiles.append(makeProfile(name: name, tagsBySection: tagsBySection))
     }
 
-    func updateProfile(_ profile: MenuBarLayoutProfile) {
-        guard
-            let index = profiles.firstIndex(where: { $0.id == profile.id }),
-            let updatedProfile = makeProfile(
-                id: profile.id,
-                name: profile.name,
-                createdAt: profile.createdAt
-            )
-        else {
+    func updateProfile(_ profile: MenuBarLayoutProfile) async {
+        let tagsBySection = await captureCurrentLayout()
+        guard let index = profiles.firstIndex(where: { $0.id == profile.id }) else {
             return
         }
-        profiles[index] = updatedProfile
+        profiles[index] = makeProfile(
+            id: profile.id,
+            name: profile.name,
+            createdAt: profile.createdAt,
+            tagsBySection: tagsBySection
+        )
     }
 
     func deleteProfile(_ profile: MenuBarLayoutProfile) {
@@ -168,30 +212,16 @@ final class MenuBarLayoutProfilesSettings: ObservableObject {
     private func makeProfile(
         id: UUID = UUID(),
         name: String,
-        createdAt: Date = Date()
-    ) -> MenuBarLayoutProfile? {
-        guard let appState else {
-            return nil
-        }
-        let now = Date()
-        let sections = MenuBarSection.Name.allCases.map { section in
-            MenuBarLayoutProfile.SectionSnapshot(
-                section: section,
-                // Exclude Ice's own spacer items: they are positioned by AppKit
-                // via their status-item autosave names, not by the layout system,
-                // so capturing them would have profile-apply synthetically move
-                // them (and surface phantom "Spacer" entries to the user).
-                itemTags: appState.itemManager.itemCache.managedItems(for: section)
-                    .filter { !$0.isSpacerItem }
-                    .map(\.tag)
-            )
-        }
-        return MenuBarLayoutProfile(
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        tagsBySection: [MenuBarSection.Name: [MenuBarItemTag]]
+    ) -> MenuBarLayoutProfile {
+        MenuBarLayoutProfile(
             id: id,
             name: normalizedProfileName(name),
             createdAt: createdAt,
-            updatedAt: now,
-            sections: sections
+            updatedAt: updatedAt,
+            sections: MenuBarLayoutProfile.makeSectionSnapshots(from: tagsBySection)
         )
     }
 

--- a/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -13,6 +13,7 @@ struct MenuBarLayoutSettingsPane: View {
     @State private var newProfileName = ""
     @State private var newGroupName = ""
     @State private var applyingProfileID: MenuBarLayoutProfile.ID?
+    @State private var isCapturingLayout = false
     @State private var showingGroupID: MenuBarItemGroup.ID?
     @State private var isPresentingError = false
     @State private var presentedError: LocalizedErrorWrapper?
@@ -104,10 +105,19 @@ struct MenuBarLayoutSettingsPane: View {
             TextField("Profile name", text: $newProfileName)
 
             Button("Save Current Layout") {
-                profileSettings.createProfile(named: newProfileName)
-                newProfileName = ""
+                saveCurrentLayout()
             }
-            .disabled(!hasItems)
+            .disabled(!hasItems || isCapturingLayout)
+        }
+    }
+
+    private func saveCurrentLayout() {
+        let name = newProfileName
+        newProfileName = ""
+        isCapturingLayout = true
+        Task {
+            defer { isCapturingLayout = false }
+            await profileSettings.createProfile(named: name)
         }
     }
 
@@ -132,17 +142,25 @@ struct MenuBarLayoutSettingsPane: View {
             Button("Apply") {
                 applyProfile(profile)
             }
-            .disabled(applyingProfileID != nil)
+            .disabled(applyingProfileID != nil || isCapturingLayout)
 
             Button("Update") {
-                profileSettings.updateProfile(profile)
+                updateProfile(profile)
             }
-            .disabled(!hasItems || applyingProfileID != nil)
+            .disabled(!hasItems || applyingProfileID != nil || isCapturingLayout)
 
             Button("Delete", role: .destructive) {
                 profileSettings.deleteProfile(profile)
             }
-            .disabled(applyingProfileID != nil)
+            .disabled(applyingProfileID != nil || isCapturingLayout)
+        }
+    }
+
+    private func updateProfile(_ profile: MenuBarLayoutProfile) {
+        isCapturingLayout = true
+        Task {
+            defer { isCapturingLayout = false }
+            await profileSettings.updateProfile(profile)
         }
     }
 

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -14,12 +14,11 @@ enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
             version: Constants.versionString,
-            date: "2026-07-08",
-            summary: "Fewer, clearer options in General.",
+            date: "2026-07-09",
+            summary: "Layout profile fix.",
             sections: [
-                ChangeSection(kind: .changed, entries: [
-                    "Simpler show options: the two separate hover settings are now a single \"Show on hover\" that reacts to both the menu bar and the Ice 2 icon, with one delay.",
-                    "The menu bar icon chooser (icon, custom image, dynamic appearance) moved to the Appearance settings, alongside the other look-and-feel options. General keeps the simple \"Show Ice 2 icon\" switch.",
+                ChangeSection(kind: .fixed, entries: [
+                    "\"Update\" on a saved layout profile now records your current arrangement. After dragging items between sections, Update could keep the old layout; Ice 2 now refreshes the menu bar before saving, so Update and Save Current Layout both store what's really in your menu bar.",
                 ]),
             ]
         )

--- a/IceTests/MenuBarLayoutProfileTests.swift
+++ b/IceTests/MenuBarLayoutProfileTests.swift
@@ -65,3 +65,146 @@ struct MenuBarLayoutProfileTests {
         #expect(decoded == group)
     }
 }
+
+// MARK: - Section snapshot capture
+
+struct MenuBarLayoutSectionSnapshotTests {
+    private func tag(_ title: String) -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .string("com.example"), title: title)
+    }
+
+    private func spacerTag(_ suffix: String) -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .ice, title: MenuBarSpacer.autosaveNamePrefix + suffix)
+    }
+
+    @Test func snapshotsCoverEverySectionInCanonicalOrder() {
+        let snapshots = MenuBarLayoutProfile.makeSectionSnapshots(from: [:])
+        #expect(snapshots.map(\.section) == MenuBarSection.Name.allCases)
+        #expect(snapshots.allSatisfy { $0.itemTags.isEmpty })
+    }
+
+    @Test func snapshotsPreserveTagOrderWithinSection() {
+        let snapshots = MenuBarLayoutProfile.makeSectionSnapshots(from: [
+            .visible: [tag("A"), tag("B"), tag("C")],
+        ])
+        let visible = snapshots.first { $0.section == .visible }
+        #expect(visible?.itemTags == [tag("A"), tag("B"), tag("C")])
+    }
+
+    @Test func snapshotsExcludeSpacerItems() {
+        let snapshots = MenuBarLayoutProfile.makeSectionSnapshots(from: [
+            .visible: [tag("A"), spacerTag("1"), tag("B")],
+            .hidden: [spacerTag("2")],
+        ])
+        let visible = snapshots.first { $0.section == .visible }
+        let hidden = snapshots.first { $0.section == .hidden }
+        #expect(visible?.itemTags == [tag("A"), tag("B")])
+        #expect(hidden?.itemTags == [])
+    }
+}
+
+// MARK: - Create / update capture behavior
+
+@MainActor
+struct MenuBarLayoutProfileCaptureTests {
+    private func tag(_ title: String) -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .string("com.example"), title: title)
+    }
+
+    @Test func createProfileCapturesCurrentLayout() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = {
+            [.visible: [self.tag("A"), self.tag("B")], .hidden: [self.tag("C")]]
+        }
+
+        await settings.createProfile(named: "Work")
+
+        #expect(settings.profiles.count == 1)
+        let profile = settings.profiles[0]
+        #expect(profile.name == "Work")
+        #expect(profile.itemCount(for: .visible) == 2)
+        #expect(profile.itemCount(for: .hidden) == 1)
+        #expect(profile.itemCount(for: .alwaysHidden) == 0)
+    }
+
+    /// The core regression test for the bug: after rearranging items, clicking
+    /// "Update" must re-capture the *current* layout, not keep the layout that
+    /// was stored when the profile was first saved.
+    @Test func updateProfileRecapturesCurrentLayout() async {
+        let settings = MenuBarLayoutProfilesSettings()
+
+        // Saved when the layout had a single visible item.
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "Work")
+        let original = settings.profiles[0]
+        #expect(original.itemCount(for: .visible) == 1)
+        #expect(original.itemCount(for: .alwaysHidden) == 0)
+
+        // User rearranges: one item moves to the always-hidden section.
+        settings.captureCurrentLayout = {
+            [.visible: [self.tag("A")], .alwaysHidden: [self.tag("B")]]
+        }
+        await settings.updateProfile(original)
+
+        #expect(settings.profiles.count == 1)
+        let updated = settings.profiles[0]
+        #expect(updated.id == original.id)
+        #expect(updated.name == original.name)
+        #expect(updated.createdAt == original.createdAt)
+        #expect(updated.itemCount(for: .visible) == 1)
+        #expect(updated.itemCount(for: .alwaysHidden) == 1)
+        #expect(updated.itemTags(for: .alwaysHidden) == [tag("B")])
+    }
+
+    @Test func updateProfileLeavesOtherProfilesUntouched() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "First")
+        settings.captureCurrentLayout = { [.visible: [self.tag("B")]] }
+        await settings.createProfile(named: "Second")
+
+        let second = settings.profiles[1]
+        settings.captureCurrentLayout = { [.visible: [self.tag("B"), self.tag("C")]] }
+        await settings.updateProfile(second)
+
+        #expect(settings.profiles[0].itemTags(for: .visible) == [tag("A")])
+        #expect(settings.profiles[1].itemTags(for: .visible) == [tag("B"), tag("C")])
+    }
+
+    @Test func updateUnknownProfileIsNoOp() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "Work")
+
+        let stranger = MenuBarLayoutProfile(
+            id: UUID(), name: "Ghost",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            sections: []
+        )
+        settings.captureCurrentLayout = { [.visible: [self.tag("Z")]] }
+        await settings.updateProfile(stranger)
+
+        #expect(settings.profiles.count == 1)
+        #expect(settings.profiles[0].itemTags(for: .visible) == [tag("A")])
+    }
+}
+
+// MARK: - Layout-capture cache refresh delay
+
+struct MenuBarLayoutCaptureRefreshDelayTests {
+    @Test func noMoveMeansNoDelay() {
+        #expect(MenuBarItemManager.layoutCaptureRefreshDelay(sinceLastMove: nil) == .zero)
+    }
+
+    @Test func recentMoveWaitsOutTheSkipWindow() {
+        // Window is 1s + 50ms; a move 200ms ago must wait the remaining 850ms.
+        let delay = MenuBarItemManager.layoutCaptureRefreshDelay(sinceLastMove: .milliseconds(200))
+        #expect(delay == .milliseconds(850))
+    }
+
+    @Test func oldMoveMeansNoDelay() {
+        let delay = MenuBarItemManager.layoutCaptureRefreshDelay(sinceLastMove: .seconds(2))
+        #expect(delay == .zero)
+    }
+}


### PR DESCRIPTION
## Problem

Rearranging menu bar items between sections and clicking **Update** on a saved layout profile did not save the new arrangement — the profile's counts stayed unchanged. Deleting the profile and using **Save Current Layout** worked around it.

## Root cause

Layout-bar drags post real move events but never refresh `MenuBarItemManager.itemCache`. That cache is only refreshed by debounced system events (frontmost-app/space/running-apps), a 30s poll, or navigating to Appearance — and all of those skip for **1 second after a move**. Both `createProfile` and `updateProfile` captured the layout from that possibly-stale cache, so clicking **Update** right after rearranging recorded the *pre-move* layout. The delete-and-recreate workaround only appeared to work because the extra interactions gave a background event time to refresh the cache first.

(The obvious suspect — the `profiles[index] = …` write-back — was ruled out: `@Published` array subscript assignment does publish.)

## Fix

- Capture now flows through one injectable seam, `MenuBarLayoutProfilesSettings.captureCurrentLayout`, whose production default calls the new `MenuBarItemManager.refreshCacheForLayoutCapture()` first — it waits out the post-move skip window, then forces a fresh cache — before reading the layout. Covers both layout-bar drags and ⌘-drags in the real menu bar.
- `createProfile`/`updateProfile` are now `async`; the Save/Update buttons run them in a `Task` with a busy state that disables the profile buttons during the brief capture.
- Extracted pure helpers (`MenuBarLayoutProfile.makeSectionSnapshots`, `MenuBarItemManager.layoutCaptureRefreshDelay`) so the logic is unit-testable without a live menu bar.

## Tests

10 new tests (36 total pass). The key regression test, `updateProfileRecapturesCurrentLayout`, proves Update stores the *current* layout rather than the stale one. Also covers snapshot building, spacer exclusion, section ordering, and the refresh-delay math.

## Release

Bumps `MARKETING_VERSION` to **2.9.7**; updates CHANGELOG and What's New.

🤖 Generated with [Claude Code](https://claude.com/claude-code)