### PR TITLE
release: v2.9.11 — stop capturing the screen when nothing will use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.9.11 - 2026-08-01
+
+### Improved
+
+- **Ice 2 looks at your screen far less often.** To draw a menu bar shape, remove the menu bar background, or round the screen corners, Ice 2 needs to know what your wallpaper looks like behind the menu bar. macOS no longer tells apps when the wallpaper changes, so Ice 2 has to look for itself every five seconds. It was doing that around the clock — including while the display was asleep or the screen was locked, where nothing it draws is visible, and for appearance settings that only tint, outline, or shadow the menu bar and never use the wallpaper at all. Ice 2 now looks only when the result will actually be drawn.
+
+- **Why you may have seen a big number in the privacy report.** macOS counts each of those looks under **System Settings → Privacy & Security → Screen & System Audio Recording**, and occasionally shows the running total in a notification — which is how it could reach tens of thousands in a month. That number should grow much more slowly from now on. To be clear about what was being counted: Ice 2 has never recorded audio, and it only ever captures the menu bar strip and the wallpaper directly behind it. macOS combines screen and audio into a single permission, so its wording mentions both.
+
 ## 2.9.10 - 2026-07-25
 
 ### Fixed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.10;
+				MARKETING_VERSION = 2.9.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -738,7 +738,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.9.10;
+				MARKETING_VERSION = 2.9.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/MenuBar/Appearance/Configurations/MenuBarAppearanceConfigurationV2.swift
+++ b/Ice/MenuBar/Appearance/Configurations/MenuBarAppearanceConfigurationV2.swift
@@ -25,6 +25,16 @@ struct MenuBarAppearanceConfigurationV2: Hashable {
         }
     }
 
+    /// A Boolean value that indicates whether the configuration draws the
+    /// desktop wallpaper.
+    ///
+    /// The wallpaper is only ever drawn to fill in the parts of the menu bar
+    /// that the configuration cuts away, so configurations that merely tint,
+    /// outline, or shadow the menu bar don't need it captured.
+    var needsDesktopWallpaper: Bool {
+        removesMenuBarBackground || roundsScreenCorners || shapeKind != .noShape
+    }
+
     var current: MenuBarAppearancePartialConfiguration {
         if isDynamic {
             switch SystemAppearance.current {

--- a/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -202,7 +202,10 @@ final class MenuBarOverlayPanel: NSPanel {
         Timer.publish(every: 5, on: .main, in: .default)
             .autoconnect()
             .sink { [weak self] _ in
-                self?.insertUpdateFlag(.desktopWallpaper)
+                guard let self, needsDesktopWallpaper else {
+                    return
+                }
+                insertUpdateFlag(.desktopWallpaper)
             }
             .store(in: &c)
 
@@ -248,9 +251,48 @@ final class MenuBarOverlayPanel: NSPanel {
                     self?.alphaValue = isHidden ? 0 : 1
                 }
                 .store(in: &c)
+
+            // Capture right away when a configuration that draws the wallpaper is
+            // applied, instead of leaving the panel unpainted until the next poll.
+            // The initial value is dropped, since `show()` already captures when
+            // the panel is first ordered front.
+            //
+            // The hop to the main queue is required: `@Published` publishes from
+            // `willSet`, so the manager still holds the previous configuration
+            // during the emission, and the update this schedules runs
+            // synchronously. Without the hop, the update would read the old
+            // configuration and decide it doesn't need the wallpaper after all.
+            appState.appearanceManager.$configuration
+                .map(\.needsDesktopWallpaper)
+                .removeDuplicates()
+                .dropFirst()
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] needsWallpaper in
+                    guard let self, needsWallpaper else {
+                        return
+                    }
+                    insertUpdateFlag(.desktopWallpaper)
+                }
+                .store(in: &c)
         }
 
         cancellables = c
+    }
+
+    /// A Boolean value that indicates whether the panel has a reason to capture
+    /// the desktop wallpaper.
+    ///
+    /// A panel is created for any nondefault appearance, but only some of them
+    /// draw the wallpaper, and none of them are visible while their own display
+    /// is hidden. Capturing in either case is wasted work — and, since capturing
+    /// requires screen recording permission, a wasted entry in the system's
+    /// privacy report.
+    private var needsDesktopWallpaper: Bool {
+        guard let appState else {
+            return false
+        }
+        return appState.appearanceManager.configuration.needsDesktopWallpaper
+            && !ScreenState.isHidden(for: owningScreen.displayID)
     }
 
     /// Inserts the given update flag into the panel's current list of update flags.
@@ -299,6 +341,7 @@ final class MenuBarOverlayPanel: NSPanel {
     /// of the given display.
     private func updateDesktopWallpaper(for display: CGDirectDisplayID, with windows: [WindowInfo]) {
         guard
+            needsDesktopWallpaper,
             let wallpaperWindow = WindowInfo.wallpaperWindow(from: windows, for: display),
             let menuBarWindow = WindowInfo.menuBarWindow(from: windows, for: display)
         else {

--- a/Ice/Utilities/ScreenState.swift
+++ b/Ice/Utilities/ScreenState.swift
@@ -1,0 +1,33 @@
+//
+//  ScreenState.swift
+//  Ice
+//
+
+import CoreGraphics
+
+/// A namespace for the current state of the screen.
+enum ScreenState {
+    /// The session dictionary key that reports the screen lock state. There is
+    /// no public API for this, but the key has been stable for many releases.
+    private static let screenIsLockedKey = "CGSSessionScreenIsLocked"
+
+    /// Returns a Boolean value that indicates whether the contents of the given
+    /// display are currently hidden from the user, either because the display is
+    /// asleep or because the screen is locked.
+    ///
+    /// Nothing drawn on top of the menu bar is visible in this state, so there
+    /// is no reason to keep capturing the screen to update it.
+    ///
+    /// - Parameter displayID: An identifier for the display to check. Displays
+    ///   sleep independently, so this must be the display being drawn on. The
+    ///   lock state, in contrast, belongs to the session as a whole.
+    static func isHidden(for displayID: CGDirectDisplayID) -> Bool {
+        if CGDisplayIsAsleep(displayID) != 0 {
+            return true
+        }
+        guard let session = CGSessionCopyCurrentDictionary() as? [String: Any] else {
+            return false
+        }
+        return session[screenIsLockedKey] as? Bool ?? false
+    }
+}

--- a/IceTests/AppearanceConfigurationV2Tests.swift
+++ b/IceTests/AppearanceConfigurationV2Tests.swift
@@ -185,6 +185,35 @@ struct AppearanceConfigurationV2Tests {
         #expect(configuration.current.borderWidth == expected)
     }
 
+    // MARK: needsDesktopWallpaper
+
+    @Test func tintBorderAndShadowDoNotNeedTheWallpaper() {
+        // These are drawn on top of the menu bar, so the panel never has to
+        // fill anything back in, and never has to capture the screen.
+        var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+        configuration.staticConfiguration.tintKind = .solid
+        configuration.staticConfiguration.hasBorder = true
+        configuration.staticConfiguration.hasShadow = true
+        #expect(!configuration.needsDesktopWallpaper)
+    }
+
+    @Test func cutawayConfigurationsNeedTheWallpaper() {
+        for makeConfiguration in [
+            { (c: inout MenuBarAppearanceConfigurationV2) in c.removesMenuBarBackground = true },
+            { (c: inout MenuBarAppearanceConfigurationV2) in c.roundsScreenCorners = true },
+            { (c: inout MenuBarAppearanceConfigurationV2) in c.shapeKind = .full },
+            { (c: inout MenuBarAppearanceConfigurationV2) in c.shapeKind = .split },
+        ] {
+            var configuration = MenuBarAppearanceConfigurationV2.defaultConfiguration
+            makeConfiguration(&configuration)
+            #expect(configuration.needsDesktopWallpaper)
+        }
+    }
+
+    @Test func defaultConfigurationDoesNotNeedTheWallpaper() {
+        #expect(!MenuBarAppearanceConfigurationV2.defaultConfiguration.needsDesktopWallpaper)
+    }
+
     // MARK: Defaults
 
     @Test func defaultConfigurationIsInsetAndUntinted() {


### PR DESCRIPTION
## Why

The menu bar appearance overlay polls the desktop wallpaper every 5 seconds — macOS no longer posts a wallpaper-change notification, so there's nothing to observe. Each poll is a `CGWindowListCreateImageFromArray` call that macOS attributes to the **Screen & System Audio Recording** permission, which is why the privacy report reaches tens of thousands of accesses a month and occasionally fires a notification about it.

The poll ran unconditionally. Two situations make it pointless.

## What changed

**1. Configurations that never draw the wallpaper.** The wallpaper is only drawn to fill in what the overlay cuts away — `removesMenuBarBackground`, `roundsScreenCorners`, or a shape. But an overlay panel is created for *any* nondefault appearance, so tint-only, border-only, and shadow-only users were capturing the screen every 5s and discarding the result. Now expressed as `MenuBarAppearanceConfigurationV2.needsDesktopWallpaper`.

**2. Display asleep or screen locked.** Nothing the panel draws is visible. New `ScreenState.isHidden(for:)` checks `CGDisplayIsAsleep` for the panel's *own* display (displays sleep independently) plus the session-wide lock flag.

Both are checked at the 5s tick — so a skipped poll also skips the `WindowInfo.createWindows` walk that precedes each capture — and again inside `updateDesktopWallpaper` as a backstop for the other trigger paths (`show()`, light/dark switch).

**Regression headed off.** With the wallpaper no longer kept warm, enabling a shape on a previously tint-only configuration would leave the cutout unpainted until the next tick. A `$configuration` subscription captures immediately instead. It hops to the main queue first: `@Published` emits from `willSet`, so the manager still holds the *old* configuration during the emission, and the synchronous update would otherwise read it and skip the capture.

## Effect

- Tint/border/shadow-only appearances: no wallpaper captures at all (previously 720/hour).
- Everyone: no captures while the display sleeps or the screen is locked.
- No shape user loses anything — the wallpaper still refreshes every 5s while the screen is visible.

## Testing

- `xcodebuild test` → 264 tests pass, no new warnings.
- 3 new tests pin `needsDesktopWallpaper` to the four drawing paths that actually consume the image, so the predicate can't drift away from the renderer.
- Not unit-testable and verified by inspection only: the Combine delivery timing and the live display-state reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)