### PR TITLE
fix(uninstall): remove the caches the in-app flow was leaving behind

### DIFF
--- a/Ice/Settings/IceUninstallConfig.swift
+++ b/Ice/Settings/IceUninstallConfig.swift
@@ -10,22 +10,37 @@ import Foundation
 /// ``UninstallSettingsPane`` and performed by ``DragonUninstaller``.
 ///
 /// Only Ice 2's own content lives here — the confirmation layout and the teardown are owned
-/// by DragonKit. Everything Ice 2 writes lives in its `UserDefaults` domain (`Defaults.store`
-/// is `.standard`) plus its saved application state, both of which the shared teardown
-/// removes from `bundleID`, so there are no extra suites and no extra cleanup paths. Ice 2
-/// keeps no separate user data either — its settings *are* its data, always removed — so
-/// there is no optional "also delete data" toggle, unlike ClipMenu.
+/// by DragonKit. Ice 2's settings live in its `UserDefaults` domain (`Defaults.store` is
+/// `.standard`), which the shared teardown wipes from `bundleID` along with the matching
+/// preference plist and saved application state, so there are no extra suites. Ice 2 keeps no
+/// separate user data either — its settings *are* its data, always removed — so there is no
+/// optional "also delete data" toggle, unlike ClipMenu.
+///
+/// `extraCleanupPaths` covers the per-bundle-id folders the shared teardown can't know about:
+/// the `Caches` and `HTTPStorages` folders macOS creates for the app's own network traffic
+/// (Sparkle's appcast fetches), plus `Application Support`. Ice 2 writes nothing to
+/// `Application Support` today, but it is listed so the in-app uninstall, the manual `rm -rf`
+/// in `README.md`, and the Homebrew cask's `zap trash:` all remove the same five paths —
+/// keeping those three from drifting is the point, and removing an absent folder is a no-op.
 enum IceUninstallConfig {
     static var config: UninstallConfig {
-        UninstallConfig(
+        // The running bundle's id, so a debug build (com.dragonapp.ice.debug) cleans its OWN
+        // domain/state/caches and never the installed release's.
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.dragonapp.ice"
+        let library = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library")
+        return UninstallConfig(
             appName: "Ice 2",
-            // The running bundle's id, so a debug build (com.dragonapp.ice.debug) cleans its
-            // OWN domain/state and never the installed release's.
-            bundleID: Bundle.main.bundleIdentifier ?? "com.dragonapp.ice",
+            bundleID: bundleID,
             checklistItems: [
                 "The app and its login item",
                 "Settings, layout profiles, and hotkeys",
                 "Saved application state",
+                "Caches and support files",
+            ],
+            extraCleanupPaths: [
+                library.appending(path: "Application Support/\(bundleID)"),
+                library.appending(path: "Caches/\(bundleID)"),
+                library.appending(path: "HTTPStorages/\(bundleID)"),
             ]
         )
     }

--- a/IceTests/UninstallConfigTests.swift
+++ b/IceTests/UninstallConfigTests.swift
@@ -10,8 +10,9 @@ import Testing
 
 /// Pins the configuration Ice 2 hands to DragonKit's uninstaller. This is the seam where a
 /// mistake silently changes what a destructive, unrecoverable operation deletes, so the
-/// contract is asserted here rather than trusted to review: the domain that gets wiped, the
-/// checklist the user is shown, and — just as importantly — that nothing *extra* is deleted.
+/// contract is asserted here rather than trusted to review: the domain that gets wiped, every
+/// path removed alongside it, the checklist the user is shown, and — just as importantly —
+/// that all of it stays scoped to the *running* bundle id.
 struct UninstallConfigTests {
     private var config: UninstallConfig { IceUninstallConfig.config }
 
@@ -29,15 +30,41 @@ struct UninstallConfigTests {
             "The app and its login item",
             "Settings, layout profiles, and hotkeys",
             "Saved application state",
+            // The caches/support folders `extraCleanupPaths` adds are deleted, so the
+            // confirmation has to say so — the sheet must not under-report the damage.
+            "Caches and support files",
         ])
     }
 
-    @Test func deletesNothingBeyondTheBundlesOwnDomain() {
+    @Test func removesThePerBundleLibraryFolders() {
+        // The three folders the shared teardown can't infer, matching the manual `rm -rf` in
+        // README.md and the Homebrew cask's `zap trash:`. Pinned exactly — and in order — so
+        // widening or narrowing an unrecoverable delete has to be a deliberate edit here.
+        let library = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library")
+        #expect(config.extraCleanupPaths == [
+            library.appending(path: "Application Support/\(config.bundleID)"),
+            library.appending(path: "Caches/\(config.bundleID)"),
+            library.appending(path: "HTTPStorages/\(config.bundleID)"),
+        ])
+    }
+
+    @Test func scopesEveryCleanupPathToTheRunningBundle() {
+        // The guardrail behind `wipesTheRunningBundlesDomain`: a debug build
+        // (com.dragonapp.ice.debug) must never delete the installed release's caches, so every
+        // path has to be built from the *running* bundle id and stay inside ~/Library.
+        let library = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library")
+        for url in config.extraCleanupPaths {
+            // Each folder is named for the running bundle id...
+            #expect(url.lastPathComponent == Bundle.main.bundleIdentifier)
+            // ...and sits under this user's ~/Library, never anywhere else on disk.
+            #expect(url.path.hasPrefix(library.path + "/"))
+        }
+    }
+
+    @Test func deletesNothingBeyondTheBundlesOwnFolders() {
         // Ice 2's settings live in `UserDefaults.standard` (`Defaults.store`), i.e. the
         // bundle-id domain the uninstaller already wipes — so no extra suites.
         #expect(config.suiteNames.isEmpty)
-        // No support files or caches outside that domain, so nothing else is removed.
-        #expect(config.extraCleanupPaths.isEmpty)
         // Ice 2 keeps no separate user data — its settings *are* its data, always removed —
         // so there is no optional "also delete data" choice to opt into.
         #expect(config.optionalDataToggle == nil)


### PR DESCRIPTION
Stacked on #56 — `IceUninstallConfig.swift` only exists on that branch, so this targets it rather than `main`. Rebase onto `main` if #56 lands first.

## The gap

`README.md` tells users to delete five paths by hand, and the Homebrew cask's `zap trash:` lists the same five. The in-app Uninstall removed only **two** of them:

| Path | README | Cask `zap` | In-app (before) | In-app (after) |
|---|---|---|---|---|
| `Application Support/com.dragonapp.ice` | ✅ | ✅ | ❌ | ✅ |
| `Caches/com.dragonapp.ice` | ✅ | ✅ | ❌ | ✅ |
| `HTTPStorages/com.dragonapp.ice` | ✅ | ✅ | ❌ | ✅ |
| `Preferences/com.dragonapp.ice.plist` | ✅ | ✅ | ✅ | ✅ |
| `Saved Application State/…savedState` | ✅ | ✅ | ✅ | ✅ |

Not hypothetical: on a machine with Ice 2 installed, `Caches/com.dragonapp.ice` and `HTTPStorages/com.dragonapp.ice` both exist — macOS creates them for the app's own network traffic (Sparkle's appcast fetches). They survived an in-app uninstall.

The gap predates #56; that PR deliberately kept the path set byte-for-byte identical to the old bespoke `runUninstall()` rather than expanding it.

## The fix

Pass the three folders to DragonKit's `extraCleanupPaths`, which exists for exactly this and names these directories in its own doc comment. Mirrors `clipmenu-2`'s config down to the `"Caches and support files"` checklist wording.

Two details worth review:

- **Built from the *running* bundle id**, resolved once and shared with `bundleID`. A debug build (`com.dragonapp.ice.debug`) cleans its own folders and never the installed release's. A new test asserts this invariant for every path, so a future addition can't hardcode the release id.
- **A fourth checklist item.** The confirmation sheet is what the user reads before an unrecoverable delete; now that caches go too, it has to say so. Without it the sheet under-reports the damage — and the test enforcing this is literally named `namesExactlyWhatIsRemoved`.

`Application Support/com.dragonapp.ice` is listed even though Ice 2 writes nothing there today (it's absent on disk, and the only source hit for "application support" is the unrelated `applicationSupportsSecureRestorableState`). It's included so all three surfaces remove the same five paths — a 2-of-3 set just re-opens a smaller version of this gap. Removing an absent folder is a no-op under `try? removeItem`.

## Homebrew cask: no change needed

Checked `teddychan/homebrew-tap` at `origin/main` (`Casks/ice-2.rb`), per the `docs/RELEASING.md` note to keep the cask's `uninstall`/`zap` paths in sync with the bundle id. Its `zap trash:` **already lists all five paths**, byte-identical to the README — corrected in `a2b4be7`. The cask was already the superset; only the in-app flow lagged. Nothing to sync.

## Verification

- `xcodebuild … build CODE_SIGNING_ALLOWED=NO` → **BUILD SUCCEEDED**
- `xcodebuild test …` → **269 tests in 31 suites passed**
- `swiftlint lint --strict` → **0 violations in 111 files**

The destructive flow was never executed — the tests read `IceUninstallConfig.config` as a value and never call `DragonUninstaller.run`. Confirmed afterwards that the real `Caches/`, `HTTPStorages/`, and `Preferences/` entries are still intact on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)