### PR TITLE
release: v2.11.0 — restore gentle update reminders and the background-update notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.11.0 - 2026-08-04
+
+### Fixed
+
+- **Scheduled update checks stop interrupting you again.** When Ice 2 checks for updates on its own schedule, it shows the update window quietly, without pulling you out of what you were doing. Version 2.10.0 moved updates onto the shared Dragon app framework that Ice 2 uses for its menu, permissions, and settings — and in that move Ice 2 stopped asking for the quiet behaviour, so a check running in the background could take over the screen unprompted. It asks for it again.
+
+- **Ice 2 tells you when a background check finds an update.** The notification titled "A new update is available" is back. Because the update window deliberately does not steal focus, it can sit behind whatever you are working in — the notification is how you know it is there. This also went missing in 2.10.0. It applies only if you have **Automatically check for updates** turned on in Settings ▸ Updates, which is where macOS will ask permission to show notifications; declining changes nothing about how updates work, you just do not get the nudge.
+
+### If you are updating from 2.9.x
+
+- **Uninstalling Ice 2 has moved into Settings.** It used to be an **Uninstall** item in the Ice 2 menu that opened a separate window. Since 2.10.0 it is the last pane in the Settings sidebar, under **Uninstall**, with the confirmation right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state. The flow was **rewritten** in 2.10.0 on top of the shared framework rather than Ice 2's own copy of that code — the steps are the same and they are covered by automated tests, but it is a rewrite of a destructive, one-way path, so if removing Ice 2 misbehaves for you, please report it.
+
 ## 2.10.0 - 2026-08-04
 
 ### Changed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -702,7 +702,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.10.0;
+				MARKETING_VERSION = 2.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -737,7 +737,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.10.0;
+				MARKETING_VERSION = 2.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -877,7 +877,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.1;
+				minimumVersion = 2.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "6ebfbb9465bf33a3169a88ecea3959753f108184",
-        "version" : "2.0.1"
+        "revision" : "d68e6693988cf2d23167ce4b9d4be5ab607b5d4e",
+        "version" : "2.1.0"
       }
     },
     {

--- a/Ice/Main/Updates.swift
+++ b/Ice/Main/Updates.swift
@@ -4,29 +4,46 @@
 //
 
 import DragonKitUpdates
+import OSLog
 import SwiftUI
+import UserNotifications
 
 /// Manager for app updates.
 ///
 /// Sparkle itself lives in DragonKit's ``DragonUpdater`` (module `DragonKitUpdates`), which
 /// every Dragon app shares — same feed handling, same settings, and the same reworded
 /// "Ice 2 is up to date" alert. Ice 2 keeps only the app-specific parts here: bringing the
-/// app forward so Sparkle's dialogs appear in front, and the debug-build guard.
+/// app forward so Sparkle's dialogs appear in front, the debug-build guard, and its own
+/// notification for an update a background check found.
 @MainActor
 final class UpdatesManager {
     /// The shared app state.
     private(set) weak var appState: AppState?
 
     /// The underlying updater. The Updates settings pane observes this directly.
-    let updater = DragonUpdater()
+    ///
+    /// Both settings are behaviour Ice 2 had when it wired Sparkle itself and lost when it
+    /// moved onto the kit, because ``DragonUpdater`` passed no user-driver delegate at all.
+    let updater = DragonUpdater(config: DragonUpdaterConfig(
+        // A scheduled check shows Sparkle's window without stealing focus, rather than a modal
+        // arriving unprompted while you are working.
+        usesGentleScheduledReminders: true,
+        onUpdateFoundInBackground: { UpdatesManager.notifyUpdateAvailable() }
+    ))
 
     /// Performs the initial setup of the manager.
     func performSetup(with appState: AppState) {
         self.appState = appState
-        // `DragonUpdater` creates and starts Sparkle lazily on first use, so touch it here:
-        // starting the updater at launch is what lets Sparkle schedule its background update
+        // Starting the updater at launch is what lets Sparkle schedule its background update
         // checks, exactly as `SPUStandardUpdaterController(startingUpdater: true)` did.
-        _ = updater.canCheckForUpdates
+        updater.start()
+        // Only users who turned scheduled checks on can ever see the notification below
+        // (`SUEnableAutomaticChecks` is false by default), and only they were prompted before:
+        // the old `SPUUpdaterDelegate` hook that requested this fired when Sparkle scheduled a
+        // check, which it only does when they are enabled. Don't prompt everyone else.
+        if updater.automaticallyChecksForUpdates {
+            requestNotificationAuthorization()
+        }
     }
 
     /// Checks for app updates.
@@ -45,5 +62,40 @@ final class UpdatesManager {
         appState.openWindow(.settings)
         updater.checkForUpdates()
         #endif
+    }
+
+    /// Asks for permission to post ``notifyUpdateAvailable()``.
+    private func requestNotificationAuthorization() {
+        Task {
+            do {
+                try await UNUserNotificationCenter.current()
+                    .requestAuthorization(options: [.badge, .alert, .sound])
+            } catch {
+                Logger.default.error("Failed to request notification authorization: \(error)")
+            }
+        }
+    }
+
+    /// Posts Ice 2's "A new update is available" notification.
+    ///
+    /// Only ever called for a check the user did not start — ``DragonUpdaterConfig`` filters out
+    /// user-initiated ones, since someone who just clicked **Check for Updates…** is already
+    /// looking at the result. Because gentle reminders are on, Sparkle shows its update window
+    /// *without* activating Ice 2, so on a busy desktop that window can sit unnoticed behind
+    /// other apps; this is the nudge.
+    ///
+    /// Deliberately just the one notification, not the `UserNotificationManager` subsystem this
+    /// replaces. Sparkle is always the one showing the update here, so there is no state for a
+    /// `UNUserNotificationCenterDelegate` to drive that Sparkle's own window doesn't already
+    /// cover, and the two callbacks the old code hung off — clearing a delivered notification
+    /// once the update got attention, and naming the version in the body — need parts of
+    /// Sparkle's delegate that ``DragonUpdaterConfig`` does not expose.
+    private static func notifyUpdateAvailable() {
+        let content = UNMutableNotificationContent()
+        content.title = "A new update is available"
+        content.body = "\(Constants.displayName) found a newer version."
+        UNUserNotificationCenter.current().add(
+            UNNotificationRequest(identifier: "UpdateCheck", content: content, trigger: nil)
+        )
     }
 }

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -15,16 +15,14 @@ enum WhatsNewConfig {
         WhatsNewContent(
             version: Constants.versionString,
             date: "2026-08-04",
-            summary: "Uninstalling Ice 2 has moved into Settings.",
+            summary: "Update checks are quiet and considerate again.",
             sections: [
-                ChangeSection(kind: .changed, entries: [
-                    "Removing Ice 2 used to be an Uninstall item in the Ice 2 menu that opened a separate window. It is now the last pane in the Settings sidebar, under Uninstall, and the confirmation appears right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state.",
-                ]),
-                ChangeSection(kind: .removed, entries: [
-                    "The Uninstall item no longer appears in the Ice 2 menu. An unrecoverable action does not belong one click away from Quit in the everyday menu — Settings ▸ Uninstall is now the way to remove Ice 2 from inside the app.",
-                ]),
                 ChangeSection(kind: .fixed, entries: [
-                    "Uninstalling no longer leaves an emptied settings file behind. macOS rewrites an app's preferences file as the app quits, which could recreate the file Ice 2 had just deleted. Ice 2 now deletes those leftovers again once it has quit.",
+                    "Scheduled update checks stop interrupting you. When Ice 2 checks for updates on its own schedule, it shows the update window quietly instead of pulling you out of what you were doing. Version 2.10.0 moved updates onto the shared Dragon app framework and lost that, so a background check could take over the screen unprompted.",
+                    "Ice 2 tells you when a background check finds an update. The notification titled \"A new update is available\" is back. Because the update window deliberately does not steal focus, it can sit behind whatever you are working in — the notification is how you know it is there. It applies only if you have Automatically check for updates turned on, which is where macOS asks permission to show notifications; declining changes nothing about how updates work.",
+                ]),
+                ChangeSection(kind: .changed, entries: [
+                    "If you are coming from 2.9.x: uninstalling Ice 2 has moved into Settings. It used to be an Uninstall item in the Ice 2 menu that opened a separate window; since 2.10.0 it is the last pane in the Settings sidebar, with the confirmation right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state. That flow was rewritten in 2.10.0 on top of the shared framework — the same steps, covered by automated tests, but it is a rewrite of a destructive, one-way path, so please report anything that misbehaves.",
                 ]),
             ]
         )


### PR DESCRIPTION
## What

DragonKit **2.1.0** adds the two hooks Ice 2 lost in 2.10.0 when updates moved onto the kit. `DragonUpdater` passed no user-driver delegate at all, so Ice 2's `supportsGentleScheduledUpdateReminders` and its own "A new update is available" notification both stopped, and `UserNotificationManager` became dead code (deleted in #64).

Restored in `UpdatesManager`:

- `usesGentleScheduledReminders: true` — a scheduled check shows Sparkle's window without stealing focus, instead of a modal arriving unprompted.
- `onUpdateFoundInBackground:` — posts the notification again.
- `updater.start()` replaces poking `canCheckForUpdates` to wake Sparkle.

## What was *not* resurrected, and why

The notification is ~20 lines in `UpdatesManager`, not a restore of the deleted `UserNotificationManager` / `UserNotificationIdentifier` pair. Of that subsystem, only "post one notification" is still reachable through the kit's hook:

| Old behaviour | Status |
|---|---|
| post "A new update is available" for a background-found update | **restored** |
| clear the delivered notification once the update got attention | not possible — needs `standardUserDriverDidReceiveUserAttention`, which `DragonUpdaterConfig` does not expose |
| body naming the version (`Version X is now available`) | not possible — the hook passes no `SUAppcastItem`, so the body is version-free |
| `UNUserNotificationCenterDelegate` so a tap re-checks | dropped — Sparkle always shows the update window here (nothing implements `standardUserDriverShouldHandleShowingScheduledUpdate`, so `handleShowingUpdate` is always true), leaving a tap handler nothing to drive that the window doesn't already cover |
| one-case `UserNotificationIdentifier` enum + generic `addRequest(with:title:body:)` | dropped — ceremony for a single call site |

Restoring the files would re-create exactly the dead code that got them deleted.

**Authorization is requested only when scheduled checks are enabled.** Ice 2 ships with `SUEnableAutomaticChecks` false, and the old `SPUUpdaterDelegate` hook that requested authorization fired only when Sparkle actually scheduled a check. Prompting every user at launch would be a *new* prompt, not a restored one.

## Release

- Pin `2.0.1` → **2.1.0** + refreshed `Package.resolved` (revision `d68e669`; `git tag --points-at` → `v2.1.0`). Conformance **R10 was failing** on the stale pin.
- `MARKETING_VERSION` `2.10.0` → **2.11.0** on both `Ice` configurations. `CURRENT_PROJECT_VERSION` untouched — CI stamps it from `git rev-list --count HEAD`, and Sparkle compares that.
- `CHANGELOG.md` + What's New pane. Both carry forward 2.10.0's **rewritten** Uninstall-in-Settings flow, since most users upgrading are coming straight from 2.9.x and never saw it.

## Verification

| Check | Before | After |
|---|---|---|
| conformance | FAIL (R10 stale pin) | **PASS** |
| `xcodebuild test` | 267 tests / 31 suites | **267 / 31** — unchanged |
| `swiftlint --strict` | 0 violations | **0 violations** |

`SUFeedURL` and `SUPublicEDKey` are **untouched** — `Ice/Resources/Info.plist` is not in this diff.

Three pre-existing `MenuBarSection.swift` main-actor warnings surface on a full recompile; confirmed present on unmodified `main` and unrelated to this change.

**Runtime updater behaviour is code-verified only.** A gentle reminder or a background notification requires the appcast to advertise a build newer than the installed one, so neither can be exercised until after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)