### PR TITLE
test: expand IceTests coverage for hotkey/color/gradient logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+### Tests
+
+- **Expanded the unit-test suite for the pure-logic layer.** Added 63 new test cases (45 → 108 total) across 8 new files in the `IceTests` target, all passing:
+  - `ModifiersTests` — symbolic string, NSEvent/CoreGraphics/Carbon flag conversions (round-trips), and `Codable`.
+  - `KeyCodeTests` — raw values, custom symbol mappings, key-equivalent fallback, and `Codable`.
+  - `KeyCombinationTests` — display value, `NSEvent` init, system-reserved lookup, equality, and the two-element `Codable` encoding (including the wrong-count decode error).
+  - `HotkeyActionTests` — persisted raw-value strings, `allCases`, and `Codable` (guards against renames that would break saved hotkeys).
+  - `PredicatesTests` — the throwing and non-throwing predicate factories.
+  - `IceColorTests` — component-preserving `Codable` round-trip and the invalid-ICC decode error path.
+  - `IceGradientTests` — color stops, alpha/location transforms, `NSGradient` conversion, interpolated/average color, and `Codable`.
+  - `ExtensionsTests` — `clamped`, `removingDuplicates`, `CGColor.brightness`, and `EdgeInsets` helpers.
+- **Coverage of the targeted logic types:** `Modifiers` 0→100%, `KeyCode` 0→95%, `KeyCombination` 0→92%, `IceGradient` 6→74%, `Predicates` 0→64%, `IceColor` 0→49%. The remaining uncovered lines in these files are system-coupled (SwiftUI view bodies, Carbon/TIS system calls) and are not unit-testable headlessly. Overall app-target line coverage moved from 5.4% to 7.4%; the bulk of the app is GUI/system integration that requires a live session with granted permissions.
+
 ## 2.9.8 - 2026-07-10
 
 ### Fixed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -10,18 +10,26 @@
 		170423D92B56DE78004A2549 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 170423D82B56DE78004A2549 /* Sparkle */; };
 		175061912B1543DD003144CD /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 175061902B1543DD003144CD /* LaunchAtLogin */; };
 		1787C4272B16890B002F50DF /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1787C4262B16890B002F50DF /* AXSwift */; };
+		17EA92DE1008D6773AC39E03 /* IceColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23731A85E77C82F006FD936 /* IceColorTests.swift */; };
 		17F71BB52B880B4500905CBA /* CompactSlider in Frameworks */ = {isa = PBXBuildFile; productRef = 17F71BB42B880B4500905CBA /* CompactSlider */; };
 		1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */; };
+		2BCF7F33DF18C9000C060A36 /* KeyCombinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D9FF7076B412B16B603C8C /* KeyCombinationTests.swift */; };
 		35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */; };
 		532D0E5212D395B68CA7F31E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */; };
+		5EE79BA2367FDAA95AF9CF2C /* IceGradientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */; };
 		7127A9FF2C4886D100D99DEF /* IfritStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 7127A9FE2C4886D100D99DEF /* IfritStatic */; };
 		7168EE532E281CBC00FF9830 /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7168EE522E281CBC00FF9830 /* AXSwift */; };
 		7188A68C2E27F9ED008F131D /* MenuBarItemService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		71A065092E680C620087DB38 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = 71A065082E680C620087DB38 /* Semaphore */; };
+		7937F9F0BC456A13B37FD10D /* ModifiersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4B03D73514A57A4612D4F6 /* ModifiersTests.swift */; };
+		861C26D46D9BD27B5C759FEF /* HotkeyActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */; };
 		883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */; };
 		986A47EC7057DE6842643937 /* SettingsBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */; };
+		CB1C634067FACF3660D7435C /* KeyCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */; };
 		DA6DC1703A2B3C4D5E6F7083 /* DragonKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA6DC1702A2B3C4D5E6F7082 /* DragonKit */; };
 		DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */; };
+		DFBC7C32FBD412329442365B /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29224478E4DA927C88733C8 /* ExtensionsTests.swift */; };
+		EEC5232C90D9CEE81286467E /* PredicatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C94DAF88A92F6747D67CCC8 /* PredicatesTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,13 +66,21 @@
 /* Begin PBXFileReference section */
 		12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsBackupTests.swift; sourceTree = "<group>"; };
 		4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarLayoutProfileTests.swift; sourceTree = "<group>"; };
+		5C4B03D73514A57A4612D4F6 /* ModifiersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModifiersTests.swift; sourceTree = "<group>"; };
+		61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IceGradientTests.swift; sourceTree = "<group>"; };
 		6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarItemTagTests.swift; sourceTree = "<group>"; };
 		7166832A2A767E6A006ABF84 /* Ice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = MenuBarItemService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
+		7C94DAF88A92F6747D67CCC8 /* PredicatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredicatesTests.swift; sourceTree = "<group>"; };
 		83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarSectionNameTests.swift; sourceTree = "<group>"; };
 		8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyCodeTests.swift; sourceTree = "<group>"; };
 		BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		C23731A85E77C82F006FD936 /* IceColorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IceColorTests.swift; sourceTree = "<group>"; };
+		CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HotkeyActionTests.swift; sourceTree = "<group>"; };
+		D5D9FF7076B412B16B603C8C /* KeyCombinationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyCombinationTests.swift; sourceTree = "<group>"; };
+		F29224478E4DA927C88733C8 /* ExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -203,6 +219,14 @@
 				6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */,
 				4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */,
 				12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */,
+				5C4B03D73514A57A4612D4F6 /* ModifiersTests.swift */,
+				9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */,
+				D5D9FF7076B412B16B603C8C /* KeyCombinationTests.swift */,
+				CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */,
+				7C94DAF88A92F6747D67CCC8 /* PredicatesTests.swift */,
+				C23731A85E77C82F006FD936 /* IceColorTests.swift */,
+				61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */,
+				F29224478E4DA927C88733C8 /* ExtensionsTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -389,6 +413,14 @@
 				35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */,
 				883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */,
 				986A47EC7057DE6842643937 /* SettingsBackupTests.swift in Sources */,
+				7937F9F0BC456A13B37FD10D /* ModifiersTests.swift in Sources */,
+				CB1C634067FACF3660D7435C /* KeyCodeTests.swift in Sources */,
+				2BCF7F33DF18C9000C060A36 /* KeyCombinationTests.swift in Sources */,
+				861C26D46D9BD27B5C759FEF /* HotkeyActionTests.swift in Sources */,
+				EEC5232C90D9CEE81286467E /* PredicatesTests.swift in Sources */,
+				17EA92DE1008D6773AC39E03 /* IceColorTests.swift in Sources */,
+				5EE79BA2367FDAA95AF9CF2C /* IceGradientTests.swift in Sources */,
+				DFBC7C32FBD412329442365B /* ExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IceTests/ExtensionsTests.swift
+++ b/IceTests/ExtensionsTests.swift
@@ -1,0 +1,90 @@
+//
+//  ExtensionsTests.swift
+//  IceTests
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+import Testing
+@testable import Ice_2
+
+struct ExtensionsTests {
+    // MARK: Comparable.clamped
+
+    @Test func clampedMinMaxWithinBoundsReturnsValue() {
+        #expect(5.clamped(min: 0, max: 10) == 5)
+    }
+
+    @Test func clampedMinMaxBelowAndAboveBounds() {
+        #expect((-3).clamped(min: 0, max: 10) == 0)
+        #expect(42.clamped(min: 0, max: 10) == 10)
+    }
+
+    @Test func clampedToRange() {
+        #expect(5.0.clamped(to: 1.0...3.0) == 3.0)
+        #expect(0.0.clamped(to: 1.0...3.0) == 1.0)
+        #expect(2.0.clamped(to: 1.0...3.0) == 2.0)
+    }
+
+    @Test func clampedAtExactBounds() {
+        #expect(0.clamped(min: 0, max: 10) == 0)
+        #expect(10.clamped(min: 0, max: 10) == 10)
+    }
+
+    // MARK: RangeReplaceableCollection.removingDuplicates
+
+    @Test func removingDuplicatesPreservesFirstOccurrenceOrder() {
+        #expect([1, 2, 2, 3, 1, 4].removingDuplicates() == [1, 2, 3, 4])
+        #expect(["a", "a", "b"].removingDuplicates() == ["a", "b"])
+    }
+
+    @Test func removingDuplicatesOnEmptyAndUnique() {
+        #expect([Int]().removingDuplicates() == [])
+        #expect([1, 2, 3].removingDuplicates() == [1, 2, 3])
+    }
+
+    // MARK: CGColor.brightness
+
+    @Test func brightnessOfWhiteAndBlack() throws {
+        let white = try #require(CGColor(srgbRed: 1, green: 1, blue: 1, alpha: 1).brightness)
+        let black = try #require(CGColor(srgbRed: 0, green: 0, blue: 0, alpha: 1).brightness)
+        #expect(abs(white - 1) < 0.01)
+        #expect(abs(black - 0) < 0.01)
+    }
+
+    @Test func brightnessWeightsGreenMostHeavily() throws {
+        // Per the W3C AERT formula, green (587) outweighs red (299) and blue (114).
+        let red = try #require(CGColor(srgbRed: 1, green: 0, blue: 0, alpha: 1).brightness)
+        let green = try #require(CGColor(srgbRed: 0, green: 1, blue: 0, alpha: 1).brightness)
+        let blue = try #require(CGColor(srgbRed: 0, green: 0, blue: 1, alpha: 1).brightness)
+        #expect(green > red)
+        #expect(red > blue)
+    }
+
+    // MARK: EdgeInsets
+
+    @Test func edgeInsetsInitAllSetsEveryEdge() {
+        let insets = EdgeInsets(all: 7)
+        #expect(insets.top == 7)
+        #expect(insets.leading == 7)
+        #expect(insets.bottom == 7)
+        #expect(insets.trailing == 7)
+    }
+
+    @Test func edgeInsetsHorizontalZeroesVerticalEdges() {
+        let insets = EdgeInsets(top: 1, leading: 2, bottom: 3, trailing: 4).horizontal
+        #expect(insets.top == 0)
+        #expect(insets.leading == 2)
+        #expect(insets.bottom == 0)
+        #expect(insets.trailing == 4)
+    }
+
+    @Test func edgeInsetsVerticalZeroesHorizontalEdges() {
+        let insets = EdgeInsets(top: 1, leading: 2, bottom: 3, trailing: 4).vertical
+        #expect(insets.top == 1)
+        #expect(insets.leading == 0)
+        #expect(insets.bottom == 3)
+        #expect(insets.trailing == 0)
+    }
+}

--- a/IceTests/HotkeyActionTests.swift
+++ b/IceTests/HotkeyActionTests.swift
@@ -1,0 +1,44 @@
+//
+//  HotkeyActionTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct HotkeyActionTests {
+    @Test func rawValuesMatchPersistedStrings() {
+        #expect(HotkeyAction.toggleHiddenSection.rawValue == "ToggleHiddenSection")
+        #expect(HotkeyAction.toggleAlwaysHiddenSection.rawValue == "ToggleAlwaysHiddenSection")
+        #expect(HotkeyAction.toggleSectionDividerIcons.rawValue == "ToggleSectionDividerIcons")
+        #expect(HotkeyAction.searchMenuBarItems.rawValue == "SearchMenuBarItems")
+        #expect(HotkeyAction.temporarilyShowMenuBarItem.rawValue == "TemporarilyShowMenuBarItem")
+        #expect(HotkeyAction.enableIceBar.rawValue == "EnableIceBar")
+        #expect(HotkeyAction.toggleAutoRehide.rawValue == "ToggleAutoRehide")
+        #expect(HotkeyAction.toggleApplicationMenus.rawValue == "ToggleApplicationMenus")
+    }
+
+    @Test func allCasesAreEnumerated() {
+        #expect(HotkeyAction.allCases.count == 8)
+    }
+
+    @Test func initFromRawValue() {
+        #expect(HotkeyAction(rawValue: "EnableIceBar") == .enableIceBar)
+        #expect(HotkeyAction(rawValue: "NotARealAction") == nil)
+    }
+
+    @Test func codableRoundTripForAllCases() throws {
+        for action in HotkeyAction.allCases {
+            let data = try JSONEncoder().encode(action)
+            let decoded = try JSONDecoder().decode(HotkeyAction.self, from: data)
+            #expect(decoded == action)
+        }
+    }
+
+    @Test func decodesFromRawStringLiteral() throws {
+        let data = Data("\"ToggleAutoRehide\"".utf8)
+        let decoded = try JSONDecoder().decode(HotkeyAction.self, from: data)
+        #expect(decoded == .toggleAutoRehide)
+    }
+}

--- a/IceTests/IceColorTests.swift
+++ b/IceTests/IceColorTests.swift
@@ -1,0 +1,45 @@
+//
+//  IceColorTests.swift
+//  IceTests
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct IceColorTests {
+    private func srgb(_ r: CGFloat, _ g: CGFloat, _ b: CGFloat, _ a: CGFloat = 1) -> CGColor {
+        CGColor(srgbRed: r, green: g, blue: b, alpha: a)
+    }
+
+    @Test func equalColorsAreEqual() {
+        let a = IceColor(cgColor: srgb(0.2, 0.4, 0.6))
+        let b = IceColor(cgColor: srgb(0.2, 0.4, 0.6))
+        #expect(a == b)
+    }
+
+    @Test func codableRoundTripPreservesComponents() throws {
+        let original = IceColor(cgColor: srgb(0.25, 0.5, 0.75, 0.8))
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(IceColor.self, from: data)
+
+        let originalComponents = original.cgColor.components ?? []
+        let decodedComponents = decoded.cgColor.components ?? []
+        #expect(originalComponents.count == decodedComponents.count)
+        for (lhs, rhs) in zip(originalComponents, decodedComponents) {
+            #expect(abs(lhs - rhs) < 0.0001)
+        }
+    }
+
+    @Test func decodingInvalidICCDataThrows() throws {
+        // Valid JSON shape, but the color-space payload is not a real ICC profile.
+        let json = """
+        {"components":[1,0,0,1],"colorSpace":"\(Data("not-icc".utf8).base64EncodedString())"}
+        """
+        let data = Data(json.utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(IceColor.self, from: data)
+        }
+    }
+}

--- a/IceTests/IceGradientTests.swift
+++ b/IceTests/IceGradientTests.swift
@@ -1,0 +1,120 @@
+//
+//  IceGradientTests.swift
+//  IceTests
+//
+
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct IceGradientTests {
+    private var blackToWhite: IceGradient {
+        IceGradient(stops: [.white(location: 0), .black(location: 1)])
+    }
+
+    // MARK: ColorStop
+
+    @Test func colorStopFactories() {
+        let white = IceGradient.ColorStop.white(location: 0.25)
+        #expect(white.location == 0.25)
+        #expect(white.color.components == [1, 1, 1, 1])
+
+        let black = IceGradient.ColorStop.black(location: 0.75)
+        #expect(black.location == 0.75)
+        #expect(black.color.components == [0, 0, 0, 1])
+
+        let custom = IceGradient.ColorStop.stop(CGColor(srgbRed: 1, green: 0, blue: 0, alpha: 1), location: 0.5)
+        #expect(custom.location == 0.5)
+    }
+
+    @Test func colorStopWithAlpha() {
+        let stop = IceGradient.ColorStop.white(location: 0).withAlpha(0.5)
+        #expect(stop.color.alpha == 0.5)
+    }
+
+    @Test func colorStopWithLocation() {
+        let stop = IceGradient.ColorStop.black(location: 0).withLocation(0.9)
+        #expect(stop.location == 0.9)
+    }
+
+    @Test func colorStopCodableRoundTrip() throws {
+        let stop = IceGradient.ColorStop.stop(CGColor(srgbRed: 0.1, green: 0.2, blue: 0.3, alpha: 1), location: 0.4)
+        let data = try JSONEncoder().encode(stop)
+        let decoded = try JSONDecoder().decode(IceGradient.ColorStop.self, from: data)
+        #expect(decoded.location == stop.location)
+    }
+
+    // MARK: IceGradient
+
+    @Test func defaultInitIsEmpty() {
+        #expect(IceGradient().stops.isEmpty)
+    }
+
+    @Test func defaultMenuBarTintIsWhiteToBlack() {
+        let tint = IceGradient.defaultMenuBarTint
+        #expect(tint.stops.count == 2)
+        #expect(tint.stops[0].location == 0)
+        #expect(tint.stops[1].location == 1)
+    }
+
+    @Test func withAlphaAppliesToAllStops() {
+        let faded = blackToWhite.withAlpha(0.5)
+        #expect(faded.stops.count == 2)
+        #expect(faded.stops.allSatisfy { $0.color.alpha == 0.5 })
+    }
+
+    @Test func nsGradientNilForEmptyGradient() {
+        #expect(IceGradient().nsGradient(using: .genericRGB) == nil)
+    }
+
+    @Test func nsGradientNonNilForPopulatedGradient() {
+        #expect(blackToWhite.nsGradient(using: .genericRGB) != nil)
+    }
+
+    @Test func colorAtEndpointsApproximatesStops() throws {
+        let space = try #require(CGColorSpace(name: CGColorSpace.extendedSRGB))
+        let start = try #require(blackToWhite.color(at: 0, using: space))
+        let end = try #require(blackToWhite.color(at: 1, using: space))
+        // Start is near white (bright), end is near black (dark).
+        let startBrightness = try #require(start.brightness)
+        let endBrightness = try #require(end.brightness)
+        #expect(startBrightness > endBrightness)
+    }
+
+    @Test func colorAtReturnsNilForEmptyGradient() {
+        #expect(IceGradient().color(at: 0.5) == nil)
+    }
+
+    @Test func colorAtUsingDefaultDisplayP3Space() {
+        // The single-argument overload resolves the extended Display P3 space.
+        #expect(blackToWhite.color(at: 0.5) != nil)
+    }
+
+    @Test func averageColorIgnoringAlphaForcesOpaque() throws {
+        let faded = blackToWhite.withAlpha(0.5)
+        let average = try #require(faded.averageColor(option: .ignoreAlpha))
+        let components = try #require(average.components)
+        #expect(abs(components[3] - 1) < 0.01)
+    }
+
+    @Test func averageColorHonorsExplicitRGBColorSpace() throws {
+        let space = try #require(CGColorSpace(name: CGColorSpace.extendedSRGB))
+        #expect(blackToWhite.averageColor(using: space) != nil)
+    }
+
+    @Test func averageColorNilForEmptyGradient() {
+        #expect(IceGradient().averageColor() == nil)
+    }
+
+    @Test func averageColorNonNilForPopulatedGradient() {
+        #expect(blackToWhite.averageColor() != nil)
+    }
+
+    @Test func codableRoundTripPreservesStopCount() throws {
+        let data = try JSONEncoder().encode(blackToWhite)
+        let decoded = try JSONDecoder().decode(IceGradient.self, from: data)
+        #expect(decoded.stops.count == 2)
+    }
+}

--- a/IceTests/KeyCodeTests.swift
+++ b/IceTests/KeyCodeTests.swift
@@ -1,0 +1,52 @@
+//
+//  KeyCodeTests.swift
+//  IceTests
+//
+
+import Carbon.HIToolbox
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct KeyCodeTests {
+    @Test func rawRepresentableRoundTrip() {
+        let code = KeyCode(rawValue: kVK_ANSI_A)
+        #expect(code.rawValue == kVK_ANSI_A)
+        #expect(KeyCode.a == code)
+    }
+
+    @Test func distinctKeysAreNotEqual() {
+        #expect(KeyCode.a != KeyCode.b)
+        #expect(KeyCode.space != KeyCode.tab)
+    }
+
+    @Test func codableRoundTrip() throws {
+        let keys: [KeyCode] = [.a, .space, .f5, .leftArrow, .keypad0]
+        let data = try JSONEncoder().encode(keys)
+        let decoded = try JSONDecoder().decode([KeyCode].self, from: data)
+        #expect(decoded == keys)
+    }
+
+    @Test func stringValueUsesCustomSymbolMappings() {
+        #expect(KeyCode.space.stringValue == "Space")
+        #expect(KeyCode.tab.stringValue == "⇥")
+        #expect(KeyCode.return.stringValue == "⏎")
+        #expect(KeyCode.delete.stringValue == "⌫")
+        #expect(KeyCode.escape.stringValue == "⎋")
+        #expect(KeyCode.leftArrow.stringValue == "←")
+        #expect(KeyCode.command.stringValue == "⌘")
+        #expect(KeyCode.f1.stringValue == "F1")
+        #expect(KeyCode.f12.stringValue == "F12")
+    }
+
+    @Test func stringValueFallsBackToKeyEquivalentForLetters() {
+        // Letters have no custom mapping, so they fall back to the
+        // system key-equivalent lookup. On an ANSI layout this is "a".
+        #expect(KeyCode.a.stringValue.lowercased() == "a")
+    }
+
+    @Test func hashableUsableInSet() {
+        let set: Set<KeyCode> = [.a, .a, .b]
+        #expect(set.count == 2)
+    }
+}

--- a/IceTests/KeyCombinationTests.swift
+++ b/IceTests/KeyCombinationTests.swift
@@ -1,0 +1,79 @@
+//
+//  KeyCombinationTests.swift
+//  IceTests
+//
+
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct KeyCombinationTests {
+    @Test func initFromNSEventExtractsKeyAndModifiers() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "a",
+            charactersIgnoringModifiers: "a",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_A)
+        ))
+        let combination = KeyCombination(event: event)
+        #expect(combination.key == .a)
+        #expect(combination.modifiers == [.command, .shift])
+    }
+
+    @Test func isSystemReservedExercisesSymbolicHotkeyLookup() {
+        // A combination with every modifier is extremely unlikely to be a
+        // registered system hotkey, so this reports false while still
+        // exercising the CopySymbolicHotKeys lookup path.
+        let combination = KeyCombination(key: .f19, modifiers: [.command, .control, .option, .shift])
+        #expect(!combination.isSystemReserved)
+    }
+
+    @Test func displayValueJoinsModifiersAndCapitalizedKey() {
+        let combination = KeyCombination(key: .space, modifiers: [.command, .shift])
+        #expect(combination.displayValue == "⇧⌘ Space")
+    }
+
+    @Test func displayValueWithNoModifiers() {
+        let combination = KeyCombination(key: .escape, modifiers: [])
+        #expect(combination.displayValue == " ⎋")
+    }
+
+    @Test func equalityConsidersKeyAndModifiers() {
+        let a = KeyCombination(key: .a, modifiers: [.command])
+        let b = KeyCombination(key: .a, modifiers: [.command])
+        let c = KeyCombination(key: .a, modifiers: [.control])
+        let d = KeyCombination(key: .b, modifiers: [.command])
+        #expect(a == b)
+        #expect(a != c)
+        #expect(a != d)
+    }
+
+    @Test func codableRoundTrip() throws {
+        let combination = KeyCombination(key: .f5, modifiers: [.control, .option])
+        let data = try JSONEncoder().encode(combination)
+        let decoded = try JSONDecoder().decode(KeyCombination.self, from: data)
+        #expect(decoded == combination)
+    }
+
+    @Test func encodesAsTwoElementArray() throws {
+        let combination = KeyCombination(key: .a, modifiers: .command)
+        let data = try JSONEncoder().encode(combination)
+        let array = try JSONDecoder().decode([Int].self, from: data)
+        #expect(array == [KeyCode.a.rawValue, Modifiers.command.rawValue])
+    }
+
+    @Test func decodingWrongElementCountThrows() {
+        let data = Data("[1, 2, 3]".utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(KeyCombination.self, from: data)
+        }
+    }
+}

--- a/IceTests/ModifiersTests.swift
+++ b/IceTests/ModifiersTests.swift
@@ -1,0 +1,78 @@
+//
+//  ModifiersTests.swift
+//  IceTests
+//
+
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct ModifiersTests {
+    private let all: Modifiers = [.control, .option, .shift, .command]
+
+    @Test func rawValuesAreDistinctBits() {
+        #expect(Modifiers.control.rawValue == 1 << 0)
+        #expect(Modifiers.option.rawValue == 1 << 1)
+        #expect(Modifiers.shift.rawValue == 1 << 2)
+        #expect(Modifiers.command.rawValue == 1 << 3)
+    }
+
+    @Test func canonicalOrderMatchesAppleStyleGuide() {
+        #expect(Modifiers.canonicalOrder == [.control, .option, .shift, .command])
+    }
+
+    @Test func symbolicValueOrdersControlOptionShiftCommand() {
+        #expect(all.symbolicValue == "⌃⌥⇧⌘")
+        #expect(Modifiers().symbolicValue == "")
+        #expect(Modifiers.command.symbolicValue == "⌘")
+        #expect(Modifiers([.shift, .command]).symbolicValue == "⇧⌘")
+    }
+
+    @Test func nsEventFlagsRoundTrip() {
+        let flags = all.nsEventFlags
+        #expect(flags.contains(.control))
+        #expect(flags.contains(.option))
+        #expect(flags.contains(.shift))
+        #expect(flags.contains(.command))
+        #expect(Modifiers(nsEventFlags: flags) == all)
+    }
+
+    @Test func cgEventFlagsRoundTrip() {
+        let flags = all.cgEventFlags
+        #expect(flags.contains(.maskControl))
+        #expect(flags.contains(.maskAlternate))
+        #expect(flags.contains(.maskShift))
+        #expect(flags.contains(.maskCommand))
+        #expect(Modifiers(cgEventFlags: flags) == all)
+    }
+
+    @Test func carbonFlagsRoundTrip() {
+        let flags = all.carbonFlags
+        #expect(flags & controlKey == controlKey)
+        #expect(flags & optionKey == optionKey)
+        #expect(flags & shiftKey == shiftKey)
+        #expect(flags & cmdKey == cmdKey)
+        #expect(Modifiers(carbonFlags: flags) == all)
+    }
+
+    @Test func emptyConversionsProduceEmptyModifiers() {
+        #expect(Modifiers(nsEventFlags: []) == Modifiers())
+        #expect(Modifiers(cgEventFlags: []) == Modifiers())
+        #expect(Modifiers(carbonFlags: 0) == Modifiers())
+    }
+
+    @Test func partialConversionPreservesOnlySetModifiers() {
+        let subset: Modifiers = [.control, .shift]
+        #expect(Modifiers(nsEventFlags: subset.nsEventFlags) == subset)
+        #expect(Modifiers(cgEventFlags: subset.cgEventFlags) == subset)
+        #expect(Modifiers(carbonFlags: subset.carbonFlags) == subset)
+    }
+
+    @Test func codableRoundTrip() throws {
+        let data = try JSONEncoder().encode(all)
+        let decoded = try JSONDecoder().decode(Modifiers.self, from: data)
+        #expect(decoded == all)
+    }
+}

--- a/IceTests/PredicatesTests.swift
+++ b/IceTests/PredicatesTests.swift
@@ -1,0 +1,49 @@
+//
+//  PredicatesTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct PredicatesTests {
+    @Test func nonThrowingInputPredicate() {
+        let isEven = Predicates<Int>.predicate { $0 % 2 == 0 }
+        #expect(isEven(4))
+        #expect(!isEven(3))
+    }
+
+    @Test func throwingInputPredicate() throws {
+        struct Boom: Error {}
+        let predicate = Predicates<Int>.predicate { (value: Int) throws -> Bool in
+            if value < 0 { throw Boom() }
+            return value > 10
+        }
+        #expect(try predicate(20))
+        #expect(try !predicate(5))
+        #expect(throws: Boom.self) {
+            _ = try predicate(-1)
+        }
+    }
+
+    @Test func nonThrowingInputlessPredicateIgnoresInput() {
+        let alwaysTrue = Predicates<String>.predicate { true }
+        #expect(alwaysTrue("anything"))
+        #expect(alwaysTrue(""))
+    }
+
+    @Test func throwingInputlessPredicateIgnoresInput() throws {
+        struct Boom: Error {}
+        var shouldThrow = false
+        let predicate = Predicates<String>.predicate { () throws -> Bool in
+            if shouldThrow { throw Boom() }
+            return true
+        }
+        #expect(try predicate("input"))
+        shouldThrow = true
+        #expect(throws: Boom.self) {
+            _ = try predicate("input")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Expands the `IceTests` unit-test suite for the pure-logic layer. Adds **63 test cases (45 → 108 total)** across 8 new files, all passing.

No production code changes — tests plus target registration in `project.pbxproj` and a `CHANGELOG.md` entry.

### New test files
- `ModifiersTests` — symbolic string, NSEvent/CG/Carbon flag round-trips, `Codable`
- `KeyCodeTests` — raw values, custom symbol mappings, key-equivalent fallback, `Codable`
- `KeyCombinationTests` — display value, `NSEvent` init, system-reserved lookup, equality, two-element `Codable` (incl. wrong-count decode error)
- `HotkeyActionTests` — persisted raw-value strings, `allCases`, `Codable`
- `PredicatesTests` — throwing / non-throwing predicate factories
- `IceColorTests` — component-preserving `Codable` round-trip + invalid-ICC decode error
- `IceGradientTests` — color stops, alpha/location transforms, `NSGradient`, interpolated/average color, `Codable`
- `ExtensionsTests` — `clamped`, `removingDuplicates`, `CGColor.brightness`, `EdgeInsets`

### Coverage of targeted logic types
`Modifiers` 0→100% · `KeyCode` 0→95% · `KeyCombination` 0→92% · `IceGradient` 6→74% · `Predicates` 0→64% · `IceColor` 0→49%.

Remaining uncovered lines in these files are system-coupled (SwiftUI view bodies, Carbon/TIS calls) and not unit-testable headlessly. Whole-app line coverage moved 5.4% → 7.4%; the bulk of the app is GUI/system integration needing a live session with granted permissions.

## Test plan
`xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS' -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO` → **TEST SUCCEEDED**, 108 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)