### PR TITLE
release: v2.9.8 — lower idle CPU + guard layout-profile Update against empty capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.9.8 - 2026-07-10
+
+### Fixed
+
+- **Updating a layout profile can no longer erase it.** If capturing the current menu bar layout failed — for example right after Ice 2 launched, or if Screen Recording permission had been revoked — clicking **Update** on a saved profile could overwrite it with an empty layout. Ice 2 now ignores an empty capture and leaves your saved profile untouched.
+
+### Improved
+
+- **Lower idle CPU and energy use.** The Ice 2 Bar no longer captures the screen every few seconds while it's hidden — it only refreshes its background color while actually visible — and menu bar item names are now computed once instead of on every access. This continues the idle-power work from 2.8.4–2.8.6.
+
 ## 2.9.7 - 2026-07-09
 
 ### Fixed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.7;
+				MARKETING_VERSION = 2.9.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -646,7 +646,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.7;
+				MARKETING_VERSION = 2.9.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/MenuBar/IceBar/IceBar.swift
+++ b/Ice/MenuBar/IceBar/IceBar.swift
@@ -313,7 +313,7 @@ private struct IceBarContentView: View {
     let section: MenuBarSection.Name
 
     private var items: [MenuBarItem] {
-        itemManager.itemCache.managedItems(for: section)
+        itemManager.itemCache[section]
     }
 
     private var configuration: MenuBarAppearanceConfigurationV2 {

--- a/Ice/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Ice/MenuBar/IceBar/IceBarColorManager.swift
@@ -82,18 +82,21 @@ final class IceBarColorManager: ObservableObject {
             )
             .receive(on: DispatchQueue.main)
             .sink { [weak self, weak iceBarPanel] in
+                // Only refresh while the Ice Bar is actually visible. When it's
+                // hidden there's no point capturing the screen every 5s — the
+                // show path (`updateAllProperties`) re-captures a fresh image
+                // before the panel is ordered front.
                 guard
                     let self,
                     let iceBarPanel,
+                    iceBarPanel.isVisible,
                     let screen = iceBarPanel.screen
                 else {
                     return
                 }
                 updateWindowImage(for: screen)
-                if iceBarPanel.isVisible {
-                    withAnimation {
-                        self.updateColorInfo(with: iceBarPanel.frame, screen: screen)
-                    }
+                withAnimation {
+                    self.updateColorInfo(with: iceBarPanel.frame, screen: screen)
                 }
             }
             .store(in: &c)

--- a/Ice/MenuBar/LayoutBar/LayoutBarContainer.swift
+++ b/Ice/MenuBar/LayoutBar/LayoutBarContainer.swift
@@ -85,7 +85,7 @@ final class LayoutBarContainer: NSView {
                     guard let self else {
                         return
                     }
-                    setArrangedViews(items: cache.managedItems(for: section))
+                    setArrangedViews(items: cache[section])
                 }
                 .store(in: &c)
 

--- a/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -83,9 +83,16 @@ struct MenuBarItem: CustomStringConvertible {
         return NSRunningApplication(processIdentifier: sourcePID)
     }
 
-    // TODO: Generate this once, during initialization.
     /// A name associated with the item, suited for display.
-    var displayName: String {
+    ///
+    /// This is computed once, during initialization.
+    let displayName: String
+
+    /// Computes the display name for the given item properties.
+    ///
+    /// The result is stored in ``displayName`` at initialization, as all of
+    /// its inputs are immutable for the lifetime of the item.
+    private static func makeDisplayName(tag: MenuBarItemTag, title: String?, sourcePID: pid_t?) -> String {
         /// Converts "UpperCamelCase" to "Title Case".
         ///
         /// Ignores cases where a single lowercase letter immediately
@@ -94,7 +101,7 @@ struct MenuBarItem: CustomStringConvertible {
             String(s).replacing(/([a-z]{2})([A-Z])/) { $0.output.1 + " " + $0.output.2 }
         }
 
-        guard !isControlItem else {
+        guard !tag.isControlItem else {
             return Constants.displayName
         }
 
@@ -104,7 +111,7 @@ struct MenuBarItem: CustomStringConvertible {
 
         lazy var fallbackName = "Menu Bar Item"
 
-        guard let sourceApplication else {
+        guard let sourceApplication = sourcePID.flatMap({ NSRunningApplication(processIdentifier: $0) }) else {
             return fallbackName
         }
 
@@ -116,7 +123,7 @@ struct MenuBarItem: CustomStringConvertible {
 
         lazy var bestName = sourceName ?? title
 
-        guard !isBentoBox else {
+        guard !tag.isBentoBox else {
             if tag == .controlCenter {
                 return bestName
             }
@@ -188,6 +195,7 @@ struct MenuBarItem: CustomStringConvertible {
         self.bounds = itemWindow.bounds
         self.title = itemWindow.title
         self.isOnScreen = itemWindow.isOnScreen
+        self.displayName = Self.makeDisplayName(tag: self.tag, title: self.title, sourcePID: self.sourcePID)
     }
 
     /// Creates a menu bar item without checks.
@@ -203,6 +211,7 @@ struct MenuBarItem: CustomStringConvertible {
         self.bounds = itemWindow.bounds
         self.title = itemWindow.title
         self.isOnScreen = itemWindow.isOnScreen
+        self.displayName = Self.makeDisplayName(tag: self.tag, title: self.title, sourcePID: self.sourcePID)
     }
 }
 

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -180,12 +180,6 @@ extension MenuBarItemManager {
             self.displayID = displayID
         }
 
-        // TODO: This is redundant now, so remove it.
-        /// Returns the managed menu bar items for the given section.
-        func managedItems(for section: MenuBarSection.Name) -> [MenuBarItem] {
-            self[section]
-        }
-
         /// Returns the address for the menu bar item with the given identity,
         /// if it exists in the cache.
         func address(for item: MenuBarItem) -> (section: MenuBarSection.Name, index: Int)? {
@@ -1453,8 +1447,8 @@ extension MenuBarItemManager {
 
         let tags = Set(group.itemTags)
         let items = (
-            itemCache.managedItems(for: .hidden) +
-            itemCache.managedItems(for: .alwaysHidden)
+            itemCache[.hidden] +
+            itemCache[.alwaysHidden]
         )
         .filter { tags.contains($0.tag) && !$0.isSpacerItem }
 

--- a/Ice/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Ice/MenuBar/Search/MenuBarSearchPanel.swift
@@ -334,7 +334,7 @@ private struct MenuBarSearchContentView: View {
                 }
                 items.append(SearchItem(headerItem, name.displayString))
 
-                for item in itemManager.itemCache.managedItems(for: name).reversed() {
+                for item in itemManager.itemCache[name].reversed() {
                     if model.mode == .temporarilyShow, name == .visible {
                         continue
                     }

--- a/Ice/Settings/Models/MenuBarLayoutProfilesSettings.swift
+++ b/Ice/Settings/Models/MenuBarLayoutProfilesSettings.swift
@@ -95,8 +95,7 @@ final class MenuBarLayoutProfilesSettings: ObservableObject {
             await appState.itemManager.refreshCacheForLayoutCapture()
             var tagsBySection = [MenuBarSection.Name: [MenuBarItemTag]]()
             for section in MenuBarSection.Name.allCases {
-                tagsBySection[section] = appState.itemManager.itemCache
-                    .managedItems(for: section)
+                tagsBySection[section] = appState.itemManager.itemCache[section]
                     .map(\.tag)
             }
             return tagsBySection
@@ -162,6 +161,14 @@ final class MenuBarLayoutProfilesSettings: ObservableObject {
 
     func updateProfile(_ profile: MenuBarLayoutProfile) async {
         let tagsBySection = await captureCurrentLayout()
+        // A capture with no items in any section means the refresh failed (no
+        // app state, revoked permission, or a cleared cache) rather than a real
+        // layout — control items are never filtered out of a capture, so a
+        // genuine layout always has at least one item. Don't overwrite a saved
+        // profile with an empty capture.
+        guard tagsBySection.values.contains(where: { !$0.isEmpty }) else {
+            return
+        }
         guard let index = profiles.firstIndex(where: { $0.id == profile.id }) else {
             return
         }
@@ -234,8 +241,8 @@ final class MenuBarLayoutProfilesSettings: ObservableObject {
             return nil
         }
 
-        let hiddenItems = appState.itemManager.itemCache.managedItems(for: .hidden)
-        let alwaysHiddenItems = appState.itemManager.itemCache.managedItems(for: .alwaysHidden)
+        let hiddenItems = appState.itemManager.itemCache[.hidden]
+        let alwaysHiddenItems = appState.itemManager.itemCache[.alwaysHidden]
         var items = hiddenItems + alwaysHiddenItems
 
         if items.isEmpty {

--- a/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -252,8 +252,8 @@ struct MenuBarLayoutSettingsPane: View {
     private func availableHiddenItemCount(for group: MenuBarItemGroup) -> Int {
         let tags = Set(group.itemTags)
         let items = (
-            itemManager.itemCache.managedItems(for: .hidden) +
-            itemManager.itemCache.managedItems(for: .alwaysHidden)
+            itemManager.itemCache[.hidden] +
+            itemManager.itemCache[.alwaysHidden]
         )
         return items.filter { tags.contains($0.tag) }.count
     }

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -14,11 +14,14 @@ enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
             version: Constants.versionString,
-            date: "2026-07-09",
-            summary: "Layout profile fix.",
+            date: "2026-07-10",
+            summary: "Idle-power and layout-profile fixes.",
             sections: [
                 ChangeSection(kind: .fixed, entries: [
-                    "\"Update\" on a saved layout profile now records your current arrangement. After dragging items between sections, Update could keep the old layout; Ice 2 now refreshes the menu bar before saving, so Update and Save Current Layout both store what's really in your menu bar.",
+                    "Updating a saved layout profile can no longer erase it. If capturing the current layout failed, Update could overwrite the profile with an empty layout; Ice 2 now ignores an empty capture and leaves your saved profile untouched.",
+                ]),
+                ChangeSection(kind: .improved, entries: [
+                    "Lower idle CPU and energy use. The Ice 2 Bar no longer captures the screen every few seconds while it's hidden, and menu bar item names are now computed once instead of on every access.",
                 ]),
             ]
         )

--- a/IceTests/MenuBarLayoutProfileTests.swift
+++ b/IceTests/MenuBarLayoutProfileTests.swift
@@ -188,6 +188,87 @@ struct MenuBarLayoutProfileCaptureTests {
         #expect(settings.profiles.count == 1)
         #expect(settings.profiles[0].itemTags(for: .visible) == [tag("A")])
     }
+
+    /// If the capture comes back with no items at all (refresh failed, revoked
+    /// permission, or a cleared cache), Update must not clobber the saved
+    /// profile with an empty layout.
+    @Test func updateProfileIgnoresEmptyDictCapture() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A"), self.tag("B")]] }
+        await settings.createProfile(named: "Work")
+        let original = settings.profiles[0]
+
+        settings.captureCurrentLayout = { [:] }
+        await settings.updateProfile(original)
+
+        #expect(settings.profiles.count == 1)
+        #expect(settings.profiles[0].itemTags(for: .visible) == [tag("A"), tag("B")])
+    }
+
+    @Test func updateProfileIgnoresAllSectionsEmptyCapture() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "Work")
+        let original = settings.profiles[0]
+
+        settings.captureCurrentLayout = { [.visible: [], .hidden: [], .alwaysHidden: []] }
+        await settings.updateProfile(original)
+
+        #expect(settings.profiles[0].itemTags(for: .visible) == [tag("A")])
+    }
+
+    @Test func updateProfileAdvancesUpdatedAtButKeepsCreatedAt() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "Work")
+        let original = settings.profiles[0]
+
+        settings.captureCurrentLayout = { [.visible: [self.tag("A"), self.tag("B")]] }
+        await settings.updateProfile(original)
+        let updated = settings.profiles[0]
+
+        #expect(updated.createdAt == original.createdAt)
+        #expect(updated.updatedAt >= original.updatedAt)
+    }
+
+    @Test func blankNameGetsUniqueDefault() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "   ")
+        await settings.createProfile(named: "")
+        #expect(settings.profiles[0].name == "Layout Profile 1")
+        #expect(settings.profiles[1].name == "Layout Profile 2")
+    }
+
+    @Test func blankNameFillsSmallestFreeIndexAfterDelete() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "")   // "Layout Profile 1"
+        await settings.createProfile(named: "")   // "Layout Profile 2"
+        settings.deleteProfile(settings.profiles[0]) // frees "Layout Profile 1"
+        await settings.createProfile(named: "")
+        #expect(settings.profiles.contains { $0.name == "Layout Profile 1" })
+    }
+
+    @Test func nonEmptyNameIsTrimmed() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "  Work  ")
+        #expect(settings.profiles[0].name == "Work")
+    }
+
+    @Test func deleteRemovesOnlyTheTargetProfile() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        settings.captureCurrentLayout = { [.visible: [self.tag("A")]] }
+        await settings.createProfile(named: "First")
+        await settings.createProfile(named: "Second")
+        let first = settings.profiles[0]
+        settings.deleteProfile(first)
+        #expect(settings.profiles.count == 1)
+        #expect(settings.profiles[0].name == "Second")
+        settings.deleteProfile(first) // already gone → no-op
+        #expect(settings.profiles.count == 1)
+    }
 }
 
 // MARK: - Layout-capture cache refresh delay
@@ -206,5 +287,14 @@ struct MenuBarLayoutCaptureRefreshDelayTests {
     @Test func oldMoveMeansNoDelay() {
         let delay = MenuBarItemManager.layoutCaptureRefreshDelay(sinceLastMove: .seconds(2))
         #expect(delay == .zero)
+    }
+
+    @Test func moveAtExactWindowMeansNoDelay() {
+        // The skip window is exactly 1s + 50ms; a move at the boundary needs no wait.
+        #expect(MenuBarItemManager.layoutCaptureRefreshDelay(sinceLastMove: .milliseconds(1050)) == .zero)
+    }
+
+    @Test func moveJustInsideWindowWaitsRemainder() {
+        #expect(MenuBarItemManager.layoutCaptureRefreshDelay(sinceLastMove: .milliseconds(1000)) == .milliseconds(50))
     }
 }


### PR DESCRIPTION
## Summary

Three safe, single-monitor-verifiable improvements plus a data-loss bugfix, cut as **v2.9.8**.

### Fixed
- **Updating a layout profile can no longer erase it.** `updateProfile` now ignores an all-empty capture (which only happens on refresh failure — no app state, revoked Screen Recording permission, or a cleared cache) instead of overwriting the saved profile with an empty layout.

### Improved — idle CPU / energy
- **Ice Bar color refresh gated behind visibility.** `IceBarColorManager` was enumerating on-screen windows + capturing the screen every 5s for *every* user even while the Ice Bar was hidden. It now only refreshes while the panel is visible (the show path already re-captures).
- **`MenuBarItem.displayName` computed once at init** instead of re-running regex + `NSRunningApplication` lookups on every access (it's read in tooltips, a11y labels, and search rows).

### Cleanup
- Removed the redundant `ItemCache.managedItems(for:)` wrapper; all 10 callers use the existing `subscript(section:)`.

### Tests
Added pure-logic coverage for the empty-capture guard, the `updatedAt`/`createdAt` contract, default-name generation, delete, and refresh-delay boundaries. **Full `IceTests` suite passes (45 tests); app builds clean.**

### Deliberately not included
Multi-display / notch Accessibility work (single-monitor machine can't verify it), and items needing on-device or specific-macOS runtime testing (ControlItem zero-width hack, MusicRecognition version gate, macOS 26 screen-capture check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)