### PR TITLE
test: cover appearance configs, settings enums, and utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
   - `SettingsBackupTests` — `writeBackup`→`restore` round-trip, malformed-file rejection, `performBackup` write-and-prune, and the folder/config helpers (`defaultFolder`, `configuredFolder`, `automaticBackupEnabled`, `currentAppVersion`). Raises `SettingsBackup` coverage 65→96%.
   - `MenuBarLayoutProfileTests` — `applyProfile`/`temporarilyShowGroup` guards when no `AppState` is present, and the `ApplyError` description.
 - **Layout-movement note:** the profile/group *model* (capture, create, update, delete, section snapshots) is unit-tested, but the actual movement *engine* (`MenuBarItemManager`) drives real menu-bar items via synthesized CGEvents and Accessibility and can only be exercised by the manual test checklist, not units.
+- **Appearance configs, settings enums, and misc utilities.** Added 30 more test cases (119 → 149 total) across 5 new files:
+  - `AppearanceConfigTests` — `MenuBarEndCap`/`MenuBarShapeKind`/`MenuBarTintKind` metadata + `Codable`, and `MenuBarFullShapeInfo`/`MenuBarSplitShapeInfo` `hasRoundedShape`, defaults, and round-trips (→ 100%).
+  - `SettingsEnumsTests` — `RehideStrategy`, `IceBarAutoEnableMode`, `IceBarLocation`, `SectionDividerStyle` raw values, `allCases`, ids, localized titles, and out-of-range `init?` (`IceBarLocation` → 100%).
+  - `MenuBarTriggerTests` — `MenuBarTrigger.bundleIdentifier`/`matches`, action raw values, `Codable`, and `MenuBarTriggerTarget` equality.
+  - `UtilityHelpersTests` — `withMutableCopy` (mutation + throwing), `LocalizedErrorWrapper` (both branches, → 100%), `SystemAppearance` titles (→ 51%).
+  - `HotkeyTests` — `Hotkey` init, disabled-without-`AppState`, and `Equatable`/`Hashable` (→ 56%).
+- Whole-app line coverage moved 7.4% → 8.2%; the ceiling remains the GUI/system layer, which needs a live session, not units.
 
 ## 2.9.8 - 2026-07-10
 

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -7,14 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12863111709580A862D997E4 /* UtilityHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3EE3A5FEDD60DB5B5DF93F /* UtilityHelpersTests.swift */; };
 		170423D92B56DE78004A2549 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 170423D82B56DE78004A2549 /* Sparkle */; };
 		175061912B1543DD003144CD /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 175061902B1543DD003144CD /* LaunchAtLogin */; };
 		1787C4272B16890B002F50DF /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1787C4262B16890B002F50DF /* AXSwift */; };
 		17EA92DE1008D6773AC39E03 /* IceColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23731A85E77C82F006FD936 /* IceColorTests.swift */; };
 		17F71BB52B880B4500905CBA /* CompactSlider in Frameworks */ = {isa = PBXBuildFile; productRef = 17F71BB42B880B4500905CBA /* CompactSlider */; };
 		1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */; };
+		298CE54C9B0BE7DB32C3D2C3 /* MenuBarTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943118A230952141233F87D3 /* MenuBarTriggerTests.swift */; };
 		2BCF7F33DF18C9000C060A36 /* KeyCombinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D9FF7076B412B16B603C8C /* KeyCombinationTests.swift */; };
 		35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */; };
+		50F5DAA3F785CC10CAC28750 /* AppearanceConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD2B847F99761CDED955A3A /* AppearanceConfigTests.swift */; };
 		532D0E5212D395B68CA7F31E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */; };
 		5EE79BA2367FDAA95AF9CF2C /* IceGradientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */; };
 		7127A9FF2C4886D100D99DEF /* IfritStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 7127A9FE2C4886D100D99DEF /* IfritStatic */; };
@@ -22,8 +25,10 @@
 		7188A68C2E27F9ED008F131D /* MenuBarItemService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		71A065092E680C620087DB38 /* Semaphore in Frameworks */ = {isa = PBXBuildFile; productRef = 71A065082E680C620087DB38 /* Semaphore */; };
 		7937F9F0BC456A13B37FD10D /* ModifiersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4B03D73514A57A4612D4F6 /* ModifiersTests.swift */; };
+		83DC40FE39537ACCA4890A12 /* HotkeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B207F953D5E17989C6C3B5 /* HotkeyTests.swift */; };
 		861C26D46D9BD27B5C759FEF /* HotkeyActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */; };
 		883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */; };
+		95AE1A0B775C85363C4404DC /* SettingsEnumsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E9DDFB62D4FA07946CC797 /* SettingsEnumsTests.swift */; };
 		986A47EC7057DE6842643937 /* SettingsBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */; };
 		CB1C634067FACF3660D7435C /* KeyCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */; };
 		DA6DC1703A2B3C4D5E6F7083 /* DragonKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA6DC1702A2B3C4D5E6F7082 /* DragonKit */; };
@@ -65,6 +70,8 @@
 
 /* Begin PBXFileReference section */
 		12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsBackupTests.swift; sourceTree = "<group>"; };
+		2D3EE3A5FEDD60DB5B5DF93F /* UtilityHelpersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UtilityHelpersTests.swift; sourceTree = "<group>"; };
+		3DD2B847F99761CDED955A3A /* AppearanceConfigTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppearanceConfigTests.swift; sourceTree = "<group>"; };
 		4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarLayoutProfileTests.swift; sourceTree = "<group>"; };
 		5C4B03D73514A57A4612D4F6 /* ModifiersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModifiersTests.swift; sourceTree = "<group>"; };
 		61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IceGradientTests.swift; sourceTree = "<group>"; };
@@ -75,12 +82,15 @@
 		7C94DAF88A92F6747D67CCC8 /* PredicatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredicatesTests.swift; sourceTree = "<group>"; };
 		83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarSectionNameTests.swift; sourceTree = "<group>"; };
 		8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		943118A230952141233F87D3 /* MenuBarTriggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarTriggerTests.swift; sourceTree = "<group>"; };
 		9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyCodeTests.swift; sourceTree = "<group>"; };
 		BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		C23731A85E77C82F006FD936 /* IceColorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IceColorTests.swift; sourceTree = "<group>"; };
 		CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HotkeyActionTests.swift; sourceTree = "<group>"; };
 		D5D9FF7076B412B16B603C8C /* KeyCombinationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyCombinationTests.swift; sourceTree = "<group>"; };
+		E7E9DDFB62D4FA07946CC797 /* SettingsEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsEnumsTests.swift; sourceTree = "<group>"; };
 		F29224478E4DA927C88733C8 /* ExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
+		F6B207F953D5E17989C6C3B5 /* HotkeyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HotkeyTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -227,6 +237,11 @@
 				C23731A85E77C82F006FD936 /* IceColorTests.swift */,
 				61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */,
 				F29224478E4DA927C88733C8 /* ExtensionsTests.swift */,
+				3DD2B847F99761CDED955A3A /* AppearanceConfigTests.swift */,
+				E7E9DDFB62D4FA07946CC797 /* SettingsEnumsTests.swift */,
+				943118A230952141233F87D3 /* MenuBarTriggerTests.swift */,
+				2D3EE3A5FEDD60DB5B5DF93F /* UtilityHelpersTests.swift */,
+				F6B207F953D5E17989C6C3B5 /* HotkeyTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -421,6 +436,11 @@
 				17EA92DE1008D6773AC39E03 /* IceColorTests.swift in Sources */,
 				5EE79BA2367FDAA95AF9CF2C /* IceGradientTests.swift in Sources */,
 				DFBC7C32FBD412329442365B /* ExtensionsTests.swift in Sources */,
+				50F5DAA3F785CC10CAC28750 /* AppearanceConfigTests.swift in Sources */,
+				95AE1A0B775C85363C4404DC /* SettingsEnumsTests.swift in Sources */,
+				298CE54C9B0BE7DB32C3D2C3 /* MenuBarTriggerTests.swift in Sources */,
+				12863111709580A862D997E4 /* UtilityHelpersTests.swift in Sources */,
+				83DC40FE39537ACCA4890A12 /* HotkeyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/IceTests/AppearanceConfigTests.swift
+++ b/IceTests/AppearanceConfigTests.swift
@@ -1,0 +1,80 @@
+//
+//  AppearanceConfigTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct AppearanceConfigTests {
+    // MARK: MenuBarEndCap
+
+    @Test func endCapRawValuesAndCodable() throws {
+        #expect(MenuBarEndCap.square.rawValue == 0)
+        #expect(MenuBarEndCap.round.rawValue == 1)
+        #expect(MenuBarEndCap.allCases.count == 2)
+        for cap in MenuBarEndCap.allCases {
+            let data = try JSONEncoder().encode(cap)
+            #expect(try JSONDecoder().decode(MenuBarEndCap.self, from: data) == cap)
+        }
+    }
+
+    // MARK: MenuBarShapeKind / TintKind
+
+    @Test func shapeKindMetadata() {
+        #expect(MenuBarShapeKind.allCases.map(\.rawValue) == [0, 1, 2])
+        #expect(MenuBarShapeKind.split.id == 2)
+        #expect(MenuBarShapeKind.noShape.localized == "None")
+        #expect(MenuBarShapeKind.full.localized == "Full")
+        #expect(MenuBarShapeKind.split.localized == "Split")
+    }
+
+    @Test func tintKindMetadata() {
+        #expect(MenuBarTintKind.allCases.map(\.rawValue) == [0, 1, 2])
+        #expect(MenuBarTintKind.gradient.id == 2)
+        #expect(MenuBarTintKind.noTint.localized == "None")
+        #expect(MenuBarTintKind.solid.localized == "Solid")
+        #expect(MenuBarTintKind.gradient.localized == "Gradient")
+    }
+
+    // MARK: Full shape info
+
+    @Test func fullShapeHasRoundedShape() {
+        #expect(MenuBarFullShapeInfo(leadingEndCap: .round, trailingEndCap: .square).hasRoundedShape)
+        #expect(MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .round).hasRoundedShape)
+        #expect(!MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .square).hasRoundedShape)
+    }
+
+    @Test func fullShapeDefaultIsRounded() {
+        #expect(MenuBarFullShapeInfo.default.leadingEndCap == .round)
+        #expect(MenuBarFullShapeInfo.default.trailingEndCap == .round)
+        #expect(MenuBarFullShapeInfo.default.hasRoundedShape)
+    }
+
+    @Test func fullShapeCodableRoundTrip() throws {
+        let info = MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .round)
+        let data = try JSONEncoder().encode(info)
+        #expect(try JSONDecoder().decode(MenuBarFullShapeInfo.self, from: data) == info)
+    }
+
+    // MARK: Split shape info
+
+    @Test func splitShapeHasRoundedShapeWhenEitherSideIsRounded() {
+        let squareSide = MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .square)
+        let roundSide = MenuBarFullShapeInfo(leadingEndCap: .round, trailingEndCap: .square)
+        #expect(!MenuBarSplitShapeInfo(leading: squareSide, trailing: squareSide).hasRoundedShape)
+        #expect(MenuBarSplitShapeInfo(leading: roundSide, trailing: squareSide).hasRoundedShape)
+        #expect(MenuBarSplitShapeInfo(leading: squareSide, trailing: roundSide).hasRoundedShape)
+    }
+
+    @Test func splitShapeDefaultIsRounded() {
+        #expect(MenuBarSplitShapeInfo.default.hasRoundedShape)
+    }
+
+    @Test func splitShapeCodableRoundTrip() throws {
+        let info = MenuBarSplitShapeInfo.default
+        let data = try JSONEncoder().encode(info)
+        #expect(try JSONDecoder().decode(MenuBarSplitShapeInfo.self, from: data) == info)
+    }
+}

--- a/IceTests/HotkeyTests.swift
+++ b/IceTests/HotkeyTests.swift
@@ -1,0 +1,48 @@
+//
+//  HotkeyTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+@MainActor
+struct HotkeyTests {
+    private var combo: KeyCombination {
+        KeyCombination(key: .a, modifiers: [.command, .shift])
+    }
+
+    @Test func initStoresActionAndCombination() {
+        let hotkey = Hotkey(action: .toggleHiddenSection, keyCombination: combo)
+        #expect(hotkey.action == .toggleHiddenSection)
+        #expect(hotkey.keyCombination == combo)
+    }
+
+    @Test func isDisabledWithoutSetup() {
+        // Without an AppState, the listener can't register, so the hotkey
+        // stays disabled even once a key combination is assigned.
+        let hotkey = Hotkey(action: .toggleHiddenSection, keyCombination: nil)
+        #expect(!hotkey.isEnabled)
+        hotkey.keyCombination = combo   // triggers enable() → Listener init? → nil
+        #expect(!hotkey.isEnabled)
+        hotkey.disable()
+        #expect(!hotkey.isEnabled)
+    }
+
+    @Test func equalityConsidersActionAndCombination() {
+        let a = Hotkey(action: .toggleHiddenSection, keyCombination: combo)
+        let b = Hotkey(action: .toggleHiddenSection, keyCombination: combo)
+        let differentAction = Hotkey(action: .toggleAlwaysHiddenSection, keyCombination: combo)
+        let differentCombo = Hotkey(action: .toggleHiddenSection, keyCombination: nil)
+        #expect(a == b)
+        #expect(a != differentAction)
+        #expect(a != differentCombo)
+    }
+
+    @Test func hashMatchesForEqualHotkeys() {
+        let a = Hotkey(action: .searchMenuBarItems, keyCombination: combo)
+        let b = Hotkey(action: .searchMenuBarItems, keyCombination: combo)
+        #expect(a.hashValue == b.hashValue)
+    }
+}

--- a/IceTests/MenuBarTriggerTests.swift
+++ b/IceTests/MenuBarTriggerTests.swift
@@ -1,0 +1,55 @@
+//
+//  MenuBarTriggerTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct MenuBarTriggerTests {
+    private func trigger(
+        bundle: String = "com.apple.Safari",
+        action: MenuBarTrigger.Action = .showHiddenSection,
+        groupID: UUID? = nil
+    ) -> MenuBarTrigger {
+        MenuBarTrigger(
+            id: UUID(),
+            name: "Safari",
+            createdAt: Date(timeIntervalSince1970: 0),
+            condition: .frontmostApplication(bundleIdentifier: bundle),
+            action: action,
+            itemGroupID: groupID
+        )
+    }
+
+    @Test func bundleIdentifierReadsCondition() {
+        #expect(trigger(bundle: "com.apple.Mail").bundleIdentifier == "com.apple.Mail")
+    }
+
+    @Test func matchesOnlyTheConfiguredBundle() {
+        let t = trigger(bundle: "com.apple.Safari")
+        #expect(t.matches(frontmostBundleIdentifier: "com.apple.Safari"))
+        #expect(!t.matches(frontmostBundleIdentifier: "com.apple.Mail"))
+    }
+
+    @Test func actionRawValues() {
+        #expect(MenuBarTrigger.Action.showHiddenSection.rawValue == "showHiddenSection")
+        #expect(MenuBarTrigger.Action.temporarilyShowItemGroup.rawValue == "temporarilyShowItemGroup")
+    }
+
+    @Test func codableRoundTrip() throws {
+        let original = trigger(action: .temporarilyShowItemGroup, groupID: UUID())
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MenuBarTrigger.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func triggerTargetEquality() {
+        let id = UUID()
+        #expect(MenuBarTriggerTarget.hiddenSection == .hiddenSection)
+        #expect(MenuBarTriggerTarget.itemGroup(id) == .itemGroup(id))
+        #expect(MenuBarTriggerTarget.itemGroup(id) != .itemGroup(UUID()))
+        #expect(MenuBarTriggerTarget.itemGroup(id) != .hiddenSection)
+    }
+}

--- a/IceTests/SettingsEnumsTests.swift
+++ b/IceTests/SettingsEnumsTests.swift
@@ -1,0 +1,47 @@
+//
+//  SettingsEnumsTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct SettingsEnumsTests {
+    @Test func rehideStrategyMetadata() {
+        #expect(RehideStrategy.allCases.map(\.rawValue) == [0, 1, 2])
+        #expect(RehideStrategy.smart.id == 0)
+        #expect(RehideStrategy(rawValue: 1) == .timed)
+        #expect(RehideStrategy.smart.localized == "Smart")
+        #expect(RehideStrategy.timed.localized == "Timed")
+        #expect(RehideStrategy.focusedApp.localized == "Focused app")
+    }
+
+    @Test func iceBarAutoEnableModeMetadata() {
+        #expect(IceBarAutoEnableMode.allCases.map(\.rawValue) == [0, 1])
+        #expect(IceBarAutoEnableMode.screensWithNotch.id == 1)
+        #expect(IceBarAutoEnableMode.screenWidth.localized == "Screen width")
+        #expect(IceBarAutoEnableMode.screensWithNotch.localized == "Screen notch")
+    }
+
+    @Test func iceBarLocationMetadata() {
+        #expect(IceBarLocation.allCases.map(\.rawValue) == [0, 1, 2])
+        #expect(IceBarLocation.iceIcon.id == 2)
+        #expect(IceBarLocation.dynamic.localized == "Dynamic")
+        #expect(IceBarLocation.mousePointer.localized == "Mouse pointer")
+        #expect(IceBarLocation.iceIcon.localized == "Ice 2 icon")
+    }
+
+    @Test func sectionDividerStyleMetadata() {
+        #expect(SectionDividerStyle.allCases.map(\.rawValue) == [0, 1])
+        #expect(SectionDividerStyle.chevron.id == 1)
+        #expect(SectionDividerStyle.noDivider.localized == "None")
+        #expect(SectionDividerStyle.chevron.localized == "Chevron")
+    }
+
+    @Test func rawValueInitRejectsOutOfRange() {
+        #expect(RehideStrategy(rawValue: 99) == nil)
+        #expect(IceBarLocation(rawValue: -1) == nil)
+        #expect(SectionDividerStyle(rawValue: 5) == nil)
+    }
+}

--- a/IceTests/UtilityHelpersTests.swift
+++ b/IceTests/UtilityHelpersTests.swift
@@ -1,0 +1,69 @@
+//
+//  UtilityHelpersTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct UtilityHelpersTests {
+    // MARK: withMutableCopy
+
+    @Test func withMutableCopyReturnsMutatedCopy() {
+        let result = withMutableCopy(of: [1, 2, 3]) { $0.append(4) }
+        #expect(result == [1, 2, 3, 4])
+    }
+
+    @Test func withMutableCopyLeavesOriginalUntouched() {
+        let original = [1, 2, 3]
+        _ = withMutableCopy(of: original) { $0.removeAll() }
+        #expect(original == [1, 2, 3])
+    }
+
+    @Test func withMutableCopyPropagatesThrownError() {
+        struct Boom: Error {}
+        #expect(throws: Boom.self) {
+            try withMutableCopy(of: 0) { _ in throw Boom() }
+        }
+    }
+
+    // MARK: LocalizedErrorWrapper
+
+    @Test func wrapperPassesThroughLocalizedErrorFields() {
+        struct Detailed: LocalizedError {
+            var errorDescription: String? { "desc" }
+            var failureReason: String? { "reason" }
+            var helpAnchor: String? { "anchor" }
+            var recoverySuggestion: String? { "suggestion" }
+        }
+        let wrapped = LocalizedErrorWrapper(Detailed())
+        #expect(wrapped.errorDescription == "desc")
+        #expect(wrapped.failureReason == "reason")
+        #expect(wrapped.helpAnchor == "anchor")
+        #expect(wrapped.recoverySuggestion == "suggestion")
+    }
+
+    @Test func wrapperUsesLocalizedDescriptionForPlainError() {
+        let plain = NSError(domain: "IceTests", code: 7, userInfo: [NSLocalizedDescriptionKey: "plain failure"])
+        let wrapped = LocalizedErrorWrapper(plain)
+        #expect(wrapped.errorDescription == "plain failure")
+        #expect(wrapped.failureReason == nil)
+        #expect(wrapped.helpAnchor == nil)
+        #expect(wrapped.recoverySuggestion == nil)
+    }
+
+    // MARK: SystemAppearance
+
+    @Test func systemAppearanceTitleKeys() {
+        #expect(SystemAppearance.light.titleKey == "Light Appearance")
+        #expect(SystemAppearance.dark.titleKey == "Dark Appearance")
+    }
+
+    @MainActor
+    @Test func currentSystemAppearanceResolvesToALightOrDarkTitle() {
+        // Exercises the exact/best-match resolution against the host appearance.
+        let title = SystemAppearance.current.titleKey
+        #expect(title == "Light Appearance" || title == "Dark Appearance")
+    }
+}


### PR DESCRIPTION
## Summary

Continues raising ice-2 unit-test coverage on the pure-logic layer. Adds **30 test cases (119 → 149 total)**, all passing. No production code changes (tests + target registration only).

### New test files
- `AppearanceConfigTests` — `MenuBarEndCap`, `MenuBarShapeKind`, `MenuBarTintKind` metadata + `Codable`; `MenuBarFullShapeInfo`/`MenuBarSplitShapeInfo` `hasRoundedShape`, defaults, and round-trips. **→ 100%** on all three config files.
- `SettingsEnumsTests` — `RehideStrategy`, `IceBarAutoEnableMode`, `IceBarLocation`, `SectionDividerStyle`: raw values, `allCases`, ids, localized titles, out-of-range `init?`. **`IceBarLocation` → 100%**.
- `MenuBarTriggerTests` — `MenuBarTrigger.bundleIdentifier`/`matches`, action raw values, `Codable` round-trip, `MenuBarTriggerTarget` equality.
- `UtilityHelpersTests` — `withMutableCopy` (mutation + throwing), `LocalizedErrorWrapper` (both branches → **100%**), `SystemAppearance` titles (→ 51%).
- `HotkeyTests` — `Hotkey` init, disabled-without-`AppState`, `Equatable`/`Hashable` (→ 56%).

### Coverage
`MenuBarShapes`/`MenuBarTintKind`/`IceBarLocation`/`LocalizedErrorWrapper`/`Helpers` → 100%; `Hotkey` 40→56%; `SystemAppearance` → 51%. The settings-model *enums* are now covered; their `ObservableObject` classes remain uncovered (bound to global `Defaults` + `AppState`, not safely unit-testable). Whole-app coverage 7.4% → 8.2%.

## Test plan
`xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS' -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO` → **TEST SUCCEEDED**, 149 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)