### PR TITLE
test: cover backup/restore file I/O and layout-profile guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   - `IceGradientTests` — color stops, alpha/location transforms, `NSGradient` conversion, interpolated/average color, and `Codable`.
   - `ExtensionsTests` — `clamped`, `removingDuplicates`, `CGColor.brightness`, and `EdgeInsets` helpers.
 - **Coverage of the targeted logic types:** `Modifiers` 0→100%, `KeyCode` 0→95%, `KeyCombination` 0→92%, `IceGradient` 6→74%, `Predicates` 0→64%, `IceColor` 0→49%. The remaining uncovered lines in these files are system-coupled (SwiftUI view bodies, Carbon/TIS system calls) and are not unit-testable headlessly. Overall app-target line coverage moved from 5.4% to 7.4%; the bulk of the app is GUI/system integration that requires a live session with granted permissions.
+- **Backup & restore and layout profiles.** Added 11 more test cases (108 → 119 total) covering the backup/restore file round-trip and the layout-profile model:
+  - `SettingsBackupTests` — `writeBackup`→`restore` round-trip, malformed-file rejection, `performBackup` write-and-prune, and the folder/config helpers (`defaultFolder`, `configuredFolder`, `automaticBackupEnabled`, `currentAppVersion`). Raises `SettingsBackup` coverage 65→96%.
+  - `MenuBarLayoutProfileTests` — `applyProfile`/`temporarilyShowGroup` guards when no `AppState` is present, and the `ApplyError` description.
+- **Layout-movement note:** the profile/group *model* (capture, create, update, delete, section snapshots) is unit-tested, but the actual movement *engine* (`MenuBarItemManager`) drives real menu-bar items via synthesized CGEvents and Accessibility and can only be exercised by the manual test checklist, not units.
 
 ## 2.9.8 - 2026-07-10
 

--- a/IceTests/MenuBarLayoutProfileTests.swift
+++ b/IceTests/MenuBarLayoutProfileTests.swift
@@ -269,6 +269,40 @@ struct MenuBarLayoutProfileCaptureTests {
         settings.deleteProfile(first) // already gone → no-op
         #expect(settings.profiles.count == 1)
     }
+
+    // MARK: - Apply / group guards without a live AppState
+
+    @Test func applyProfileWithoutAppStateThrows() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        let profile = MenuBarLayoutProfile(
+            id: UUID(), name: "X",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            sections: []
+        )
+        await #expect(throws: MenuBarLayoutProfilesSettings.ApplyError.self) {
+            try await settings.applyProfile(profile)
+        }
+    }
+
+    @Test func temporarilyShowGroupWithoutAppStateReturnsZero() async {
+        let settings = MenuBarLayoutProfilesSettings()
+        let group = MenuBarItemGroup(
+            id: UUID(), name: "G",
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            itemTags: []
+        )
+        let count = await settings.temporarilyShowGroup(group)
+        #expect(count == 0)
+    }
+
+    @Test func applyErrorHasUserFacingDescription() {
+        #expect(
+            MenuBarLayoutProfilesSettings.ApplyError.missingAppState.errorDescription
+                == "Ice is not ready to apply layout profiles."
+        )
+    }
 }
 
 // MARK: - Layout-capture cache refresh delay

--- a/IceTests/SettingsBackupTests.swift
+++ b/IceTests/SettingsBackupTests.swift
@@ -147,4 +147,107 @@ struct SettingsBackupTests {
         #expect(remaining.count == 1)
         #expect(remaining.first?.lastPathComponent == "Ice-Settings-2026-01-03-000000.icebackup")
     }
+
+    // MARK: - writeBackup / restore (file round-trip)
+
+    @Test func writeBackupThenRestoreReproducesValues() throws {
+        let (source, sSuite) = makeScratch()
+        let (target, tSuite) = makeScratch()
+        let folder = FileManager.default.temporaryDirectory
+            .appending(path: "IceTests-" + UUID().uuidString)
+        defer {
+            UserDefaults.standard.removePersistentDomain(forName: sSuite)
+            UserDefaults.standard.removePersistentDomain(forName: tSuite)
+            try? FileManager.default.removeItem(at: folder)
+        }
+        source.set("dark", forKey: Defaults.Key.iceIcon.rawValue)
+        source.set(7, forKey: Defaults.Key.showOnHoverDelay.rawValue)
+
+        // writeBackup also creates the (missing) destination folder.
+        let url = try SettingsBackup.writeBackup(
+            of: source, to: folder, appVersion: "3.1", date: Date(timeIntervalSince1970: 100)
+        )
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        #expect(url.pathExtension == SettingsBackup.fileExtension)
+
+        try SettingsBackup.restore(from: url, into: target)
+        #expect(target.string(forKey: Defaults.Key.iceIcon.rawValue) == "dark")
+        #expect(target.integer(forKey: Defaults.Key.showOnHoverDelay.rawValue) == 7)
+    }
+
+    @Test func restoreThrowsOnMalformedFile() throws {
+        let (target, tSuite) = makeScratch()
+        let folder = FileManager.default.temporaryDirectory
+            .appending(path: "IceTests-" + UUID().uuidString)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer {
+            UserDefaults.standard.removePersistentDomain(forName: tSuite)
+            try? FileManager.default.removeItem(at: folder)
+        }
+        let url = folder.appending(path: "Ice-Settings-2026-01-01-000000.icebackup")
+        try Data("not a plist".utf8).write(to: url)
+        #expect(throws: (any Error).self) {
+            try SettingsBackup.restore(from: url, into: target)
+        }
+    }
+
+    @Test func performBackupWritesToConfiguredFolderAndPrunes() throws {
+        let (source, sSuite) = makeScratch()
+        let folder = FileManager.default.temporaryDirectory
+            .appending(path: "IceTests-" + UUID().uuidString)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer {
+            UserDefaults.standard.removePersistentDomain(forName: sSuite)
+            try? FileManager.default.removeItem(at: folder)
+        }
+        source.set(folder.path, forKey: Defaults.Key.backupFolderPath.rawValue)
+        source.set("v", forKey: Defaults.Key.iceIcon.rawValue)
+
+        // Pre-seed two older backups so keeping:1 trims after the fresh write.
+        for stamp in ["2020-01-01-000000", "2020-01-02-000000"] {
+            try Data("x".utf8).write(to: folder.appending(path: "Ice-Settings-\(stamp).icebackup"))
+        }
+        // A far-future date makes the new file sort newest.
+        let url = try SettingsBackup.performBackup(
+            defaults: source, appVersion: "v", date: Date(timeIntervalSince1970: 2_000_000_000), keeping: 1
+        )
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        let remaining = SettingsBackup.listBackups(in: folder)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.lastPathComponent == url.lastPathComponent)
+    }
+
+    // MARK: - Folder / config helpers
+
+    @Test func defaultFolderIsDocumentsIceBackups() {
+        let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+        #expect(SettingsBackup.defaultFolder(home: home).path == "/Users/test/Documents/Ice Backups")
+    }
+
+    @Test func configuredFolderUsesStoredPathWhenSet() {
+        let (defaults, suite) = makeScratch()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        defaults.set("/tmp/my-backups", forKey: Defaults.Key.backupFolderPath.rawValue)
+        #expect(SettingsBackup.configuredFolder(defaults).path == "/tmp/my-backups")
+    }
+
+    @Test func configuredFolderFallsBackToDefaultWhenUnsetOrEmpty() {
+        let (defaults, suite) = makeScratch()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        #expect(SettingsBackup.configuredFolder(defaults) == SettingsBackup.defaultFolder())
+        defaults.set("", forKey: Defaults.Key.backupFolderPath.rawValue)
+        #expect(SettingsBackup.configuredFolder(defaults) == SettingsBackup.defaultFolder())
+    }
+
+    @Test func automaticBackupEnabledDefaultsTrueAndRespectsStored() {
+        let (defaults, suite) = makeScratch()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        #expect(SettingsBackup.automaticBackupEnabled(defaults))
+        defaults.set(false, forKey: Defaults.Key.automaticBackupEnabled.rawValue)
+        #expect(!SettingsBackup.automaticBackupEnabled(defaults))
+    }
+
+    @Test func currentAppVersionIsNonEmpty() {
+        #expect(!SettingsBackup.currentAppVersion.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary

Follows up the pure-logic test work by targeting the two areas called out as priorities: **backup/restore** and **layout movement**. Adds **11 test cases (108 → 119 total)**, all passing. No production code changes.

Scope decision: kept everything in ice-2 (no DragonKit changes). Note that backup/restore is duplicated — Ice uses its own `SettingsBackup`, while DragonKit ships an unused near-identical `DragonBackup`; consolidating/testing that shared engine in the dragon-kit repo is deferred.

### `SettingsBackupTests` — `SettingsBackup` 65% → **96%**
- `writeBackup` → `restore` file round-trip (incl. folder auto-creation)
- malformed-file rejection on restore
- `performBackup` writes to the configured folder and prunes to the retention limit
- folder/config helpers: `defaultFolder`, `configuredFolder` (set / unset / empty), `automaticBackupEnabled` (default + stored), `currentAppVersion`

### `MenuBarLayoutProfileTests` — layout profile model
- `applyProfile` throws `ApplyError` with no `AppState`
- `temporarilyShowGroup` returns 0 with no `AppState`
- `ApplyError.missingAppState` user-facing description

### Layout-movement scope
The profile/group **model** (capture, create, update, delete, section snapshots) is unit-tested. The actual movement **engine** (`MenuBarItemManager`, ~2k lines) moves real menu-bar items via synthesized CGEvents + Accessibility and needs a live session with granted permissions — it's covered by the manual test checklist, not units.

## Test plan
`xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS' -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO` → **TEST SUCCEEDED**, 119 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)