### PR TITLE
refactor(settings): stop shadowing DragonKit's backup type names (R3)

### DIFF
--- a/Ice/Settings/Backup/SettingsBackup.swift
+++ b/Ice/Settings/Backup/SettingsBackup.swift
@@ -5,6 +5,15 @@
 
 import Foundation
 
+/// Errors thrown when reading a backup file.
+///
+/// Named for its owner rather than the generic `BackupError`, which is a public
+/// DragonKit type name (see dragon-kit CONFORMANCE.md §R3).
+enum SettingsBackupError: Error, Equatable {
+    case malformed
+    case unsupportedVersion(Int)
+}
+
 /// Folder-based backup & restore of all of Ice's settings.
 ///
 /// Ice keeps every user setting in `UserDefaults.standard` under the keys in
@@ -38,11 +47,6 @@ enum SettingsBackup {
     /// The settings keys carried in a backup.
     static var backedUpKeys: [Defaults.Key] {
         Defaults.Key.allCases.filter { !excludedKeys.contains($0) }
-    }
-
-    enum BackupError: Error, Equatable {
-        case malformed
-        case unsupportedVersion(Int)
     }
 
     private enum PayloadKey {
@@ -115,11 +119,11 @@ enum SettingsBackup {
     static func deserialize(_ data: Data) throws -> [String: Any] {
         let object = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
         guard let payload = object as? [String: Any] else {
-            throw BackupError.malformed
+            throw SettingsBackupError.malformed
         }
         let version = payload[PayloadKey.schemaVersion] as? Int ?? 0
         guard version <= schemaVersion else {
-            throw BackupError.unsupportedVersion(version)
+            throw SettingsBackupError.unsupportedVersion(version)
         }
         return payload
     }

--- a/Ice/Settings/SettingsPanes/IceBackupSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/IceBackupSettingsPane.swift
@@ -1,11 +1,16 @@
 //
-//  BackupSettingsPane.swift
+//  IceBackupSettingsPane.swift
 //  Ice
 //
 
 import SwiftUI
 
-struct BackupSettingsPane: View {
+/// Ice 2's own folder-based backup pane. Deliberately not DragonKit's
+/// `BackupSettingsPane`, which snapshots a single UserDefaults suite — Ice 2 keeps
+/// versioned backup files in a user-chosen folder so settings can sync across Macs
+/// (see dragon-kit CONFORMANCE.md §R11). The `Ice` prefix keeps the name from
+/// shadowing the kit's pane (§R3).
+struct IceBackupSettingsPane: View {
     @EnvironmentObject var appState: AppState
 
     /// Backup folder. Defaults to ~/Documents/Ice Backups; the user can point it

--- a/Ice/Settings/SettingsView.swift
+++ b/Ice/Settings/SettingsView.swift
@@ -126,7 +126,7 @@ struct SettingsView: View {
         case .permissions:
             PermissionsPane(permissions: [.accessibility(), .screenRecording()])
         case .backup:
-            BackupSettingsPane()
+            IceBackupSettingsPane()
         case .whatsNew:
             WhatsNewPane(content: WhatsNewConfig.content)
         case .about:

--- a/IceTests/SettingsBackupTests.swift
+++ b/IceTests/SettingsBackupTests.swift
@@ -89,7 +89,7 @@ struct SettingsBackupTests {
             "defaults": [String: Any](),
         ]
         let data = try SettingsBackup.serialize(payload)
-        #expect(throws: SettingsBackup.BackupError.unsupportedVersion(SettingsBackup.schemaVersion + 1)) {
+        #expect(throws: SettingsBackupError.unsupportedVersion(SettingsBackup.schemaVersion + 1)) {
             _ = try SettingsBackup.deserialize(data)
         }
     }
@@ -100,7 +100,7 @@ struct SettingsBackupTests {
         let data = try PropertyListSerialization.data(
             fromPropertyList: ["a", "b"], format: .binary, options: 0
         )
-        #expect(throws: SettingsBackup.BackupError.malformed) {
+        #expect(throws: SettingsBackupError.malformed) {
             _ = try SettingsBackup.deserialize(data)
         }
     }


### PR DESCRIPTION
First of four PRs bringing Ice 2 into full [DragonKit conformance](https://github.com/teddychan/dragon-kit/blob/main/CONFORMANCE.md). Baseline on `main` is **13 violations**; this PR clears 2.

## Why

**R3 — no app type may shadow a public DragonKit type.** `Ice/Settings/SettingsView.swift` imports DragonKit *and* called a local `BackupSettingsPane`. It compiled, because Swift resolves the local type first — so Ice 2 looked like it used the kit's pane while using its own. That invisibility is the whole reason R3 exists.

Ice 2's folder-based, versioned backup is a **sanctioned divergence** (CONFORMANCE.md §R11): DragonKit's `DragonBackup` snapshots a single UserDefaults suite, while Ice 2 writes timestamped `.icebackup` files into a user-chosen folder so settings sync across Macs via Dropbox/iCloud/Drive. So the *behaviour* stays; only the *names* stop colliding.

## What changed

| before | after |
|---|---|
| `BackupSettingsPane` (`BackupSettingsPane.swift`) | `IceBackupSettingsPane` (`IceBackupSettingsPane.swift`) |
| `SettingsBackup.BackupError` | top-level `SettingsBackupError` |

Same views, same error cases, same on-disk backup format — a pure rename plus doc comments pointing at the rules.

## Verification

| check | result |
|---|---|
| `xcodebuild … -configuration Debug build CODE_SIGNING_ALLOWED=NO` | **BUILD SUCCEEDED** |
| `xcodebuild test` (the CI invocation) | **267 tests in 31 suites passed** — same as `main` |
| `swiftlint lint --strict` (0.65.0) | **0 violations, 0 serious** in 111 files |
| `dragon-conformance.py` | 13 → **11 violations** (both R3 backup shadows cleared) |

The third R3 violation (`UpdatesSettingsPane`) is cleared in PR 3 of this series, where Ice 2's pane is *deleted* in favour of the kit's — renaming a type that is about to be removed would be churn.

## Follow-ups in this series

1. this PR — R3 renames
2. R4 — drop `IceForm`/`IceSection`/`IceGroupBox`, adopt `DragonForm`/`DragonSection`/`.dragonAnnotation`
3. R6/R7 — `DragonUpdater` + the kit's `UpdatesSettingsPane`, and `LoginItem` for launch-at-login
4. `.dragon-conformance.json` + the conformance CI workflow (last, so the check lands green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)