### PR TITLE
ci: assert the release tag matches the app's marketing version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@ jobs:
       xcode_scheme: Ice
       xcode_export_options: .github/release/exportOptions.plist
       xcode_development_team: 4AF3KGGV29
+      # Fail the release (before notarization) if the tag doesn't match the
+      # exported app's CFBundleShortVersionString — i.e. the Ice target's
+      # MARKETING_VERSION in Ice.xcodeproj. Guards against tagging vX.Y.Z without
+      # bumping the project, which would ship an app reporting the old version and
+      # put a stale version in the Sparkle appcast.
+      assert_tag_matches_plist: true
       zip_name_template: 'Ice-2-{TAG}.zip'
       zip_keep_parent: true
       generate_appcast_glob: xcodebuild


### PR DESCRIPTION
Opts into the shared release pipeline's `assert_tag_matches_plist` check.

**Why:** tagging `vX.Y.Z` without bumping the `Ice` target's `MARKETING_VERSION` releases green today — the zip is named for the tag, but the exported app reports the old version and the Sparkle appcast carries a stale `sparkle:shortVersionString`. Because Ice 2's version lives in `Ice.xcodeproj` rather than a hand-edited `Info.plist`, it's the easiest one of the Dragon apps to forget.

**What changes:** the shared workflow now fails the run before notarization (seconds, not a 10–60m notary round trip) when the tag and the exported app's `CFBundleShortVersionString` disagree.

The input was previously honoured only on the `script` build path — it sat inside a step gated on `build_kind == 'script'`, so the `xcodebuild` path never ran it. teddychan/dragon-release-ci#13, released as `v5.1.0`, hoisted it to run for every `build_kind`. This repo pins `@v5`, which already floats to that commit — no pin bump needed.

**Verified a no-op for current practice:** the `Ice` target's `MARKETING_VERSION` matched the tag at v2.9.9, v2.9.10, v2.9.11 and v2.10.0, so this is a safety net rather than a new hurdle. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)