### PR TITLE
test: cover HotkeysSettings load/persist headlessly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   - `HotkeyTests` — `Hotkey` init, disabled-without-`AppState`, and `Equatable`/`Hashable` (→ 56%).
 - Whole-app line coverage moved 7.4% → 8.2%; the ceiling remains the GUI/system layer, which needs a live session, not units.
 - **Settings-model load & persistence.** Made the `Defaults` helper's backing store injectable (new `Defaults.store`, defaulting to `.standard` — behavior-preserving) so the settings models can be driven headlessly against a throwaway `UserDefaults` suite. Added 9 test cases in a serialized `DefaultsAndSettingsLoadTests` suite covering the `Defaults` wrapper and the `GeneralSettings`/`AdvancedSettings`/`MenuBarTriggerSettings` load & persist paths (constructing a real, un-booted `AppState`). Coverage: `GeneralSettings` 10→91%, `AdvancedSettings` 14→100%, `Defaults` 0→81%, `MenuBarTriggerSettings` 10→52%. Whole-app line coverage 8.2% → 10.6%.
+- **Hotkeys settings.** Added 4 more test cases (158 → 162 total) for `HotkeysSettings`: one hotkey per action, `hotkey(withAction:)` lookup, and load/persist of a stored key combination (which also exercises real registration). Coverage: `HotkeysSettings` 12→90%, `Hotkey` 56→84%, `HotkeyRegistry` 1→45%. Whole-app line coverage 10.6% → 11.5%.
 
 ## 2.9.8 - 2026-07-10
 

--- a/IceTests/DefaultsAndSettingsLoadTests.swift
+++ b/IceTests/DefaultsAndSettingsLoadTests.swift
@@ -186,4 +186,57 @@ struct DefaultsAndSettingsLoadTests {
             #expect(settings.triggers.first?.bundleIdentifier == "com.apple.Safari")
         }
     }
+
+    // MARK: - HotkeysSettings
+
+    @MainActor
+    @Test func hotkeysSettingsHasOneHotkeyPerActionInitiallyUnset() {
+        let settings = HotkeysSettings()
+        #expect(settings.hotkeys.count == HotkeyAction.allCases.count)
+        let actions = Set(settings.hotkeys.map(\.action))
+        #expect(actions == Set(HotkeyAction.allCases))
+        #expect(settings.hotkeys.allSatisfy { $0.keyCombination == nil })
+    }
+
+    @MainActor
+    @Test func hotkeyWithActionReturnsMatchingHotkey() {
+        let settings = HotkeysSettings()
+        #expect(settings.hotkey(withAction: .searchMenuBarItems)?.action == .searchMenuBarItems)
+        #expect(settings.hotkey(withAction: .toggleHiddenSection)?.action == .toggleHiddenSection)
+    }
+
+    @MainActor
+    @Test func hotkeysSettingsLoadsStoredCombination() async throws {
+        try await withScratchStore { scratch in
+            // Obscure combination that can't collide with a real global hotkey.
+            let combo = KeyCombination(key: .f19, modifiers: [.control, .option, .command])
+            let data = try JSONEncoder().encode(combo as KeyCombination?)
+            scratch.set([HotkeyAction.searchMenuBarItems.rawValue: data], forKey: Defaults.Key.hotkeys.rawValue)
+
+            let settings = HotkeysSettings()
+            settings.performSetup(with: AppState())
+            try? await Task.sleep(for: .milliseconds(50))
+
+            #expect(settings.hotkey(withAction: .searchMenuBarItems)?.keyCombination == combo)
+            // Actions with no stored combination stay unset.
+            #expect(settings.hotkey(withAction: .toggleAutoRehide)?.keyCombination == nil)
+        }
+    }
+
+    @MainActor
+    @Test func hotkeysSettingsPersistsCombinationChange() async throws {
+        try await withScratchStore { scratch in
+            let settings = HotkeysSettings()
+            settings.performSetup(with: AppState())
+
+            let combo = KeyCombination(key: .f19, modifiers: [.control, .option, .command])
+            settings.hotkey(withAction: .enableIceBar)?.keyCombination = combo
+            try? await Task.sleep(for: .milliseconds(50))
+
+            let dict = try #require(scratch.dictionary(forKey: Defaults.Key.hotkeys.rawValue) as? [String: Data])
+            let stored = try #require(dict[HotkeyAction.enableIceBar.rawValue])
+            let decoded = try JSONDecoder().decode(KeyCombination?.self, from: stored)
+            #expect(decoded == combo)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Extends the headless settings-model testing to `HotkeysSettings`. Adds **4 test cases (158 → 162 total)**, all passing. No production code changes.

- one `Hotkey` per `HotkeyAction`, initially unset
- `hotkey(withAction:)` lookup
- load a stored key combination via `performSetup(with: AppState())`
- persist a key-combination change back to the `Defaults` store

### Coverage
`HotkeysSettings` 12 → **90%**, `Hotkey` 56 → **84%**, `HotkeyRegistry` 1 → **45%** (the load test exercises real registration). Whole-app **10.6% → 11.5%**.

### Validity (mutation-tested)
To confirm the suite actually catches regressions, I injected three bugs and ran the suite — each was caught by exactly the covering test(s), then reverted:
- `Modifiers` `⌘`→`MUTANT` → `symbolicValueOrdersControlOptionShiftCommand` + `displayValueJoinsModifiersAndCapitalizedKey`
- `SettingsBackup.apply` skips removal → `applyIsReplaceNotMerge`
- `GeneralSettings` drops `useIceBar` load → `generalSettingsLoadsStoredValues`

## Test plan
`xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS' -enableCodeCoverage YES CODE_SIGNING_ALLOWED=NO` → **TEST SUCCEEDED**, 162 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)