### PR TITLE
release: v2.9.10 — fix NaN menu bar color, speed up wallpaper lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.9.10 - 2026-07-25
+
+### Fixed
+
+- **The menu bar color can no longer be calculated from an empty screen capture.** When a capture of the menu bar area came back completely transparent — which can happen while displays are being reconfigured or right after waking from sleep — Ice 2 produced an invalid ("not a number") average color and passed it along as if it were real, which could tint the Ice 2 Bar or the item search panel with a garbage color. Ice 2 now treats an empty capture as "no color available" and keeps the previous color instead.
+
+### Improved
+
+- **Faster lookup of the wallpaper behind the menu bar.** This lookup inspected each window's owning application before checking its title, which meant building a process object for every window on screen. Checking the title first makes the scan roughly 40× faster (about 1 ms down to 25 µs on a typical desktop). It runs whenever Ice 2 refreshes the menu bar appearance overlay, the Ice 2 Bar, or the item search panel.
+
+### Behind the scenes
+
+- **More automated checks.** The test suite grew from 162 to 261 checks, now also covering menu bar image processing, appearance-settings upgrades, menu bar window identification, and the shared concurrency helpers. Both fixes above were found while writing those tests.
+
 ## 2.9.9 - 2026-07-11
 
 ### Behind the scenes

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -14,12 +14,16 @@
 		17EA92DE1008D6773AC39E03 /* IceColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23731A85E77C82F006FD936 /* IceColorTests.swift */; };
 		17F71BB52B880B4500905CBA /* CompactSlider in Frameworks */ = {isa = PBXBuildFile; productRef = 17F71BB42B880B4500905CBA /* CompactSlider */; };
 		1B8351CC0D124C9F10C178D1 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */; };
+		207AAA1C30BD781DF04675E0 /* ObjectStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15FF0BDD5C41C98A91805B7 /* ObjectStorageTests.swift */; };
 		298CE54C9B0BE7DB32C3D2C3 /* MenuBarTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943118A230952141233F87D3 /* MenuBarTriggerTests.swift */; };
 		2BCF7F33DF18C9000C060A36 /* KeyCombinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5D9FF7076B412B16B603C8C /* KeyCombinationTests.swift */; };
 		35564E94C0C83A0B3313403A /* MenuBarItemTagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */; };
+		4728C5A92AD442D6FBEFD00A /* PublisherOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6511C5168A7BF558CE9FAFF7 /* PublisherOperatorTests.swift */; };
 		50F5DAA3F785CC10CAC28750 /* AppearanceConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD2B847F99761CDED955A3A /* AppearanceConfigTests.swift */; };
 		532D0E5212D395B68CA7F31E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */; };
 		5EE79BA2367FDAA95AF9CF2C /* IceGradientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */; };
+		6AA9FF5BA60A12C390EECE31 /* WindowInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF413CD9CC7D016105A22EF0 /* WindowInfoTests.swift */; };
+		6BA9AD8CA208DCE48761A132 /* ConcurrencyHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99044B6F44B0A594C1C1812A /* ConcurrencyHelpersTests.swift */; };
 		7127A9FF2C4886D100D99DEF /* IfritStatic in Frameworks */ = {isa = PBXBuildFile; productRef = 7127A9FE2C4886D100D99DEF /* IfritStatic */; };
 		7168EE532E281CBC00FF9830 /* AXSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7168EE522E281CBC00FF9830 /* AXSwift */; };
 		7188A68C2E27F9ED008F131D /* MenuBarItemService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = 7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -28,14 +32,18 @@
 		83DC40FE39537ACCA4890A12 /* HotkeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B207F953D5E17989C6C3B5 /* HotkeyTests.swift */; };
 		861C26D46D9BD27B5C759FEF /* HotkeyActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */; };
 		883544A1BDB23DEB15E409B2 /* MenuBarLayoutProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */; };
+		91967593C089C4EA20BA497D /* SharedExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF2282483FF8E16A487D9C3 /* SharedExtensionsTests.swift */; };
 		95AE1A0B775C85363C4404DC /* SettingsEnumsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E9DDFB62D4FA07946CC797 /* SettingsEnumsTests.swift */; };
 		986A47EC7057DE6842643937 /* SettingsBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */; };
+		B7A44344DAD9EC55EEE80484 /* AppearanceConfigurationV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F665A8F8A6DCDEFFC549933 /* AppearanceConfigurationV2Tests.swift */; };
 		BAA1F5944C8280680E42F490 /* DefaultsAndSettingsLoadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A415CBF1182F36DCF75316EC /* DefaultsAndSettingsLoadTests.swift */; };
 		CB1C634067FACF3660D7435C /* KeyCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */; };
 		DA6DC1703A2B3C4D5E6F7083 /* DragonKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA6DC1702A2B3C4D5E6F7082 /* DragonKit */; };
 		DCC69CC55ECE780ACFFCE0E3 /* MenuBarSectionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */; };
 		DFBC7C32FBD412329442365B /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29224478E4DA927C88733C8 /* ExtensionsTests.swift */; };
+		EB7044F527F93442F4101F0D /* CodeSigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEBB5C379A572DC09662235 /* CodeSigningTests.swift */; };
 		EEC5232C90D9CEE81286467E /* PredicatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C94DAF88A92F6747D67CCC8 /* PredicatesTests.swift */; };
+		F19D55B35458F123AD7FFEF5 /* CGImageProcessingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371FFD52849B676061381844 /* CGImageProcessingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,25 +80,33 @@
 /* Begin PBXFileReference section */
 		12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsBackupTests.swift; sourceTree = "<group>"; };
 		2D3EE3A5FEDD60DB5B5DF93F /* UtilityHelpersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UtilityHelpersTests.swift; sourceTree = "<group>"; };
+		371FFD52849B676061381844 /* CGImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGImageProcessingTests.swift; sourceTree = "<group>"; };
 		3DD2B847F99761CDED955A3A /* AppearanceConfigTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppearanceConfigTests.swift; sourceTree = "<group>"; };
 		4A5B2BD6986E421B6263F2D3 /* MenuBarLayoutProfileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarLayoutProfileTests.swift; sourceTree = "<group>"; };
 		5C4B03D73514A57A4612D4F6 /* ModifiersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModifiersTests.swift; sourceTree = "<group>"; };
 		61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IceGradientTests.swift; sourceTree = "<group>"; };
+		6511C5168A7BF558CE9FAFF7 /* PublisherOperatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PublisherOperatorTests.swift; sourceTree = "<group>"; };
 		6866D199BAA4CC3EF01677AD /* MenuBarItemTagTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarItemTagTests.swift; sourceTree = "<group>"; };
 		7166832A2A767E6A006ABF84 /* Ice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Ice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7188A6832E27F9ED008F131D /* MenuBarItemService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = MenuBarItemService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		76B9EDF33EEA9E254E354B9C /* SmokeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
 		7C94DAF88A92F6747D67CCC8 /* PredicatesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PredicatesTests.swift; sourceTree = "<group>"; };
+		7F665A8F8A6DCDEFFC549933 /* AppearanceConfigurationV2Tests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppearanceConfigurationV2Tests.swift; sourceTree = "<group>"; };
 		83522341C381D492260EB102 /* MenuBarSectionNameTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarSectionNameTests.swift; sourceTree = "<group>"; };
 		8D4AA61E3DFF2CBC460604F1 /* IceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		943118A230952141233F87D3 /* MenuBarTriggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MenuBarTriggerTests.swift; sourceTree = "<group>"; };
+		99044B6F44B0A594C1C1812A /* ConcurrencyHelpersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrencyHelpersTests.swift; sourceTree = "<group>"; };
 		9B081058EC5AE64B9D485511 /* KeyCodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyCodeTests.swift; sourceTree = "<group>"; };
+		A15FF0BDD5C41C98A91805B7 /* ObjectStorageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ObjectStorageTests.swift; sourceTree = "<group>"; };
 		A415CBF1182F36DCF75316EC /* DefaultsAndSettingsLoadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultsAndSettingsLoadTests.swift; sourceTree = "<group>"; };
+		AAF2282483FF8E16A487D9C3 /* SharedExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedExtensionsTests.swift; sourceTree = "<group>"; };
 		BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		BDEBB5C379A572DC09662235 /* CodeSigningTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodeSigningTests.swift; sourceTree = "<group>"; };
 		C23731A85E77C82F006FD936 /* IceColorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IceColorTests.swift; sourceTree = "<group>"; };
 		CEC00E31681F07866FE98D6B /* HotkeyActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HotkeyActionTests.swift; sourceTree = "<group>"; };
 		D5D9FF7076B412B16B603C8C /* KeyCombinationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyCombinationTests.swift; sourceTree = "<group>"; };
 		E7E9DDFB62D4FA07946CC797 /* SettingsEnumsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsEnumsTests.swift; sourceTree = "<group>"; };
+		EF413CD9CC7D016105A22EF0 /* WindowInfoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WindowInfoTests.swift; sourceTree = "<group>"; };
 		F29224478E4DA927C88733C8 /* ExtensionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
 		F6B207F953D5E17989C6C3B5 /* HotkeyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HotkeyTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -245,6 +261,14 @@
 				2D3EE3A5FEDD60DB5B5DF93F /* UtilityHelpersTests.swift */,
 				F6B207F953D5E17989C6C3B5 /* HotkeyTests.swift */,
 				A415CBF1182F36DCF75316EC /* DefaultsAndSettingsLoadTests.swift */,
+				7F665A8F8A6DCDEFFC549933 /* AppearanceConfigurationV2Tests.swift */,
+				371FFD52849B676061381844 /* CGImageProcessingTests.swift */,
+				99044B6F44B0A594C1C1812A /* ConcurrencyHelpersTests.swift */,
+				A15FF0BDD5C41C98A91805B7 /* ObjectStorageTests.swift */,
+				6511C5168A7BF558CE9FAFF7 /* PublisherOperatorTests.swift */,
+				AAF2282483FF8E16A487D9C3 /* SharedExtensionsTests.swift */,
+				EF413CD9CC7D016105A22EF0 /* WindowInfoTests.swift */,
+				BDEBB5C379A572DC09662235 /* CodeSigningTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -445,6 +469,14 @@
 				12863111709580A862D997E4 /* UtilityHelpersTests.swift in Sources */,
 				83DC40FE39537ACCA4890A12 /* HotkeyTests.swift in Sources */,
 				BAA1F5944C8280680E42F490 /* DefaultsAndSettingsLoadTests.swift in Sources */,
+				B7A44344DAD9EC55EEE80484 /* AppearanceConfigurationV2Tests.swift in Sources */,
+				F19D55B35458F123AD7FFEF5 /* CGImageProcessingTests.swift in Sources */,
+				6BA9AD8CA208DCE48761A132 /* ConcurrencyHelpersTests.swift in Sources */,
+				207AAA1C30BD781DF04675E0 /* ObjectStorageTests.swift in Sources */,
+				4728C5A92AD442D6FBEFD00A /* PublisherOperatorTests.swift in Sources */,
+				91967593C089C4EA20BA497D /* SharedExtensionsTests.swift in Sources */,
+				6AA9FF5BA60A12C390EECE31 /* WindowInfoTests.swift in Sources */,
+				EB7044F527F93442F4101F0D /* CodeSigningTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -667,7 +699,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.9;
+				MARKETING_VERSION = 2.9.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -702,7 +734,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.9;
+				MARKETING_VERSION = 2.9.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Utilities/Extensions.swift
+++ b/Ice/Utilities/Extensions.swift
@@ -160,6 +160,14 @@ extension CGImage {
             }
         }
 
+        // Every pixel was below the alpha threshold, so no pixel contributed
+        // to the average and there is no color to report. Without this guard
+        // the divisions below are 0/0, which yields a NaN color that callers
+        // can't distinguish from a real one.
+        guard count > 0 else {
+            return nil
+        }
+
         // Components are currently in integer format (0 to 255), but need
         // to be converted to floating point (0 to 1). Makes more sense to
         // scale the count up to match the components, rather than scale

--- a/IceTests/AppearanceConfigurationV2Tests.swift
+++ b/IceTests/AppearanceConfigurationV2Tests.swift
@@ -1,0 +1,202 @@
+//
+//  AppearanceConfigurationV2Tests.swift
+//  IceTests
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Ice_2
+
+/// Covers the menu bar appearance configuration: its decoder must tolerate
+/// settings written by older versions of Ice (every key falls back to a
+/// default), and its derived values drive shape/tint rendering.
+struct AppearanceConfigurationV2Tests {
+    private func decodeConfiguration(_ json: String) throws -> MenuBarAppearanceConfigurationV2 {
+        try JSONDecoder().decode(MenuBarAppearanceConfigurationV2.self, from: Data(json.utf8))
+    }
+
+    private func decodePartial(_ json: String) throws -> MenuBarAppearancePartialConfiguration {
+        try JSONDecoder().decode(MenuBarAppearancePartialConfiguration.self, from: Data(json.utf8))
+    }
+
+    // MARK: Decoding with missing keys
+
+    @Test func emptyObjectDecodesToTheDefaultConfiguration() throws {
+        // Settings saved before any appearance key existed must still load.
+        #expect(try decodeConfiguration("{}") == .defaultConfiguration)
+    }
+
+    @Test func missingKeysFallBackIndividually() throws {
+        // Only two keys are present; the rest keep their defaults.
+        let configuration = try decodeConfiguration(#"{"isInset":false,"isDynamic":true}"#)
+        let defaults = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        #expect(configuration.isInset == false)
+        #expect(configuration.isDynamic == true)
+        #expect(configuration.shapeKind == defaults.shapeKind)
+        #expect(configuration.removesMenuBarBackground == defaults.removesMenuBarBackground)
+        #expect(configuration.roundsScreenCorners == defaults.roundsScreenCorners)
+        #expect(configuration.fullShapeInfo == defaults.fullShapeInfo)
+        #expect(configuration.splitShapeInfo == defaults.splitShapeInfo)
+    }
+
+    @Test func unrecognizedKeysAreIgnored() throws {
+        // Settings written by a newer build must not break an older decoder.
+        let configuration = try decodeConfiguration(#"{"isInset":false,"someFutureKey":"whatever"}"#)
+        #expect(configuration.isInset == false)
+    }
+
+    @Test func shapeKindAndShapeInfoDecodeTogether() throws {
+        let json = #"{"shapeKind":1,"fullShapeInfo":{"leadingEndCap":0,"trailingEndCap":0}}"#
+        let configuration = try decodeConfiguration(json)
+        #expect(configuration.shapeKind == .full)
+        #expect(configuration.fullShapeInfo.leadingEndCap == .square)
+        #expect(configuration.fullShapeInfo.trailingEndCap == .square)
+    }
+
+    @Test func partialConfigurationFallsBackPerKey() throws {
+        let partial = try decodePartial(#"{"hasBorder":true,"borderWidth":4}"#)
+        let defaults = MenuBarAppearancePartialConfiguration.defaultConfiguration
+        #expect(partial.hasBorder == true)
+        #expect(partial.borderWidth == 4)
+        #expect(partial.hasShadow == defaults.hasShadow)
+        #expect(partial.tintKind == defaults.tintKind)
+        #expect(partial.borderColor == defaults.borderColor)
+    }
+
+    @Test func partialConfigurationEmptyObjectIsAllDefaults() throws {
+        #expect(try decodePartial("{}") == .defaultConfiguration)
+    }
+
+    // MARK: Encoding round trip
+
+    @Test func encodeDecodeRoundTripPreservesScalarSettings() throws {
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.shapeKind = .split
+        configuration.isInset = false
+        configuration.isDynamic = true
+        configuration.removesMenuBarBackground = true
+        configuration.roundsScreenCorners = true
+        configuration.fullShapeInfo = MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .round)
+        configuration.staticConfiguration.hasShadow = true
+        configuration.staticConfiguration.borderWidth = 3
+        configuration.staticConfiguration.tintKind = .solid
+
+        let data = try JSONEncoder().encode(configuration)
+        let decoded = try JSONDecoder().decode(MenuBarAppearanceConfigurationV2.self, from: data)
+
+        #expect(decoded.shapeKind == .split)
+        #expect(decoded.isInset == false)
+        #expect(decoded.isDynamic == true)
+        #expect(decoded.removesMenuBarBackground == true)
+        #expect(decoded.roundsScreenCorners == true)
+        #expect(decoded.fullShapeInfo == configuration.fullShapeInfo)
+        #expect(decoded.staticConfiguration.hasShadow == true)
+        #expect(decoded.staticConfiguration.borderWidth == 3)
+        #expect(decoded.staticConfiguration.tintKind == .solid)
+    }
+
+    @Test func encodedPayloadCarriesEveryKey() throws {
+        let data = try JSONEncoder().encode(MenuBarAppearanceConfigurationV2.defaultConfiguration)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let expectedKeys: Set<String> = [
+            "lightModeConfiguration",
+            "darkModeConfiguration",
+            "staticConfiguration",
+            "shapeKind",
+            "fullShapeInfo",
+            "splitShapeInfo",
+            "isInset",
+            "isDynamic",
+            "removesMenuBarBackground",
+            "roundsScreenCorners",
+        ]
+        #expect(expectedKeys.isSubset(of: Set(object.keys)))
+    }
+
+    // MARK: hasRoundedShape
+
+    @Test func noShapeIsNeverRounded() {
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.shapeKind = .noShape
+        configuration.fullShapeInfo = .default // rounded, but irrelevant
+        configuration.splitShapeInfo = .default
+        #expect(!configuration.hasRoundedShape)
+    }
+
+    @Test func fullShapeDefersToFullShapeInfo() {
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.shapeKind = .full
+        configuration.splitShapeInfo = .default // rounded, but must not be consulted
+
+        configuration.fullShapeInfo = MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .square)
+        #expect(!configuration.hasRoundedShape)
+
+        configuration.fullShapeInfo = MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .round)
+        #expect(configuration.hasRoundedShape)
+    }
+
+    @Test func splitShapeDefersToSplitShapeInfo() {
+        let squareSide = MenuBarFullShapeInfo(leadingEndCap: .square, trailingEndCap: .square)
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.shapeKind = .split
+        configuration.fullShapeInfo = .default // rounded, but must not be consulted
+
+        configuration.splitShapeInfo = MenuBarSplitShapeInfo(leading: squareSide, trailing: squareSide)
+        #expect(!configuration.hasRoundedShape)
+
+        configuration.splitShapeInfo = MenuBarSplitShapeInfo(leading: squareSide, trailing: .default)
+        #expect(configuration.hasRoundedShape)
+    }
+
+    // MARK: current
+
+    @MainActor
+    @Test func currentUsesStaticConfigurationWhenNotDynamic() {
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.isDynamic = false
+        configuration.staticConfiguration.borderWidth = 11
+        configuration.lightModeConfiguration.borderWidth = 22
+        configuration.darkModeConfiguration.borderWidth = 33
+        #expect(configuration.current.borderWidth == 11)
+    }
+
+    @MainActor
+    @Test func currentUsesAnAppearanceSpecificConfigurationWhenDynamic() {
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.isDynamic = true
+        configuration.staticConfiguration.borderWidth = 11
+        // Both appearance branches agree, so the result is host-independent.
+        configuration.lightModeConfiguration.borderWidth = 44
+        configuration.darkModeConfiguration.borderWidth = 44
+        #expect(configuration.current.borderWidth == 44)
+    }
+
+    @MainActor
+    @Test func currentSelectsTheBranchMatchingTheSystemAppearance() {
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.isDynamic = true
+        configuration.lightModeConfiguration.borderWidth = 1
+        configuration.darkModeConfiguration.borderWidth = 2
+        let expected: Double = switch SystemAppearance.current {
+        case .light: 1
+        case .dark: 2
+        }
+        #expect(configuration.current.borderWidth == expected)
+    }
+
+    // MARK: Defaults
+
+    @Test func defaultConfigurationIsInsetAndUntinted() {
+        let configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        #expect(configuration.isInset)
+        #expect(!configuration.isDynamic)
+        #expect(!configuration.removesMenuBarBackground)
+        #expect(!configuration.roundsScreenCorners)
+        #expect(configuration.shapeKind == .noShape)
+        #expect(configuration.staticConfiguration.tintKind == .noTint)
+        #expect(!configuration.staticConfiguration.hasBorder)
+        #expect(!configuration.staticConfiguration.hasShadow)
+        #expect(configuration.staticConfiguration.borderWidth == 1)
+    }
+}

--- a/IceTests/CGImageProcessingTests.swift
+++ b/IceTests/CGImageProcessingTests.swift
@@ -1,0 +1,240 @@
+//
+//  CGImageProcessingTests.swift
+//  IceTests
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Ice_2
+
+/// Covers the pixel-processing logic behind menu bar item image capture
+/// (transparency trimming) and the Ice Bar's average-color tinting.
+struct CGImageProcessingTests {
+    // MARK: Fixtures
+
+    /// Creates an image by drawing into a premultiplied-first ARGB context.
+    private func makeImage(width: Int, height: Int, draw: (CGContext) -> Void) throws -> CGImage {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ))
+        draw(context)
+        return try #require(context.makeImage())
+    }
+
+    /// Creates a color in the same device RGB space the fixture contexts use,
+    /// so drawing it doesn't run a color-space conversion and skew the
+    /// expected component values.
+    private func deviceColor(_ red: CGFloat, _ green: CGFloat, _ blue: CGFloat, _ alpha: CGFloat = 1) -> CGColor {
+        CGColor(colorSpace: CGColorSpaceCreateDeviceRGB(), components: [red, green, blue, alpha])!
+    }
+
+    /// Creates a fully transparent image.
+    private func makeClearImage(width: Int = 10, height: Int = 10) throws -> CGImage {
+        try makeImage(width: width, height: height) { _ in }
+    }
+
+    /// Creates an image filled entirely with the given color.
+    private func makeFilledImage(width: Int = 10, height: Int = 10, color: CGColor) throws -> CGImage {
+        try makeImage(width: width, height: height) { context in
+            context.setFillColor(color)
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        }
+    }
+
+    private func components(of color: CGColor) throws -> [CGFloat] {
+        try #require(color.components)
+    }
+
+    // MARK: averageColor
+
+    @Test func averageColorOfSolidFillIsThatColor() throws {
+        let image = try makeFilledImage(color: deviceColor(1, 0, 0))
+        let average = try #require(image.averageColor())
+        let c = try components(of: average)
+        #expect(abs(c[0] - 1) < 0.02)
+        #expect(abs(c[1] - 0) < 0.02)
+        #expect(abs(c[2] - 0) < 0.02)
+        #expect(abs(c[3] - 1) < 0.02)
+    }
+
+    @Test func averageColorBlendsTwoHalves() throws {
+        // Left half red, right half blue -> the average sits halfway between.
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(1, 0, 0))
+            context.fill(CGRect(x: 0, y: 0, width: 5, height: 10))
+            context.setFillColor(deviceColor(0, 0, 1))
+            context.fill(CGRect(x: 5, y: 0, width: 5, height: 10))
+        }
+        let average = try #require(image.averageColor())
+        let c = try components(of: average)
+        #expect(abs(c[0] - 0.5) < 0.05)
+        #expect(abs(c[1] - 0) < 0.05)
+        #expect(abs(c[2] - 0.5) < 0.05)
+    }
+
+    @Test func averageColorSkipsPixelsBelowAlphaThreshold() throws {
+        // Half fully transparent, half opaque red.
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(1, 0, 0))
+            context.fill(CGRect(x: 5, y: 0, width: 5, height: 10))
+        }
+
+        // Threshold 0.5 excludes the transparent half, leaving pure red.
+        let excluded = try #require(image.averageColor(alphaThreshold: 0.5))
+        let excludedComponents = try components(of: excluded)
+        #expect(abs(excludedComponents[0] - 1) < 0.05)
+        #expect(abs(excludedComponents[3] - 1) < 0.05)
+
+        // Threshold 0 includes every pixel, halving both red and alpha.
+        let included = try #require(image.averageColor(alphaThreshold: 0))
+        let includedComponents = try components(of: included)
+        #expect(abs(includedComponents[0] - 0.5) < 0.05)
+        #expect(abs(includedComponents[3] - 0.5) < 0.05)
+    }
+
+    @Test func averageColorIgnoreAlphaForcesOpaqueResult() throws {
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(1, 1, 1))
+            context.fill(CGRect(x: 0, y: 0, width: 5, height: 10))
+        }
+        let withAlpha = try #require(image.averageColor(alphaThreshold: 0))
+        let ignoringAlpha = try #require(image.averageColor(alphaThreshold: 0, option: .ignoreAlpha))
+        #expect(try components(of: withAlpha)[3] < 0.9)
+        #expect(try abs(components(of: ignoringAlpha)[3] - 1) < 0.001)
+    }
+
+    @Test func averageColorIsNilWhenNoPixelClearsTheThreshold() throws {
+        // A fully transparent capture has no contributing pixels. Returning a
+        // color here would divide by zero and hand callers a NaN color they
+        // can't tell apart from a real one.
+        let image = try makeClearImage()
+        #expect(image.averageColor() == nil)
+        #expect(image.averageColor(option: .ignoreAlpha) == nil)
+    }
+
+    @Test func averageColorStillReportsAColorWhenOnePixelClearsTheThreshold() throws {
+        // The zero-pixel guard must not swallow a legitimately sparse image.
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(1, 0, 0))
+            context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        }
+        let average = try #require(image.averageColor(alphaThreshold: 0.5))
+        let c = try components(of: average)
+        #expect(!c.contains { $0.isNaN })
+        #expect(abs(c[0] - 1) < 0.05)
+    }
+
+    @Test func averageColorClampsOutOfRangeAlphaThreshold() throws {
+        // Thresholds outside 0...1 are clamped rather than rejected.
+        let image = try makeFilledImage(color: deviceColor(0, 1, 0))
+        #expect(image.averageColor(alphaThreshold: -5) != nil)
+        #expect(image.averageColor(alphaThreshold: 5) != nil)
+    }
+
+    @Test func averageColorUsesRequestedRGBColorSpace() throws {
+        let image = try makeFilledImage(color: deviceColor(1, 0, 0))
+        let p3 = try #require(CGColorSpace(name: CGColorSpace.displayP3))
+        let average = try #require(image.averageColor(using: p3))
+        #expect(average.colorSpace?.name == p3.name)
+    }
+
+    @Test func averageColorIgnoresNonRGBColorSpaceRequest() throws {
+        // A non-RGB request falls back to an RGB space instead of failing.
+        let image = try makeFilledImage(color: deviceColor(1, 0, 0))
+        let gray = CGColorSpaceCreateDeviceGray()
+        let average = try #require(image.averageColor(using: gray))
+        #expect(average.colorSpace?.model == .rgb)
+    }
+
+    // MARK: trimmingTransparency
+
+    @Test func trimmingRemovesTransparentBorderOnAllEdges() throws {
+        // A 4x4 opaque block surrounded by transparency.
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(0, 0, 1))
+            context.fill(CGRect(x: 3, y: 3, width: 4, height: 4))
+        }
+        let trimmed = try #require(image.trimmingTransparency())
+        #expect(trimmed.width == 4)
+        #expect(trimmed.height == 4)
+    }
+
+    @Test func trimmingSingleEdgeLeavesOtherDimensionsIntact() throws {
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(0, 0, 1))
+            context.fill(CGRect(x: 3, y: 3, width: 4, height: 4))
+        }
+        let trimmedMinX = try #require(image.trimmingTransparency(around: [.minXEdge]))
+        #expect(trimmedMinX.width == 7)
+        #expect(trimmedMinX.height == 10)
+
+        let trimmedMaxX = try #require(image.trimmingTransparency(around: [.maxXEdge]))
+        #expect(trimmedMaxX.width == 7)
+        #expect(trimmedMaxX.height == 10)
+    }
+
+    @Test func trimmingEmptyEdgeSetReturnsImageUnchanged() throws {
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(0, 0, 1))
+            context.fill(CGRect(x: 3, y: 3, width: 4, height: 4))
+        }
+        let trimmed = try #require(image.trimmingTransparency(around: []))
+        #expect(trimmed.width == 10)
+        #expect(trimmed.height == 10)
+    }
+
+    @Test func trimmingFullyOpaqueImageIsANoOp() throws {
+        let image = try makeFilledImage(color: deviceColor(1, 1, 1))
+        let trimmed = try #require(image.trimmingTransparency())
+        #expect(trimmed.width == 10)
+        #expect(trimmed.height == 10)
+    }
+
+    @Test func trimmingFullyTransparentImageReturnsNil() throws {
+        // Nothing opaque to anchor an inset to, so trimming can't produce an image.
+        let image = try makeClearImage()
+        #expect(image.trimmingTransparency() == nil)
+    }
+
+    @Test func trimmingIsSkippedWhenAlphaThresholdIsOpaque() throws {
+        // A threshold of 1 or more makes every pixel "transparent", so the
+        // guard bails out and hands back the original image untouched.
+        let image = try makeClearImage()
+        let trimmed = try #require(image.trimmingTransparency(alphaThreshold: 1))
+        #expect(trimmed.width == 10)
+        #expect(trimmed.height == 10)
+    }
+
+    // MARK: isTransparent
+
+    @Test func fullyTransparentImageIsTransparent() throws {
+        #expect(try makeClearImage().isTransparent())
+    }
+
+    @Test func imageWithAnyOpaquePixelIsNotTransparent() throws {
+        let image = try makeImage(width: 10, height: 10) { context in
+            context.setFillColor(deviceColor(1, 1, 1))
+            context.fill(CGRect(x: 9, y: 9, width: 1, height: 1))
+        }
+        #expect(!image.isTransparent())
+    }
+
+    @Test func isTransparentHonorsAlphaThreshold() throws {
+        // Faint pixels count as transparent only once the threshold exceeds them.
+        let image = try makeFilledImage(color: deviceColor(1, 1, 1, 0.25))
+        #expect(!image.isTransparent(alphaThreshold: 0))
+        #expect(image.isTransparent(alphaThreshold: 0.5))
+    }
+
+    @Test func isTransparentReturnsFalseWhenThresholdIsOpaque() throws {
+        // A threshold of 1 fails the guard, which reports "not transparent".
+        #expect(!(try makeClearImage().isTransparent(alphaThreshold: 1)))
+    }
+}

--- a/IceTests/CodeSigningTests.swift
+++ b/IceTests/CodeSigningTests.swift
@@ -1,0 +1,42 @@
+//
+//  CodeSigningTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+/// Covers the Team Identifier lookup that decides whether the menu bar item
+/// XPC service can enforce its `isFromSameTeam` peer requirement.
+///
+/// The concrete value depends on how the host was signed (a Developer ID
+/// build has a team; an ad-hoc local build does not), so these tests assert
+/// the invariants that must hold either way.
+struct CodeSigningTests {
+    @Test func hasTeamIdentifierAgreesWithTheLookup() {
+        #expect(CodeSigning.hasTeamIdentifier == (CodeSigning.teamIdentifier != nil))
+    }
+
+    @Test func teamIdentifierIsNeverEmpty() {
+        // The implementation deliberately maps an empty team to nil, so an
+        // empty string must never surface.
+        if let team = CodeSigning.teamIdentifier {
+            #expect(!team.isEmpty)
+        }
+    }
+
+    @Test func teamIdentifierIsStableAcrossCalls() {
+        // Nothing is cached, so repeated lookups must still agree.
+        #expect(CodeSigning.teamIdentifier == CodeSigning.teamIdentifier)
+        #expect(CodeSigning.hasTeamIdentifier == CodeSigning.hasTeamIdentifier)
+    }
+
+    @Test func teamIdentifierHasNoWhitespace() {
+        // A Team Identifier is an opaque alphanumeric string; whitespace would
+        // mean we read the wrong signing-information field.
+        if let team = CodeSigning.teamIdentifier {
+            #expect(team.rangeOfCharacter(from: .whitespacesAndNewlines) == nil)
+        }
+    }
+}

--- a/IceTests/ConcurrencyHelpersTests.swift
+++ b/IceTests/ConcurrencyHelpersTests.swift
@@ -1,0 +1,113 @@
+//
+//  ConcurrencyHelpersTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+import os.lock
+@testable import Ice_2
+
+/// Covers the task-timeout wrapper and the once-only claim used to guarantee
+/// continuations resume exactly once (menu bar item moves, app relaunches).
+struct ConcurrencyHelpersTests {
+    // MARK: TaskTimeoutError
+
+    @Test func timeoutErrorDescriptionsAgree() {
+        let error = TaskTimeoutError()
+        #expect(error.description == "Task timed out before completion")
+        #expect(error.errorDescription == error.description)
+    }
+
+    // MARK: Task(timeout:)
+
+    @Test func taskWithTimeoutReturnsAFastResult() async throws {
+        let task = Task<Int, any Error>(timeout: .seconds(10)) { 42 }
+        #expect(try await task.value == 42)
+    }
+
+    @Test func taskWithTimeoutThrowsWhenTheOperationIsTooSlow() async {
+        let task = Task<Int, any Error>(timeout: .milliseconds(50)) {
+            try await Task.sleep(for: .seconds(30))
+            return 0
+        }
+        await #expect(throws: TaskTimeoutError.self) {
+            _ = try await task.value
+        }
+    }
+
+    @Test func taskWithTimeoutPropagatesTheOperationsOwnError() async {
+        struct Boom: Error {}
+        let task = Task<Int, any Error>(timeout: .seconds(10)) {
+            throw Boom()
+        }
+        await #expect(throws: Boom.self) {
+            _ = try await task.value
+        }
+    }
+
+    @Test func taskWithTimeoutCancelsTheOperationOnTimeout() async throws {
+        let finished = OSAllocatedUnfairLock(initialState: false)
+        let task = Task<Int, any Error>(timeout: .milliseconds(50)) {
+            try await Task.sleep(for: .seconds(30))
+            finished.withLock { $0 = true }
+            return 1
+        }
+        _ = try? await task.value
+        // Give the cancelled child a moment to unwind.
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(finished.withLock { $0 } == false)
+    }
+
+    // MARK: Task.detached(timeout:)
+
+    @Test func detachedTaskWithTimeoutReturnsAFastResult() async throws {
+        let task = Task<Int, any Error>.detached(timeout: .seconds(10)) { 7 }
+        #expect(try await task.value == 7)
+    }
+
+    @Test func detachedTaskWithTimeoutThrowsWhenTheOperationIsTooSlow() async {
+        let task = Task<Int, any Error>.detached(timeout: .milliseconds(50)) {
+            try await Task.sleep(for: .seconds(30))
+            return 0
+        }
+        await #expect(throws: TaskTimeoutError.self) {
+            _ = try await task.value
+        }
+    }
+
+    // MARK: tryClaimOnce
+
+    @Test func tryClaimOnceSucceedsExactlyOnceSequentially() {
+        let lock = OSAllocatedUnfairLock(initialState: false)
+        #expect(lock.tryClaimOnce())
+        #expect(!lock.tryClaimOnce())
+        #expect(!lock.tryClaimOnce())
+    }
+
+    @Test func tryClaimOnceLeavesTheStateClaimed() {
+        let lock = OSAllocatedUnfairLock(initialState: false)
+        _ = lock.tryClaimOnce()
+        #expect(lock.withLock { $0 } == true)
+    }
+
+    @Test func tryClaimOnceRejectsAnAlreadyClaimedState() {
+        let lock = OSAllocatedUnfairLock(initialState: true)
+        #expect(!lock.tryClaimOnce())
+    }
+
+    @Test func tryClaimOnceIsAtomicUnderContention() async {
+        let lock = OSAllocatedUnfairLock(initialState: false)
+        let winners = await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<64 {
+                group.addTask { lock.tryClaimOnce() }
+            }
+            var count = 0
+            for await claimed in group where claimed {
+                count += 1
+            }
+            return count
+        }
+        #expect(winners == 1)
+    }
+}

--- a/IceTests/ObjectStorageTests.swift
+++ b/IceTests/ObjectStorageTests.swift
@@ -1,0 +1,121 @@
+//
+//  ObjectStorageTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+/// Covers the associated-object storage Ice uses to attach state to AppKit
+/// objects it doesn't own. Getting the strong/weak distinction wrong here
+/// leaks windows and panels, so both are pinned down.
+struct ObjectStorageTests {
+    private final class Payload {
+        let id: Int
+        init(id: Int) {
+            self.id = id
+        }
+    }
+
+    // MARK: Strong storage
+
+    @Test func valueIsNilBeforeAnythingIsStored() {
+        let storage = ObjectStorage<String>()
+        #expect(storage.value(for: NSObject()) == nil)
+    }
+
+    @Test func storedValueIsRetrievable() {
+        let storage = ObjectStorage<String>()
+        let owner = NSObject()
+        storage.set("hello", for: owner)
+        #expect(storage.value(for: owner) == "hello")
+    }
+
+    @Test func storingAgainOverwritesTheValue() {
+        let storage = ObjectStorage<String>()
+        let owner = NSObject()
+        storage.set("first", for: owner)
+        storage.set("second", for: owner)
+        #expect(storage.value(for: owner) == "second")
+    }
+
+    @Test func settingNilClearsTheValue() {
+        let storage = ObjectStorage<String>()
+        let owner = NSObject()
+        storage.set("hello", for: owner)
+        storage.set(nil, for: owner)
+        #expect(storage.value(for: owner) == nil)
+    }
+
+    @Test func eachOwnerHasItsOwnValue() {
+        let storage = ObjectStorage<String>()
+        let first = NSObject()
+        let second = NSObject()
+        storage.set("first", for: first)
+        storage.set("second", for: second)
+        #expect(storage.value(for: first) == "first")
+        #expect(storage.value(for: second) == "second")
+    }
+
+    @Test func separateStorageInstancesDoNotCollideOnTheSameOwner() {
+        // The lookup key is derived from the storage instance itself.
+        let a = ObjectStorage<String>()
+        let b = ObjectStorage<String>()
+        let owner = NSObject()
+        a.set("from a", for: owner)
+        b.set("from b", for: owner)
+        #expect(a.value(for: owner) == "from a")
+        #expect(b.value(for: owner) == "from b")
+    }
+
+    @Test func strongStorageKeepsTheValueAlive() {
+        let storage = ObjectStorage<Payload>()
+        let owner = NSObject()
+        var payload: Payload? = Payload(id: 1)
+        storage.set(payload, for: owner)
+        payload = nil
+        // `set` retains, so dropping the local reference changes nothing.
+        #expect(storage.value(for: owner)?.id == 1)
+    }
+
+    // MARK: Weak storage
+
+    @Test func weakStoredValueIsRetrievableWhileAlive() {
+        let storage = ObjectStorage<Payload>()
+        let owner = NSObject()
+        let payload = Payload(id: 7)
+        storage.weakSet(payload, for: owner)
+        #expect(storage.value(for: owner) === payload)
+    }
+
+    @Test func weakStoredValueDisappearsWhenReleased() {
+        let storage = ObjectStorage<Payload>()
+        let owner = NSObject()
+        var payload: Payload? = Payload(id: 2)
+        storage.weakSet(payload, for: owner)
+        #expect(storage.value(for: owner) != nil)
+        payload = nil
+        // The wrapper survives, but the reference inside it is gone.
+        #expect(storage.value(for: owner) == nil)
+    }
+
+    @Test func weakSetNilClearsTheValue() {
+        let storage = ObjectStorage<Payload>()
+        let owner = NSObject()
+        storage.weakSet(Payload(id: 3), for: owner)
+        storage.weakSet(nil, for: owner)
+        #expect(storage.value(for: owner) == nil)
+    }
+
+    @Test func weakSetReplacesAPreviouslyStrongValue() {
+        let storage = ObjectStorage<Payload>()
+        let owner = NSObject()
+        storage.set(Payload(id: 4), for: owner)
+        var replacement: Payload? = Payload(id: 5)
+        storage.weakSet(replacement, for: owner)
+        #expect(storage.value(for: owner)?.id == 5)
+        replacement = nil
+        #expect(storage.value(for: owner) == nil)
+    }
+}

--- a/IceTests/PublisherOperatorTests.swift
+++ b/IceTests/PublisherOperatorTests.swift
@@ -1,0 +1,129 @@
+//
+//  PublisherOperatorTests.swift
+//  IceTests
+//
+
+import Combine
+import Foundation
+import Testing
+@testable import Ice_2
+
+/// Covers the custom Combine operators that Ice's reactive plumbing is
+/// built on — settings observation, state invalidation, and event merging.
+struct PublisherOperatorTests {
+    /// Synchronously drains a publisher that emits on subscribe.
+    private func collect<P: Publisher>(_ publisher: P) -> [P.Output] where P.Failure == Never {
+        var output = [P.Output]()
+        let cancellable = publisher.sink { output.append($0) }
+        cancellable.cancel()
+        return output
+    }
+
+    // MARK: replace
+
+    @Test func replaceSubstitutesAFreshlyComputedElement() {
+        var callCount = 0
+        let result = collect([1, 2, 3].publisher.replace { () -> Int in
+            callCount += 1
+            return callCount
+        })
+        // The closure runs once per upstream element.
+        #expect(result == [1, 2, 3])
+        #expect(callCount == 3)
+    }
+
+    @Test func replaceWithSubstitutesAConstant() {
+        #expect(collect([1, 2, 3].publisher.replace(with: "x")) == ["x", "x", "x"])
+    }
+
+    @Test func replacePreservesUpstreamElementCount() {
+        #expect(collect(Empty<Int, Never>().replace(with: 0)).isEmpty)
+    }
+
+    // MARK: removeNil
+
+    @Test func removeNilDropsNilElements() {
+        let upstream = [1, nil, 2, nil, nil, 3].publisher
+        #expect(collect(upstream.removeNil()) == [1, 2, 3])
+    }
+
+    @Test func removeNilOnAllNilProducesNothing() {
+        let upstream = [Int?.none, nil].publisher
+        #expect(collect(upstream.removeNil()).isEmpty)
+    }
+
+    // MARK: removeDuplicates for tuples
+
+    @Test func removeDuplicatesComparesEveryTupleElement() {
+        let subject = PassthroughSubject<(Int, String), Never>()
+        var output = [(Int, String)]()
+        let cancellable = subject.removeDuplicates().sink { output.append($0) }
+
+        subject.send((1, "a"))
+        subject.send((1, "a")) // fully duplicate - dropped
+        subject.send((1, "b")) // second element differs - kept
+        subject.send((2, "b")) // first element differs - kept
+        subject.send((2, "b")) // fully duplicate - dropped
+        cancellable.cancel()
+
+        #expect(output.count == 3)
+        #expect(output.map(\.0) == [1, 1, 2])
+        #expect(output.map(\.1) == ["a", "b", "b"])
+    }
+
+    @Test func removeDuplicatesKeepsNonAdjacentRepeats() {
+        // Only consecutive duplicates are removed.
+        let subject = PassthroughSubject<(Int, Int), Never>()
+        var output = [(Int, Int)]()
+        let cancellable = subject.removeDuplicates().sink { output.append($0) }
+
+        subject.send((1, 1))
+        subject.send((2, 2))
+        subject.send((1, 1))
+        cancellable.cancel()
+
+        #expect(output.count == 3)
+    }
+
+    // MARK: discardMerge
+
+    @Test func discardMergeEmitsForEitherUpstream() {
+        let ints = PassthroughSubject<Int, Never>()
+        let strings = PassthroughSubject<String, Never>()
+        var count = 0
+        let cancellable = ints.discardMerge(strings).sink { _ in count += 1 }
+
+        ints.send(1)
+        strings.send("a")
+        ints.send(2)
+        strings.send("b")
+        cancellable.cancel()
+
+        #expect(count == 4)
+    }
+
+    @Test func discardMergeStopsAfterCancellation() {
+        let ints = PassthroughSubject<Int, Never>()
+        let strings = PassthroughSubject<String, Never>()
+        var count = 0
+        let cancellable = ints.discardMerge(strings).sink { _ in count += 1 }
+
+        ints.send(1)
+        cancellable.cancel()
+        ints.send(2)
+        strings.send("a")
+
+        #expect(count == 1)
+    }
+
+    // MARK: mergeMap
+
+    @Test func mergeMapFlattensAPublisherPerSequenceElement() {
+        let result = collect(Just([1, 2, 3]).mergeMap { Just($0 * 2) })
+        #expect(Set(result) == [2, 4, 6])
+    }
+
+    @Test func mergeMapOnEmptySequenceEmitsNothing() {
+        #expect(collect(Just([Int]()).mergeMap { Just($0) }).isEmpty)
+    }
+}

--- a/IceTests/SharedExtensionsTests.swift
+++ b/IceTests/SharedExtensionsTests.swift
@@ -1,0 +1,115 @@
+//
+//  SharedExtensionsTests.swift
+//  IceTests
+//
+
+import CoreGraphics
+import Dispatch
+import Foundation
+import Testing
+@testable import Ice_2
+
+/// Covers the geometry and dispatch helpers shared between the app and the
+/// menu bar item XPC service.
+struct SharedExtensionsTests {
+    // MARK: CGPoint.distance
+
+    @Test func distanceMatchesPythagoras() {
+        #expect(CGPoint(x: 0, y: 0).distance(to: CGPoint(x: 3, y: 4)) == 5)
+        #expect(CGPoint(x: -3, y: -4).distance(to: .zero) == 5)
+    }
+
+    @Test func distanceToSelfIsZero() {
+        let point = CGPoint(x: 12.5, y: -7)
+        #expect(point.distance(to: point) == 0)
+    }
+
+    @Test func distanceIsSymmetric() {
+        let a = CGPoint(x: 1, y: 9)
+        let b = CGPoint(x: -4, y: 2)
+        #expect(a.distance(to: b) == b.distance(to: a))
+    }
+
+    @Test func distanceIgnoresAxisSign() {
+        // Only the magnitude of each delta matters.
+        #expect(CGPoint(x: 0, y: 0).distance(to: CGPoint(x: -3, y: 4)) == 5)
+        #expect(CGPoint(x: 0, y: 0).distance(to: CGPoint(x: 3, y: -4)) == 5)
+    }
+
+    // MARK: CGRect.center
+
+    @Test func centerIsTheMidpointOfTheRect() {
+        #expect(CGRect(x: 10, y: 20, width: 30, height: 40).center == CGPoint(x: 25, y: 40))
+    }
+
+    @Test func centerOfZeroSizedRectIsItsOrigin() {
+        #expect(CGRect(x: 5, y: 6, width: 0, height: 0).center == CGPoint(x: 5, y: 6))
+    }
+
+    @Test func centerHandlesNegativeOrigins() {
+        #expect(CGRect(x: -10, y: -10, width: 4, height: 6).center == CGPoint(x: -8, y: -7))
+    }
+
+    // MARK: CGError.logString
+
+    @Test func logStringNamesEveryKnownError() {
+        let expected: [(CGError, String)] = [
+            (.success, "success"),
+            (.failure, "failure"),
+            (.illegalArgument, "illegalArgument"),
+            (.invalidConnection, "invalidConnection"),
+            (.invalidContext, "invalidContext"),
+            (.cannotComplete, "cannotComplete"),
+            (.notImplemented, "notImplemented"),
+            (.rangeCheck, "rangeCheck"),
+            (.typeCheck, "typeCheck"),
+            (.invalidOperation, "invalidOperation"),
+            (.noneAvailable, "noneAvailable"),
+        ]
+        for (error, name) in expected {
+            #expect(error.logString == "\(error.rawValue): \(name)")
+        }
+    }
+
+    @Test func logStringForUnknownErrorFallsBackToUnknown() {
+        // Guards the @unknown default branch against future CGError cases.
+        let unknown = CGError(rawValue: 9999)
+        #expect(unknown?.logString == "9999: unknown")
+    }
+
+    // MARK: DispatchQueue.targetingGlobal
+
+    @Test func targetingGlobalPreservesTheLabel() {
+        let queue = DispatchQueue.targetingGlobal(label: "com.dragonapp.ice.tests.serial")
+        #expect(queue.label == "com.dragonapp.ice.tests.serial")
+    }
+
+    @Test func targetingGlobalQueueExecutesWork() {
+        let queue = DispatchQueue.targetingGlobal(label: "com.dragonapp.ice.tests.exec")
+        var value = 0
+        queue.sync { value = 42 }
+        #expect(value == 42)
+    }
+
+    @Test func targetingGlobalAcceptsConcurrentAttributesAndQoS() {
+        let queue = DispatchQueue.targetingGlobal(
+            label: "com.dragonapp.ice.tests.concurrent",
+            qos: .userInitiated,
+            attributes: .concurrent
+        )
+        #expect(queue.label == "com.dragonapp.ice.tests.concurrent")
+
+        // A concurrent queue still runs every submitted block.
+        let group = DispatchGroup()
+        let counter = NSCountedSet()
+        for index in 0..<8 {
+            queue.async(group: group) {
+                objc_sync_enter(counter)
+                counter.add(index)
+                objc_sync_exit(counter)
+            }
+        }
+        #expect(group.wait(timeout: .now() + 5) == .success)
+        #expect(counter.count == 8)
+    }
+}

--- a/IceTests/WindowInfoTests.swift
+++ b/IceTests/WindowInfoTests.swift
@@ -1,0 +1,224 @@
+//
+//  WindowInfoTests.swift
+//  IceTests
+//
+
+import Cocoa
+import Testing
+@testable import Ice_2
+
+/// Covers how Ice identifies the two system windows it depends on: the
+/// menu bar window (used for capture, appearance overlays and height
+/// measurement) and the wallpaper window (used for average-color tinting).
+struct WindowInfoTests {
+    /// Mirrors `WindowInfo`'s stored properties so fixtures can be built
+    /// through its synthesized `Codable` conformance — the type itself has
+    /// no memberwise initializer.
+    private struct Fixture: Encodable {
+        var windowID: CGWindowID = 1
+        var ownerPID: pid_t = 501
+        var bounds: CGRect = .zero
+        var layer: Int = 0
+        var title: String?
+        var ownerName: String?
+        var isOnScreen: Bool = true
+    }
+
+    private func makeWindow(_ fixture: Fixture) throws -> WindowInfo {
+        let data = try JSONEncoder().encode(fixture)
+        return try JSONDecoder().decode(WindowInfo.self, from: data)
+    }
+
+    /// A rect guaranteed to sit inside the main display.
+    private var boundsInsideMainDisplay: CGRect {
+        CGDisplayBounds(CGMainDisplayID()).insetBy(dx: 10, dy: 10)
+    }
+
+    /// A rect guaranteed to sit outside the main display.
+    private var boundsOutsideMainDisplay: CGRect {
+        let displayBounds = CGDisplayBounds(CGMainDisplayID())
+        return CGRect(x: displayBounds.maxX + 1000, y: displayBounds.maxY + 1000, width: 100, height: 24)
+    }
+
+    /// A window that satisfies every menu bar window criterion.
+    private func makeMenuBarWindow(
+        windowID: CGWindowID = 1,
+        title: String? = "Menubar",
+        ownerName: String? = "Window Server",
+        layer: Int = Int(kCGMainMenuWindowLevel),
+        isOnScreen: Bool = true,
+        bounds: CGRect? = nil
+    ) throws -> WindowInfo {
+        try makeWindow(Fixture(
+            windowID: windowID,
+            bounds: bounds ?? boundsInsideMainDisplay,
+            layer: layer,
+            title: title,
+            ownerName: ownerName,
+            isOnScreen: isOnScreen
+        ))
+    }
+
+    // MARK: Codable
+
+    @Test func codableRoundTripPreservesEveryField() throws {
+        let bounds = CGRect(x: 10, y: 20, width: 300, height: 24)
+        let window = try makeWindow(Fixture(
+            windowID: 42,
+            ownerPID: 777,
+            bounds: bounds,
+            layer: 25,
+            title: "Menubar",
+            ownerName: "Window Server",
+            isOnScreen: true
+        ))
+        #expect(window.windowID == 42)
+        #expect(window.ownerPID == 777)
+        #expect(window.bounds == bounds)
+        #expect(window.layer == 25)
+        #expect(window.title == "Menubar")
+        #expect(window.ownerName == "Window Server")
+        #expect(window.isOnScreen)
+
+        let reencoded = try JSONEncoder().encode(window)
+        let decoded = try JSONDecoder().decode(WindowInfo.self, from: reencoded)
+        #expect(decoded.windowID == window.windowID)
+        #expect(decoded.bounds == window.bounds)
+        #expect(decoded.title == window.title)
+        #expect(decoded.ownerName == window.ownerName)
+        #expect(decoded.layer == window.layer)
+        #expect(decoded.isOnScreen == window.isOnScreen)
+    }
+
+    @Test func absentTitleAndOwnerNameDecodeToNil() throws {
+        let window = try makeWindow(Fixture())
+        #expect(window.title == nil)
+        #expect(window.ownerName == nil)
+    }
+
+    // MARK: isWindowServerWindow
+
+    @Test func windowServerWindowIsIdentifiedByOwnerName() throws {
+        #expect(try makeWindow(Fixture(ownerName: "Window Server")).isWindowServerWindow)
+        #expect(!(try makeWindow(Fixture(ownerName: "Dock")).isWindowServerWindow))
+        #expect(!(try makeWindow(Fixture(ownerName: nil)).isWindowServerWindow))
+        // The check is exact, not a prefix or case-insensitive match.
+        #expect(!(try makeWindow(Fixture(ownerName: "window server")).isWindowServerWindow))
+    }
+
+    // MARK: menuBarWindow
+
+    @Test func menuBarWindowMatchesAFullyQualifyingWindow() throws {
+        let window = try makeMenuBarWindow()
+        let found = WindowInfo.menuBarWindow(from: [window], for: CGMainDisplayID())
+        #expect(found?.windowID == window.windowID)
+    }
+
+    @Test func menuBarWindowRejectsOffScreenWindows() throws {
+        let window = try makeMenuBarWindow(isOnScreen: false)
+        #expect(WindowInfo.menuBarWindow(from: [window], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func menuBarWindowRejectsTheWrongLayer() throws {
+        let window = try makeMenuBarWindow(layer: Int(kCGMainMenuWindowLevel) - 1)
+        #expect(WindowInfo.menuBarWindow(from: [window], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func menuBarWindowRejectsTheWrongTitle() throws {
+        #expect(WindowInfo.menuBarWindow(from: [try makeMenuBarWindow(title: "Menu Bar")], for: CGMainDisplayID()) == nil)
+        #expect(WindowInfo.menuBarWindow(from: [try makeMenuBarWindow(title: nil)], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func menuBarWindowRejectsNonWindowServerOwners() throws {
+        let window = try makeMenuBarWindow(ownerName: "Dock")
+        #expect(WindowInfo.menuBarWindow(from: [window], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func menuBarWindowRejectsWindowsOutsideTheDisplay() throws {
+        let window = try makeMenuBarWindow(bounds: boundsOutsideMainDisplay)
+        #expect(WindowInfo.menuBarWindow(from: [window], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func menuBarWindowSkipsNonMatchesAndReturnsTheFirstMatch() throws {
+        let decoys = [
+            try makeMenuBarWindow(windowID: 10, title: "Backstop"),
+            try makeMenuBarWindow(windowID: 11, ownerName: "Dock"),
+            try makeMenuBarWindow(windowID: 12, isOnScreen: false),
+        ]
+        let matches = [
+            try makeMenuBarWindow(windowID: 13),
+            try makeMenuBarWindow(windowID: 14),
+        ]
+        let found = WindowInfo.menuBarWindow(from: decoys + matches, for: CGMainDisplayID())
+        #expect(found?.windowID == 13)
+    }
+
+    @Test func menuBarWindowOnEmptyListIsNil() {
+        #expect(WindowInfo.menuBarWindow(from: [], for: CGMainDisplayID()) == nil)
+    }
+
+    // MARK: wallpaperWindow
+
+    @Test func wallpaperWindowRejectsNonDockOwners() throws {
+        // Owned by this test process, so it can't be the Dock's wallpaper window.
+        let window = try makeWindow(Fixture(
+            ownerPID: ProcessInfo.processInfo.processIdentifier,
+            bounds: boundsInsideMainDisplay,
+            title: "Wallpaper-1"
+        ))
+        #expect(WindowInfo.wallpaperWindow(from: [window], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func wallpaperWindowRequiresTheWallpaperTitlePrefix() throws {
+        guard let dockPID = NSRunningApplication.dockPID else {
+            return // No Dock running; nothing deterministic to assert.
+        }
+        let wrongTitle = try makeWindow(Fixture(
+            ownerPID: dockPID,
+            bounds: boundsInsideMainDisplay,
+            title: "Desktop Picture"
+        ))
+        #expect(WindowInfo.wallpaperWindow(from: [wrongTitle], for: CGMainDisplayID()) == nil)
+
+        let noTitle = try makeWindow(Fixture(ownerPID: dockPID, bounds: boundsInsideMainDisplay))
+        #expect(WindowInfo.wallpaperWindow(from: [noTitle], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func wallpaperWindowMatchesADockOwnedWallpaperInsideTheDisplay() throws {
+        guard let dockPID = NSRunningApplication.dockPID else {
+            return // No Dock running; nothing deterministic to assert.
+        }
+        let window = try makeWindow(Fixture(
+            windowID: 99,
+            ownerPID: dockPID,
+            bounds: boundsInsideMainDisplay,
+            title: "Wallpaper-1-0"
+        ))
+        #expect(WindowInfo.wallpaperWindow(from: [window], for: CGMainDisplayID())?.windowID == 99)
+    }
+
+    @Test func wallpaperWindowRejectsWindowsOutsideTheDisplay() throws {
+        guard let dockPID = NSRunningApplication.dockPID else {
+            return // No Dock running; nothing deterministic to assert.
+        }
+        let window = try makeWindow(Fixture(
+            ownerPID: dockPID,
+            bounds: boundsOutsideMainDisplay,
+            title: "Wallpaper-1-0"
+        ))
+        #expect(WindowInfo.wallpaperWindow(from: [window], for: CGMainDisplayID()) == nil)
+    }
+
+    @Test func wallpaperWindowOnEmptyListIsNil() {
+        #expect(WindowInfo.wallpaperWindow(from: [], for: CGMainDisplayID()) == nil)
+    }
+}
+
+private extension NSRunningApplication {
+    /// The process identifier of the running Dock, if it can be found.
+    static var dockPID: pid_t? {
+        NSWorkspace.shared.runningApplications
+            .first { $0.bundleIdentifier == "com.apple.dock" }?
+            .processIdentifier
+    }
+}

--- a/Shared/Utilities/WindowInfo.swift
+++ b/Shared/Utilities/WindowInfo.swift
@@ -121,9 +121,12 @@ extension WindowInfo {
     static func wallpaperWindow(from windows: [WindowInfo], for display: CGDirectDisplayID) -> WindowInfo? {
         let displayBounds = CGDisplayBounds(display)
         return windows.first { window in
+            // Check the title first. It's a cheap string comparison, whereas
+            // the owner check constructs an NSRunningApplication for every
+            // window it inspects, which dominates the cost of this scan.
+            window.title?.hasPrefix("Wallpaper") == true &&
             // Wallpaper window belongs to the Dock process.
             window.owningApplication?.bundleIdentifier == "com.apple.dock" &&
-            window.title?.hasPrefix("Wallpaper") == true &&
             displayBounds.contains(window.bounds)
         }
     }


### PR DESCRIPTION
## What

Expands the automated test suite from **162 → 261 checks**, and fixes the two real defects that writing those tests surfaced.

## Fixes

**1. `CGImage.averageColor` returned a NaN color instead of `nil`.** `count` starts at every pixel and is decremented for each pixel below the alpha threshold. If no pixel clears it, `count` reaches 0, so every component is `0/0`. Probed against the real function:

```
fully transparent image, default alphaThreshold 0.5
  -> Optional(CGColor ( nan nan nan nan ))
  -> with .ignoreAlpha: [nan, nan, nan, 1.0]
```

It returned **non-nil**, so all three callers (`MenuBarManager.swift:248`, `IceBarColorManager.swift:146`, `MenuBarSearchModel.swift:71`) accepted a garbage color as real and fed it to the Ice Bar / search panel tint. All three already sit inside `guard let ... else { return }`, so returning `nil` turns this into a clean no-op. Reachable when a capture comes back fully transparent — display reconfiguration, wake from sleep, unrendered wallpaper.

**2. `WindowInfo.wallpaperWindow` evaluated the expensive clause first.** It checked `owningApplication?.bundleIdentifier` — which constructs an `NSRunningApplication` per window — before the cheap `title?.hasPrefix("Wallpaper")`. Measured over the real on-screen window list (46 windows), 20 scans:

| Clause order | Time |
|---|---|
| bundle-ID first (before) | 19.9 ms |
| title first (after) | 0.46 ms |

**~43× faster** (~1 ms → ~23 µs per call). Pure reordering — same window matched, and now covered by tests so it's verifiably behaviour-preserving. `menuBarWindow` already ordered cheap-first, so this was an inconsistency.

## Coverage

`Ice 2.app` **11.51% → 14.26%** (+559 lines), `MenuBarItemService.xpc` **15.42% → 24.85%**. No production code was reshaped for testability.

| File | Before → After | Guards |
|---|---|---|
| `Extensions.swift` | 6.2% → **64.9%** | item image trimming, Ice Bar average colour, all custom Combine operators |
| `MenuBarAppearanceConfigurationV2.swift` | 0% → **100%** | appearance settings surviving an upgrade (per-key decode fallback) |
| `ConcurrencyHelpers.swift` | 0% → **98.5%** | task timeouts, resume-exactly-once claims |
| `CodeSigning.swift` | 0% → **87.5%** | the XPC `isFromSameTeam` peer gate |
| `WindowInfo.swift` | 28.9% → **64.5%** | menu bar / wallpaper window identification |
| `SharedExtensions.swift` | 15.4% → **100%** | geometry + dispatch helpers |
| `ObjectStorage.swift` | 0% → **100%** | strong vs weak associated storage |

Two techniques worth knowing: fixtures for types with **no memberwise init** are built by round-tripping their synthesized `Codable` (`WindowInfo` declares `init?(dictionary:)`, so Swift synthesizes none); and CGImage fixtures must build fill colours **in the context's own colour space** — `CGColor(red:green:blue:alpha:)` gets colour-converted on draw (pure red lands at g=38/255), which silently breaks exact component assertions.

## Verification

- 261/261 tests pass; SwiftLint 0.65.0 `--strict` clean (0 violations, same version as CI).
- **Mutation-tested.** Four deliberate defects — `.noShape` reporting a rounded shape, a dropped `isOnScreen` check, `weakSet` retaining strongly, `CGRect.center` returning the origin — each failed exactly the covering test (7 failures), then were reverted.
- Two suspicions were investigated and **cleared**, not assumed: NaN colours do *not* defeat the `averageColorInfo != info` dedupe (`CGColor` equality isn't component-wise IEEE), and the 5-second timer in `MenuBarManager` does *not* cause idle screen captures (it bails unless the Settings window is visible).

## Release

`MARKETING_VERSION` 2.9.9 → 2.9.10. `CURRENT_PROJECT_VERSION` is intentionally untouched — `dragon-release-ci` stamps `CFBundleVersion` from the commit count at build time (`release-macos.yml:312-313`, `:418`), so the committed value is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)