### PR TITLE
refactor(menu): bump DragonKit to 1.5.0 and adopt the shared DragonAppMenu

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -894,7 +894,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.3.0;
+				minimumVersion = 1.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "fbc9ff884240e448f3f4c17dc1871eb68f84a029",
-        "version" : "1.3.0"
+        "revision" : "62301b93029769054e6872d2d754a262930eed8c",
+        "version" : "1.5.0"
       }
     },
     {

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -5,6 +5,7 @@
 
 import Cocoa
 import Combine
+import DragonKit
 import LaunchAtLogin
 
 // MARK: - ControlItem
@@ -558,51 +559,19 @@ final class ControlItem {
         menu.addItem(.separator())
 
         // Standard lifecycle items (SKILL.md §5A), flattened to the top level
-        // rather than nested in an "Ice 2" submenu.
-        let aboutItem = menuItem(
-            title: "About Ice 2",
-            symbolName: "info.circle",
-            action: #selector(openAbout)
-        )
-        aboutItem.target = self
-        menu.addItem(aboutItem)
-
-        let checkForUpdatesItem = menuItem(
-            title: "Check for updates…",
-            symbolName: "arrow.triangle.2.circlepath",
-            action: #selector(checkForUpdates)
-        )
-        checkForUpdatesItem.target = self
-        menu.addItem(checkForUpdatesItem)
-
-        let settingsItem = menuItem(
-            title: "Settings…",
-            symbolName: "gearshape",
-            action: #selector(openSettings),
-            keyEquivalent: ","
-        )
-        settingsItem.keyEquivalentModifierMask = .command
-        settingsItem.target = self
-        menu.addItem(settingsItem)
-
-        menu.addItem(.separator())
-
-        let uninstallItem = menuItem(
-            title: "Uninstall Ice 2…",
-            symbolName: "trash",
-            action: #selector(performUninstall)
-        )
-        uninstallItem.target = self
-        menu.addItem(uninstallItem)
-
-        let quitItem = menuItem(
-            title: "Quit Ice 2",
-            symbolName: "power",
-            action: #selector(NSApp.terminate),
-            keyEquivalent: "q"
-        )
-        quitItem.keyEquivalentModifierMask = .command
-        menu.addItem(quitItem)
+        // rather than nested in an "Ice 2" submenu. They come from DragonKit so
+        // every Dragon app shows the same titles, symbols, and order instead of
+        // drifting. `items(_:)` supplies the divider before Uninstall/Quit
+        // itself, so the separator above is the only one added here.
+        for item in DragonAppMenu.items(DragonAppMenu.Config(
+            appName: "Ice 2",
+            onAbout: { [weak self] in self?.openAbout() },
+            onSettings: { [weak self] in self?.openSettings() },
+            onCheckForUpdates: { [weak self] in self?.checkForUpdates() },
+            onUninstall: { [weak self] in self?.performUninstall() }
+        )) {
+            menu.addItem(item)
+        }
 
         return menu
     }


### PR DESCRIPTION
## Why

Ice 2 hand-built the five status-item lifecycle items (About, Check for updates, Settings, Uninstall, Quit) — and so did every other Dragon app. Four independent copies of the same menu is exactly how they drifted: titles, SF Symbols, and order diverged app by app with nothing to catch it.

DragonKit 1.5.0 ships `DragonAppMenu` as the single source of truth for that dropdown. This PR bumps the pin and builds the tail of Ice 2's menu from it.

## What changed

- `Ice.xcodeproj/project.pbxproj` — dragon-kit `minimumVersion` 1.3.0 → 1.5.0.
- `Package.resolved` — dragon-kit re-resolved to 1.5.0 (`62301b9`), was 1.3.0 (`fbc9ff8`).
- `Ice/MenuBar/ControlItem/ControlItem.swift` — `createMenu(with:)` now appends `DragonAppMenu.items(...)` instead of hand-rolling six `NSMenuItem`s (net −31 lines), plus `import DragonKit`. Closures forward to the existing `openAbout` / `checkForUpdates` / `openSettings` / `performUninstall` handlers, captured `[weak self]`.

Ice 2's own quick actions (Search Menu Bar Items, the Hidden/Always-Hidden toggles) are untouched and still lead the menu; only the shared tail is delegated. The separator *before* About stays — `items(_:)` deliberately has no leading separator. The separator that used to sit between Settings and Uninstall is gone from this file because `items(_:)` inserts that divider itself; keeping ours would double it.

## Intentional visible changes

| | before | after |
|---|---|---|
| updates title (en) | Check for updates… | **Check for Updates…** (macOS title case) |
| updates icon | `arrow.triangle.2.circlepath` | **`arrow.down.circle`** (matches the Updates pane's sidebar symbol) |

Everything else — order, the other five symbols, ⌘, and ⌘Q — is identical to what Ice 2 rendered before. (`NSMenuItem.keyEquivalentModifierMask` defaults to `.command`, so dropping the explicit assignments is a no-op.)

## Known consequence: the menu does NOT localize

DragonKit resolves these titles through `L()`, and its bundle ships 7 languages (en, es, fr, ja, ko, zh-Hans, zh-Hant). Ice 2 has no localization of its own — no `.lproj`, no `Localizable.strings`. The net effect, verified against the built bundle:

`LocalizationManager` defaults to `.system`, whose preferred codes are `Bundle.main.preferredLocalizations`. For `Ice 2.app` that is **`["en"]` regardless of the OS language** — the bundle declares `CFBundleDevelopmentRegion = en` and offers no other localization, so CFBundle's negotiation has nothing else to pick. `L()` therefore resolves DragonKit's `en.lproj` and the menu renders in **English on a Japanese Mac**.

So there is **no mixed-language UI** — but the flip side is that DragonKit's other six languages are unreachable from Ice 2 (this already applies to the DragonKit-owned About / What's New / Permissions panes, not just the menu). Making them reachable would need Ice 2 to ship its own localizations (or `CFBundleLocalizations`) or to surface DragonKit's `LanguagePicker`. Out of scope here.

## Verification

- `xcodebuild -project Ice.xcodeproj -scheme Ice -configuration Debug -destination 'platform=macOS,arch=arm64' build` → **BUILD SUCCEEDED**
- `xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'` (the CI invocation) → **TEST SUCCEEDED**, 264 tests in 30 suites
- `swiftlint lint --strict` (0.65.0, same as CI) → clean

No `MARKETING_VERSION` bump and no release tag — this is a dependency + refactor PR only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)