### PR TITLE
Add permission-free menu bar window probe for issue #53

### DIFF
--- a/scripts/menubar-probe.swift
+++ b/scripts/menubar-probe.swift
@@ -1,0 +1,157 @@
+// menubar-probe.swift
+//
+// A standalone, permission-free probe for issue #53 (menu bar items not hidden
+// on macOS 27). It exercises the single private API that Ice's entire menu bar
+// model rests on — `CGSGetProcessMenuBarWindowList` — and reports how many
+// windows the WindowServer says the menu bar is made of.
+//
+// On macOS 26 and earlier, every menu bar item is its own window, so the list
+// contains one entry per item plus the main menu bar itself. If macOS 27 has
+// collapsed the menu bar into a single window, the list collapses to just the
+// main menu bar and Ice sees zero items.
+//
+// Requires no Accessibility and no Screen Recording permission. It reads window
+// metadata only: it creates nothing, moves nothing, and changes no setting.
+//
+// Run it without cloning the repository:
+//
+//   curl -fsSL https://raw.githubusercontent.com/teddychan/ice-2/main/scripts/menubar-probe.swift \
+//     -o /tmp/menubar-probe.swift &&
+//     swiftc -O /tmp/menubar-probe.swift -o /tmp/menubar-probe &&
+//     /tmp/menubar-probe
+//
+// Or from a checkout:
+//
+//   swiftc -O scripts/menubar-probe.swift -o /tmp/menubar-probe && /tmp/menubar-probe
+//
+// Must run in a normal logged-in GUI session — it needs a WindowServer
+// connection, so it will not work over SSH or on a headless CI runner.
+
+import CoreGraphics
+import Foundation
+
+typealias CGSConnectionID = Int32
+
+@_silgen_name("CGSMainConnectionID")
+func CGSMainConnectionID() -> CGSConnectionID
+
+@_silgen_name("CGSGetWindowCount")
+func CGSGetWindowCount(
+    _ cid: CGSConnectionID,
+    _ targetCID: CGSConnectionID,
+    _ outCount: inout Int32
+) -> CGError
+
+@_silgen_name("CGSGetProcessMenuBarWindowList")
+func CGSGetProcessMenuBarWindowList(
+    _ cid: CGSConnectionID,
+    _ targetCID: CGSConnectionID,
+    _ count: Int32,
+    _ list: UnsafeMutablePointer<CGWindowID>,
+    _ outCount: inout Int32
+) -> CGError
+
+@_silgen_name("CGSGetWindowLevel")
+func CGSGetWindowLevel(
+    _ cid: CGSConnectionID,
+    _ wid: CGWindowID,
+    _ outLevel: inout CGWindowLevel
+) -> CGError
+
+@_silgen_name("CGSGetScreenRectForWindow")
+func CGSGetScreenRectForWindow(
+    _ cid: CGSConnectionID,
+    _ wid: CGWindowID,
+    _ outRect: inout CGRect
+) -> CGError
+
+let connection = CGSMainConnectionID()
+let mainMenuLevel = CGWindowLevelForKey(.mainMenuWindow)
+
+// MARK: Environment
+
+let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+print("macOS: \(osVersion)")
+print("main menu window level: \(mainMenuLevel)")
+print("CGSMainConnectionID: \(connection)")
+
+guard connection != 0 else {
+    print("\nRESULT: FAILED — no WindowServer connection. Run this from a normal")
+    print("logged-in GUI session, not over SSH and not from a headless CI runner.")
+    exit(1)
+}
+
+// MARK: The probe
+
+var capacity: Int32 = 0
+let countResult = CGSGetWindowCount(connection, 0, &capacity)
+guard countResult == .success else {
+    print("\nRESULT: FAILED — CGSGetWindowCount returned \(countResult.rawValue)")
+    exit(1)
+}
+
+var list = [CGWindowID](repeating: 0, count: Int(capacity))
+var returnedCount: Int32 = 0
+let listResult = CGSGetProcessMenuBarWindowList(connection, 0, capacity, &list, &returnedCount)
+guard listResult == .success else {
+    print("\nRESULT: FAILED — CGSGetProcessMenuBarWindowList returned \(listResult.rawValue)")
+    print("If this symbol is gone or now returns an error, that alone explains #53.")
+    exit(1)
+}
+
+let windowIDs = [CGWindowID](list[..<Int(returnedCount)])
+
+// MARK: Report
+
+print("\nCGSGetProcessMenuBarWindowList returned \(windowIDs.count) window(s):\n")
+
+var itemWindowCount = 0
+for windowID in windowIDs {
+    var level: CGWindowLevel = 0
+    let levelResult = CGSGetWindowLevel(connection, windowID, &level)
+    var frame = CGRect.zero
+    let frameResult = CGSGetScreenRectForWindow(connection, windowID, &frame)
+
+    let isMainMenuBar = levelResult == .success && level == mainMenuLevel
+    if !isMainMenuBar {
+        itemWindowCount += 1
+    }
+
+    let levelText = levelResult == .success ? "\(level)" : "err \(levelResult.rawValue)"
+    let frameText = frameResult == .success
+        ? "x=\(Int(frame.minX)) y=\(Int(frame.minY)) w=\(Int(frame.width)) h=\(Int(frame.height))"
+        : "frame err \(frameResult.rawValue)"
+    let kind = isMainMenuBar ? "MAIN MENU BAR" : "item"
+
+    print("  wid \(windowID)  level \(levelText)  \(frameText)  <- \(kind)")
+}
+
+print("\n--- summary ---")
+print("total menu bar windows : \(windowIDs.count)")
+print("individual item windows: \(itemWindowCount)")
+
+if itemWindowCount == 0 {
+    print("""
+
+    RESULT: REPRODUCED the root cause of issue #53.
+
+    The WindowServer reports no per-item menu bar windows. Ice enumerates menu
+    bar items exclusively through CGSGetProcessMenuBarWindowList and filters out
+    the main menu bar window, so it sees an empty item list. That is why the Ice
+    icon still appears (a plain NSStatusItem, unaffected) while nothing hides,
+    and why the layout view spins on "loading menu bar items" forever.
+
+    Expanding the control item to 10,000pt cannot hide anything either: with a
+    single consolidated menu bar window there are no sibling item windows to push
+    off the left edge.
+    """)
+} else {
+    print("""
+
+    RESULT: NOT reproduced on this system.
+
+    \(itemWindowCount) per-item menu bar windows are present, which is the layout
+    Ice is built for. Hiding works here by expanding the hidden control item so
+    the item windows to its left overflow past the left edge of the menu bar.
+    """)
+}


### PR DESCRIPTION
## Why

[#53](https://github.com/teddychan/ice-2/issues/53) reports that menu bar items are not hidden on macOS 27. macOS 27 represents **all** menu bar items as a single WindowServer window rather than one window per item, which empties the item list Ice builds its entire model from — `CGSGetProcessMenuBarWindowList` in `Shared/Bridging/Bridging.swift`, after `.itemsOnly` filters out `kCGMainMenuWindowLevel`.

That single fact accounts for every reported symptom: the Ice icon still appears (a plain `NSStatusItem`), nothing hides (expanding the control item to 10,000pt has no sibling item windows to push off-screen, so it just stretches), and the layout pane sits on "Loading menu bar items…" because `hasItems` is false.

This is not an Ice regression — Bartender, Barbee, Thaw, Sane Bar, Glow and BetterTouchTool's menu bar features all broke identically. See upstream [jordanbaird/Ice#954](https://github.com/jordanbaird/Ice/issues/954).

## What this adds

`scripts/menubar-probe.swift` — a standalone script that calls that one API and reports how many windows the WindowServer says the menu bar is made of. It exists so a macOS 27 reporter can confirm or refute the diagnosis in one run, and so the check is repeatable across beta seeds instead of re-pasted into issue threads.

- No Accessibility and no Screen Recording permission required.
- Reads window metadata only — creates nothing, moves nothing, changes no setting.
- Compiled by the person running it, so the source is auditable before execution.
- Requires a logged-in GUI session for a WindowServer connection.

## Verification

Built and run on macOS 26.5.2 (25F84), where it reports 22 per-item windows and captures the hiding mechanism working — items at negative x, pushed off the left edge:

```
wid 1473  level 25  x=-4075 w=5008   <- expanded hidden control item
wid 39    level 25  x=-4105 w=30     <- item, off the left edge
wid 1474  level 25  x=-9191 w=5008   <- expanded always-hidden control item

individual item windows: 22
RESULT: NOT reproduced on this system.
```

On macOS 27 the diagnosis predicts `individual item windows: 0`. **Not yet confirmed on macOS 27** — no access to that OS, and there is no macOS 27 GitHub runner image (`xcode-27-arm64` is Xcode 27 on macOS 26.5.2).

## CI

`scripts/` falls outside SwiftLint's `included: [Ice]` and the conformance manifest's `sources`, so this adds no CI surface. `swiftlint lint --strict` passes locally, exit 0.

No product code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)