### PR TITLE
docs: add Tests section with measured coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ profiles, and searches your items.
 - [Menu bar sections](#menu-bar-sections)
 - [Troubleshooting](#troubleshooting)
 - [Building from source](#building-from-source)
+- [Tests](#tests)
 - [Contributing](#contributing)
 - [Credits](#credits)
 - [License](#license)
@@ -217,6 +218,37 @@ bash scripts/run-debug.sh
 Swift sources are linted with [SwiftLint](https://github.com/realm/SwiftLint)
 (`.swiftlint.yml`); CI runs `swiftlint lint --strict` on every pull request that
 touches Swift files.
+
+## Tests
+
+The unit tests live in `IceTests/` and are written with Swift Testing. They cover the
+pure, permission-free parts of Ice 2: menu bar item tags and layout profiles, section
+names and triggers, appearance configuration and its settings upgrades, colors and
+gradients, hotkeys (key codes, modifiers, combinations, and actions), menu bar image
+processing and window identification, code signing checks, settings persistence and
+backup, and the shared concurrency helpers. Anything that needs live `NSStatusItem`s,
+event taps, or granted permissions is covered by the manual checklist in
+[docs/testing/layout-pane-manual-tests.md](docs/testing/layout-pane-manual-tests.md)
+instead.
+
+```bash
+xcodebuild test -project Ice.xcodeproj -scheme Ice \
+  -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO
+```
+
+`CODE_SIGNING_ALLOWED=NO` lets the suite run without the project's Apple Development
+signing certificate; drop it if you have one.
+
+| Metric | Value |
+|---|---|
+| Test cases | 261 passing |
+| Line coverage | 14.3% of the `Ice 2.app` target |
+| Measured on | v2.9.10 (`f55a610`), Xcode 26.6 on macOS 26.5.2 |
+
+Coverage is low by nature rather than by neglect: most of the app target is SwiftUI
+settings views and menu-bar machinery that needs live status items, event taps, and
+granted permissions, none of which run headlessly. The tests concentrate on the logic
+that can be exercised without them.
 
 ## Contributing
 


### PR DESCRIPTION
Adds a `## Tests` section directly after `## Building from source`, with a matching `- [Tests](#tests)` entry in `## Contents`. Same section applied across all four Dragon App repos so they stay uniform.

## Measured, not asserted

Every figure comes from a real run on this machine — nothing estimated:

```
✔ Test run with 261 tests in 30 suites passed after 0.594 seconds.
** TEST SUCCEEDED **
```

| Metric | Value |
|---|---|
| Test cases | 261 passing |
| Line coverage | 14.3% of the `Ice 2.app` target |
| Measured on | v2.9.10 (`f55a610`), Xcode 26.6 on macOS 26.5.2 |

Coverage came from `xcrun xccov view --report --only-targets`, which reports per target:

```
Ice 2.app              14.32% (2910/20320)
IceTests.xctest        99.36% (2471/2487)
MenuBarItemService.xpc 25.30% (251/992)
```

The table quotes the **`Ice 2.app`** figure rather than the whole-bundle aggregate (20.82%), because the aggregate is inflated by the test bundle counting its own code at 99%. Naming the target keeps the number checkable.

The count is independently corroborated by the top CHANGELOG entry: *"The test suite grew from 162 to 261 checks."*

## The documented test command was broken

The command already in the README fails on any machine without the project's signing certificate:

```
error: No signing certificate "Mac Development" found: No "Mac Development" signing
certificate matching team ID K2ATHQPJDP with a private key was found.
```

So the section documents the form that actually works, adding `CODE_SIGNING_ALLOWED=NO`, with a note to drop it if you have the cert.

## On the low number

14.3% is stated plainly with a sentence explaining it is structural, not neglect — most of the app target is SwiftUI settings views and menu-bar machinery requiring live status items, event taps, and granted permissions, none of which run headlessly. The section points at `docs/testing/layout-pane-manual-tests.md` for what is verified by hand instead. I'd rather publish an honest 14.3% than a flattering aggregate.

## Worth knowing

ice-2 has `lint.yml` but **no test workflow**, so no CI badge is included here — there would be nothing for it to point at, and the suite never runs on a PR. Of the four repos only yahoo-keykey-2 runs tests in CI. Adding one here would let this table be replaced by a live badge instead of a timestamped snapshot.

Only `README.md` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)