### PR TITLE
ci: declare Ice 2's DragonKit conformance and check it on every PR (R0)

### DIFF
--- a/.dragon-conformance.json
+++ b/.dragon-conformance.json
@@ -1,0 +1,13 @@
+{
+  "app": "Ice 2",
+  "sources": ["Ice", "Shared", "MenuBarItemService"],
+  "strings": ["Ice/**/*.lproj/*.strings"],
+  "pin": {
+    "file": "Ice.xcodeproj/project.pbxproj",
+    "pattern": "dragon-kit\";[^}]*minimumVersion = ([0-9.]+)"
+  },
+  "paneOrder": {
+    "file": "Ice/Main/Navigation/NavigationIdentifiers/SettingsNavigationIdentifier.swift"
+  },
+  "traits": ["sparkle"]
+}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,20 @@
+name: DragonKit conformance
+
+# Thin caller: the rules (CONFORMANCE.md) and the checker live in dragon-kit and only there,
+# so Ice 2 picks up new rules automatically instead of keeping a copy that drifts — which is
+# the duplication the spec exists to prevent. What gets checked here is declared in
+# .dragon-conformance.json at the repo root.
+#
+# Pinned at @main because dragon-kit has no v2 tag for this workflow yet; move to @v2 once it
+# exists, so the pin covers the workflow's interface rather than tracking a branch.
+on:
+  pull_request:
+  workflow_dispatch: {}
+
+# The reusable workflow only checks out this repo and dragon-kit; read is all it needs.
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    uses: teddychan/dragon-kit/.github/workflows/conformance.yml@main


### PR DESCRIPTION
Last of four PRs bringing Ice 2 into full [DragonKit conformance](https://github.com/teddychan/dragon-kit/blob/main/CONFORMANCE.md). **Stacked on #62 → #61 → #60** — this PR's diff is only its own commit.

Deliberately last: the check is **green the moment it lands** instead of red-blocking the three PRs that do the actual work.

## What changed

- **`.dragon-conformance.json`** — R0: the app declares where its sources, strings, pane order and DragonKit pin live. Without it the checker can't run, and a missing config is itself a violation.
- **`.github/workflows/conformance.yml`** — a thin caller of the kit's reusable workflow, so the rules stay in dragon-kit and Ice 2 picks up new ones automatically.

## Two deltas from the suggested config, both deliberate

**1. `sources` includes `Shared` and `MenuBarItemService`.** The Ice target builds `Shared/` too, and `MenuBarItemService/` is shipped inside the app bundle. Scanning only `Ice` would leave 11 files where a shadowed type or a stray `SMAppService` call could hide. With all three roots the checker sees **115** Swift files instead of 104 — and still passes.

**2. The `pin` pattern is anchored to the dragon-kit package block:**

```
"pattern": "dragon-kit\";[^}]*minimumVersion = ([0-9.]+)"
```

`minimumVersion = ([0-9.]+)` on its own is unsound for a `.pbxproj`: the checker does one `re.search` over the whole file, so it matches the **first** package reference, not DragonKit's. On `main` that silently read **Sparkle's 2.5.2** and "passed" for the wrong reason; once #62 removes the Sparkle and LaunchAtLogin references it reads **AXSwift's 0.3.2** and fails with `pinned to DragonKit 0.3.2 but 2.0.1 is released`. Anchoring makes R10 check the thing it claims to check. (Worth fixing in the §R0 example in CONFORMANCE.md — any pbxproj-based app copying it hits this.)

## No §R11 exceptions

Ice 2 needs none. Its folder-based backup is still a sanctioned divergence from `DragonBackup`, but #60 fixed it by *renaming* the types out of the kit's namespace rather than excusing the collision — so there is no violation left to excuse. An `exceptions` entry would also suppress any *future* R3 finding at that path, which is exactly the invisibility R3 exists to prevent.

## Verification

| check | result |
|---|---|
| `dragon-conformance.py --app . --kit …` (committed config, no override) | **PASS — no violations** (115 Swift files, 39 kit types) |
| `xcodebuild … -configuration Debug build CODE_SIGNING_ALLOWED=NO` | **BUILD SUCCEEDED** |
| `xcodebuild test` (the CI invocation) | **267 tests in 31 suites passed** — same as `main` |
| `swiftlint lint --strict` (0.65.0) | **0 violations, 0 serious** |

Series summary: `main` **13 violations** → #60 −2 (R3) → #61 −4 (R4) → #62 −7 (R3, R6, R7) → **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)