### PR TITLE
test: cover settings-model load/persist via injectable Defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - `UtilityHelpersTests` — `withMutableCopy` (mutation + throwing), `LocalizedErrorWrapper` (both branches, → 100%), `SystemAppearance` titles (→ 51%).
   - `HotkeyTests` — `Hotkey` init, disabled-without-`AppState`, and `Equatable`/`Hashable` (→ 56%).
 - Whole-app line coverage moved 7.4% → 8.2%; the ceiling remains the GUI/system layer, which needs a live session, not units.
+- **Settings-model load & persistence.** Made the `Defaults` helper's backing store injectable (new `Defaults.store`, defaulting to `.standard` — behavior-preserving) so the settings models can be driven headlessly against a throwaway `UserDefaults` suite. Added 9 test cases in a serialized `DefaultsAndSettingsLoadTests` suite covering the `Defaults` wrapper and the `GeneralSettings`/`AdvancedSettings`/`MenuBarTriggerSettings` load & persist paths (constructing a real, un-booted `AppState`). Coverage: `GeneralSettings` 10→91%, `AdvancedSettings` 14→100%, `Defaults` 0→81%, `MenuBarTriggerSettings` 10→52%. Whole-app line coverage 8.2% → 10.6%.
 
 ## 2.9.8 - 2026-07-10
 

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */; };
 		95AE1A0B775C85363C4404DC /* SettingsEnumsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E9DDFB62D4FA07946CC797 /* SettingsEnumsTests.swift */; };
 		986A47EC7057DE6842643937 /* SettingsBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */; };
+		BAA1F5944C8280680E42F490 /* DefaultsAndSettingsLoadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A415CBF1182F36DCF75316EC /* DefaultsAndSettingsLoadTests.swift */; };
 		CB1C634067FACF3660D7435C /* KeyCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */; };
 		DA6DC1703A2B3C4D5E6F7083 /* DragonKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA6DC1702A2B3C4D5E6F7082 /* DragonKit */; };
 		DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */; };
@@ -84,6 +85,7 @@
 		8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		943118A230952141233F87D3 /* MenuBarTriggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarTriggerTests.swift; sourceTree = "<group>"; };
 		9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyCodeTests.swift; sourceTree = "<group>"; };
+		A415CBF1182F36DCF75316EC /* DefaultsAndSettingsLoadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultsAndSettingsLoadTests.swift; sourceTree = "<group>"; };
 		BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		C23731A85E77C82F006FD936 /* IceColorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IceColorTests.swift; sourceTree = "<group>"; };
 		CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HotkeyActionTests.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				943118A230952141233F87D3 /* MenuBarTriggerTests.swift */,
 				2D3EE3A5FEDD60DB5B5DF93F /* UtilityHelpersTests.swift */,
 				F6B207F953D5E17989C6C3B5 /* HotkeyTests.swift */,
+				A415CBF1182F36DCF75316EC /* DefaultsAndSettingsLoadTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -441,6 +444,7 @@
 				298CE54C9B0BE7DB32C3D2C3 /* MenuBarTriggerTests.swift in Sources */,
 				12863111709580A862D997E4 /* UtilityHelpersTests.swift in Sources */,
 				83DC40FE39537ACCA4890A12 /* HotkeyTests.swift in Sources */,
+				BAA1F5944C8280680E42F490 /* DefaultsAndSettingsLoadTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -6,10 +6,14 @@
 import Foundation
 
 enum Defaults {
+    /// The backing store for all reads and writes. Defaults to
+    /// `.standard`; overridable in tests to point at a throwaway suite.
+    nonisolated(unsafe) static var store: UserDefaults = .standard
+
     /// Returns a dictionary containing the keys and values for
     /// the defaults meant to be seen by all applications.
     static var globalDomain: [String: Any] {
-        UserDefaults.standard.persistentDomain(forName: UserDefaults.globalDomain) ?? [:]
+        store.persistentDomain(forName: UserDefaults.globalDomain) ?? [:]
     }
 
     /// Returns the object for the specified key.
@@ -17,7 +21,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func object(forKey key: Key) -> Any? {
-        UserDefaults.standard.object(forKey: key.rawValue)
+        store.object(forKey: key.rawValue)
     }
 
     /// Returns the string for the specified key.
@@ -25,7 +29,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func string(forKey key: Key) -> String? {
-        UserDefaults.standard.string(forKey: key.rawValue)
+        store.string(forKey: key.rawValue)
     }
 
     /// Returns the array for the specified key.
@@ -33,7 +37,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func array(forKey key: Key) -> [Any]? {
-        UserDefaults.standard.array(forKey: key.rawValue)
+        store.array(forKey: key.rawValue)
     }
 
     /// Returns the dictionary for the specified key.
@@ -41,7 +45,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func dictionary(forKey key: Key) -> [String: Any]? {
-        UserDefaults.standard.dictionary(forKey: key.rawValue)
+        store.dictionary(forKey: key.rawValue)
     }
 
     /// Returns the data for the specified key.
@@ -49,7 +53,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func data(forKey key: Key) -> Data? {
-        UserDefaults.standard.data(forKey: key.rawValue)
+        store.data(forKey: key.rawValue)
     }
 
     /// Returns the string array for the specified key.
@@ -57,7 +61,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func stringArray(forKey key: Key) -> [String]? {
-        UserDefaults.standard.stringArray(forKey: key.rawValue)
+        store.stringArray(forKey: key.rawValue)
     }
 
     /// Returns the integer value for the specified key.
@@ -65,7 +69,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func integer(forKey key: Key) -> Int {
-        UserDefaults.standard.integer(forKey: key.rawValue)
+        store.integer(forKey: key.rawValue)
     }
 
     /// Returns the single precision floating point value for
@@ -74,7 +78,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func float(forKey key: Key) -> Float {
-        UserDefaults.standard.float(forKey: key.rawValue)
+        store.float(forKey: key.rawValue)
     }
 
     /// Returns the double precision floating point value for
@@ -83,7 +87,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func double(forKey key: Key) -> Double {
-        UserDefaults.standard.double(forKey: key.rawValue)
+        store.double(forKey: key.rawValue)
     }
 
     /// Returns the Boolean value for the specified key.
@@ -91,7 +95,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func bool(forKey key: Key) -> Bool {
-        UserDefaults.standard.bool(forKey: key.rawValue)
+        store.bool(forKey: key.rawValue)
     }
 
     /// Returns the url for the specified key.
@@ -99,7 +103,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to retrieve the value for.
     static func url(forKey key: Key) -> URL? {
-        UserDefaults.standard.url(forKey: key.rawValue)
+        store.url(forKey: key.rawValue)
     }
 
     /// Sets the value for the specified key.
@@ -107,7 +111,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to set the value for.
     static func set(_ value: Any?, forKey key: Key) {
-        UserDefaults.standard.set(value, forKey: key.rawValue)
+        store.set(value, forKey: key.rawValue)
     }
 
     /// Removes the value of the specified key.
@@ -115,7 +119,7 @@ enum Defaults {
     /// - Parameter key: The key in the UserDefaults database
     ///   to remove the value for.
     static func removeObject(forKey key: Key) {
-        UserDefaults.standard.removeObject(forKey: key.rawValue)
+        store.removeObject(forKey: key.rawValue)
     }
 
     /// Retrieves the value for the given key, and, if it is

--- a/IceTests/DefaultsAndSettingsLoadTests.swift
+++ b/IceTests/DefaultsAndSettingsLoadTests.swift
@@ -1,0 +1,189 @@
+//
+//  DefaultsAndSettingsLoadTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+/// These tests swap the process-wide `Defaults.store` to a throwaway suite, so
+/// the suite is `.serialized` to prevent them from racing each other on that
+/// shared seam. No other test touches `Defaults.store`.
+@Suite(.serialized)
+struct DefaultsAndSettingsLoadTests {
+    /// Installs a fresh throwaway store, runs `body`, then restores the previous
+    /// store and deletes the suite.
+    private func withScratchStore(_ body: (UserDefaults) throws -> Void) rethrows {
+        let name = "IceTests.defaults." + UUID().uuidString
+        let scratch = UserDefaults(suiteName: name)!
+        let previous = Defaults.store
+        Defaults.store = scratch
+        defer {
+            Defaults.store = previous
+            UserDefaults.standard.removePersistentDomain(forName: name)
+        }
+        try body(scratch)
+    }
+
+    @MainActor
+    private func withScratchStore(_ body: (UserDefaults) async throws -> Void) async rethrows {
+        let name = "IceTests.defaults." + UUID().uuidString
+        let scratch = UserDefaults(suiteName: name)!
+        let previous = Defaults.store
+        Defaults.store = scratch
+        defer {
+            Defaults.store = previous
+            UserDefaults.standard.removePersistentDomain(forName: name)
+        }
+        try await body(scratch)
+    }
+
+    // MARK: - Defaults wrapper
+
+    @Test func typedAccessorsReadThroughStore() {
+        withScratchStore { scratch in
+            scratch.set("s", forKey: Defaults.Key.iceIcon.rawValue)
+            scratch.set(3, forKey: Defaults.Key.showOnHoverDelay.rawValue)
+            scratch.set(1.5, forKey: Defaults.Key.rehideInterval.rawValue)
+            scratch.set(true, forKey: Defaults.Key.useIceBar.rawValue)
+            scratch.set(Data("x".utf8), forKey: Defaults.Key.hotkeys.rawValue)
+
+            #expect(Defaults.string(forKey: .iceIcon) == "s")
+            #expect(Defaults.object(forKey: .iceIcon) as? String == "s")
+            #expect(Defaults.integer(forKey: .showOnHoverDelay) == 3)
+            #expect(Defaults.double(forKey: .rehideInterval) == 1.5)
+            #expect(Defaults.bool(forKey: .useIceBar))
+            #expect(Defaults.data(forKey: .hotkeys) == Data("x".utf8))
+        }
+    }
+
+    @Test func setAndRemoveRoundTrip() {
+        withScratchStore { _ in
+            Defaults.set("hello", forKey: .iceIcon)
+            #expect(Defaults.string(forKey: .iceIcon) == "hello")
+            Defaults.removeObject(forKey: .iceIcon)
+            #expect(Defaults.object(forKey: .iceIcon) == nil)
+        }
+    }
+
+    @Test func arrayAndDictionaryAccessors() {
+        withScratchStore { _ in
+            Defaults.set(["a", "b"], forKey: .menuBarSpacers)
+            Defaults.set(["k": 1], forKey: .sections)
+            #expect(Defaults.array(forKey: .menuBarSpacers)?.count == 2)
+            #expect(Defaults.stringArray(forKey: .menuBarSpacers) == ["a", "b"])
+            #expect(Defaults.dictionary(forKey: .sections)?["k"] as? Int == 1)
+        }
+    }
+
+    @Test func ifPresentAssignsOnlyWhenPresentAndTypeMatches() {
+        withScratchStore { _ in
+            var value = "default"
+            Defaults.ifPresent(key: .iceIcon, assign: &value)
+            #expect(value == "default") // absent → unchanged
+
+            Defaults.set("stored", forKey: .iceIcon)
+            Defaults.ifPresent(key: .iceIcon, assign: &value)
+            #expect(value == "stored") // present → assigned
+        }
+    }
+
+    @Test func ifPresentBodyRunsOnlyWhenPresent() {
+        withScratchStore { _ in
+            var ran = false
+            Defaults.ifPresent(key: .rehideStrategy) { (_: Int) in ran = true }
+            #expect(!ran)
+
+            Defaults.set(2, forKey: .rehideStrategy)
+            var captured: Int?
+            Defaults.ifPresent(key: .rehideStrategy) { (value: Int) in captured = value }
+            #expect(captured == 2)
+        }
+    }
+
+    // MARK: - GeneralSettings load
+
+    @MainActor
+    @Test func generalSettingsLoadsStoredValues() async {
+        await withScratchStore { scratch in
+            scratch.set(false, forKey: Defaults.Key.showIceIcon.rawValue)
+            scratch.set(true, forKey: Defaults.Key.useIceBar.rawValue)
+            scratch.set(42.0, forKey: Defaults.Key.rehideInterval.rawValue)
+            scratch.set(RehideStrategy.timed.rawValue, forKey: Defaults.Key.rehideStrategy.rawValue)
+            scratch.set(IceBarLocation.iceIcon.rawValue, forKey: Defaults.Key.iceBarLocation.rawValue)
+            scratch.set(IceBarAutoEnableMode.screensWithNotch.rawValue, forKey: Defaults.Key.iceBarAutoEnableMode.rawValue)
+
+            let settings = GeneralSettings()
+            settings.performSetup(with: AppState())
+            // Let the @Published persistence sinks fire their initial values.
+            try? await Task.sleep(for: .milliseconds(50))
+
+            #expect(settings.showIceIcon == false)
+            #expect(settings.useIceBar == true)
+            #expect(settings.rehideInterval == 42.0)
+            #expect(settings.rehideStrategy == .timed)
+            #expect(settings.iceBarLocation == .iceIcon)
+            #expect(settings.iceBarAutoEnableMode == .screensWithNotch)
+        }
+    }
+
+    @MainActor
+    @Test func generalSettingsPersistsChangesToStore() async {
+        await withScratchStore { scratch in
+            let settings = GeneralSettings()
+            settings.performSetup(with: AppState())
+
+            settings.useIceBar = true
+            settings.rehideStrategy = .focusedApp
+            try? await Task.sleep(for: .milliseconds(50))
+
+            #expect(scratch.bool(forKey: Defaults.Key.useIceBar.rawValue))
+            #expect(scratch.integer(forKey: Defaults.Key.rehideStrategy.rawValue) == RehideStrategy.focusedApp.rawValue)
+        }
+    }
+
+    // MARK: - AdvancedSettings load
+
+    @MainActor
+    @Test func advancedSettingsLoadsStoredValues() async {
+        await withScratchStore { scratch in
+            scratch.set(false, forKey: Defaults.Key.enableAlwaysHiddenSection.rawValue)
+            scratch.set(99.0, forKey: Defaults.Key.tempShowInterval.rawValue)
+            scratch.set(SectionDividerStyle.chevron.rawValue, forKey: Defaults.Key.sectionDividerStyle.rawValue)
+
+            let settings = AdvancedSettings()
+            settings.performSetup(with: AppState())
+            try? await Task.sleep(for: .milliseconds(50))
+
+            #expect(settings.enableAlwaysHiddenSection == false)
+            #expect(settings.tempShowInterval == 99.0)
+            #expect(settings.sectionDividerStyle == .chevron)
+        }
+    }
+
+    // MARK: - MenuBarTriggerSettings load
+
+    @MainActor
+    @Test func triggerSettingsDecodesStoredTriggers() async throws {
+        try await withScratchStore { scratch in
+            let trigger = MenuBarTrigger(
+                id: UUID(),
+                name: "Safari",
+                createdAt: Date(timeIntervalSince1970: 0),
+                condition: .frontmostApplication(bundleIdentifier: "com.apple.Safari"),
+                action: .showHiddenSection,
+                itemGroupID: nil
+            )
+            let data = try JSONEncoder().encode([trigger])
+            scratch.set(data, forKey: Defaults.Key.menuBarTriggers.rawValue)
+
+            let settings = MenuBarTriggerSettings()
+            settings.performSetup(with: AppState())
+            try? await Task.sleep(for: .milliseconds(50))
+
+            #expect(settings.triggers.count == 1)
+            #expect(settings.triggers.first?.bundleIdentifier == "com.apple.Safari")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Raises coverage of the **settings-model classes** — the biggest remaining testable-but-uncovered chunk — by driving them **headlessly** (no XCUITest, no app launch, no TCC, CI-friendly). Adds **9 test cases (149 → 158)**, all passing.

### One small production change
`Defaults` now reads/writes through an injectable `Defaults.store` (defaults to `.standard`). Behavior-preserving — the app is unchanged; tests can point it at a throwaway `UserDefaults` suite.

### Why headless works
`AppState`'s heavy wiring (event taps, menu bar, permissions) lives in a **lazy `setupTask`** that only runs on `performSetup(hasPermissions:)`. Constructing `AppState()` alone just allocates managers with no side effects, so a settings model's `performSetup(with:)` can run in the unit-test host. Verified: `MenuBarItemSpacingManager.offset` is an inert stored property, so the settings sinks fire nothing dangerous.

### New tests (`DefaultsAndSettingsLoadTests`, `.serialized`)
- `Defaults` wrapper — typed accessors, `set`/`removeObject`, array/dictionary/stringArray, and both `ifPresent` variants (present/absent). **0 → 81%**.
- `GeneralSettings` — loads stored values (bools, doubles, enum raw values) and persists changes back to the store. **10 → 91%**.
- `AdvancedSettings` — loads stored values. **14 → 100%**.
- `MenuBarTriggerSettings` — decodes stored triggers. **10 → 52%**.

The suite is `.serialized` because it swaps the process-wide `Defaults.store`; no other suite touches it.

### Coverage
Whole-app line coverage **8.2% → 10.6%** (largest jump so far, crossing into double digits).

## Test plan
`xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS' -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO` → **TEST SUCCEEDED**, 158 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)