### PR TITLE
chore(run-debug): drop redundant CODE_SIGNING_ALLOWED=NO overrides

### DIFF
--- a/scripts/run-debug.sh
+++ b/scripts/run-debug.sh
@@ -30,10 +30,10 @@ cd "$repo_root"
 echo "==> Building $SCHEME ($CONFIG)…"
 xcodebuild -scheme "$SCHEME" -configuration "$CONFIG" \
   -destination 'generic/platform=macOS' \
-  build CODE_SIGNING_ALLOWED=NO -quiet
+  build -quiet
 
 products_dir="$(xcodebuild -scheme "$SCHEME" -configuration "$CONFIG" \
-  -destination 'generic/platform=macOS' -showBuildSettings CODE_SIGNING_ALLOWED=NO 2>/dev/null \
+  -destination 'generic/platform=macOS' -showBuildSettings 2>/dev/null \
   | awk -F' = ' '/ BUILT_PRODUCTS_DIR = /{print $2; exit}')"
 
 src="$products_dir/Ice 2.app"
@@ -59,6 +59,8 @@ if ! "$pb" -c "Set :CFBundleDisplayName $DEBUG_NAME" "$dst/Contents/Info.plist" 
   "$pb" -c "Add :CFBundleDisplayName string $DEBUG_NAME" "$dst/Contents/Info.plist"
 fi
 
+# The Debug configuration already ad-hoc signs, but the PlistBuddy edits above
+# invalidate that signature ("invalid Info.plist"), so the copy must be re-signed.
 echo "==> Ad-hoc signing…"
 codesign --force --deep --sign - "$dst" >/dev/null 2>&1
 


### PR DESCRIPTION
Follow-up to #50, which switched the Debug configuration to ad-hoc signing (`CODE_SIGN_IDENTITY = "-"`, Manual, no team). That made the `CODE_SIGNING_ALLOWED=NO` overrides in `scripts/run-debug.sh` dead weight — the build signs itself now, and `-showBuildSettings` never signed anything to begin with. Both are removed.

### The final `codesign` stays

The `codesign --force --deep --sign -` after the bundle-id rewrite is still load-bearing, verified rather than assumed. Copying the build output, applying only the PlistBuddy edits, and re-verifying gives:

```
probe.app: invalid Info.plist (plist or signature have been modified)
```

Added a comment above it so it isn't mistaken for duplicate work later.

Worth noting: Debug carries `ENABLE_HARDENED_RUNTIME = YES`, and ad-hoc + hardened runtime is what trips Library Validation on the vendored Sparkle framework. It doesn't bite here — the built app comes out `flags=0x2(adhoc)` with no `runtime` flag, and the re-sign (no `-o runtime`) would strip it regardless. A second reason to keep it.

### Verification

`bash scripts/run-debug.sh`:

- Builds, re-ids, signs, and launches with no errors
- Process stays alive past a minute; no crash reports in `~/Library/Logs/DiagnosticReports`
- `codesign --verify --deep --strict` → valid on disk, satisfies its Designated Requirement
- Bundle id `com.dragonapp.ice.debug`, `flags=0x2(adhoc)`
- Embedded XPC keeps its original id `com.dragonapp.ice.MenuBarItemService`

No changes to the Release configuration or any workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)