### PR TITLE
fix(a11y): add accessibility labels to menu bar end cap pickers

### DIFF
--- a/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarShapePicker.swift
+++ b/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarShapePicker.swift
@@ -84,6 +84,7 @@ private struct MenuBarFullShapePicker: View, Equatable {
             }
             .resizable()
             .help("Square Cap")
+            .accessibilityLabel("Square cap")
             .tag(endCap)
         case .round:
             Image(size: CGSize(width: 12, height: 12)) { context in
@@ -96,6 +97,7 @@ private struct MenuBarFullShapePicker: View, Equatable {
             }
             .resizable()
             .help("Round Cap")
+            .accessibilityLabel("Round cap")
             .tag(endCap)
         }
     }


### PR DESCRIPTION
## Problem

`Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarShapePicker.swift` renders the square/round end cap options as icon-only segments of a segmented `Picker` (the content is a drawn `Image`, with no text). Each carried only a `.help(...)` modifier.

On macOS, `.help()` sets the tooltip and the accessibility **hint** — it does **not** set the accessibility **label**. With no label, VoiceOver falls back to describing the underlying image/shape instead of announcing what the control does.

This violates the project engineering standard: "Ensure controls have meaningful labels."

## Fix

Add `.accessibilityLabel(...)` to both segments in `endCapPickerContentView(endCap:edge:)`, **alongside** — not replacing — the existing `.help(...)`. Tooltips are unchanged.

```swift
.resizable()
.help("Square Cap")
.accessibilityLabel("Square cap")
.tag(endCap)
```

The label is attached to the segment's content view (the interactive picker option), before `.tag(endCap)`, so the tag modifier stays outermost and selection behavior is untouched. Because both the leading and trailing pickers share this one builder, all four rendered segments are covered.

## Audit of other controls in this file

Checked every other control in the file; no further changes were needed:

- `IcePicker("Shape Kind", ...)` — has a visible text label.
- `Picker("Leading End Cap", ...)` / `Picker("Trailing End Cap", ...)` — titled. `.labelsHidden()` hides the label visually but preserves it for VoiceOver.
- `MenuBarEndCapExampleView` and the `Rectangle()` in the example stack — decorative, non-interactive. Left alone.

## Scope

Two added lines in one file. No logic, layout, or styling changes.

## Verification

- `swiftlint lint --strict` (0.65.0) — 0 violations, 0 serious in 104 files
- `xcodebuild clean build -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'` — `** BUILD SUCCEEDED **`, no new warnings (the 3 remaining warnings are pre-existing actor-isolation warnings in `MenuBarSection.swift`, an untouched file)
- `xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'` — `** TEST SUCCEEDED **`, 288 tests across 35 suites

Not verified: the actual VoiceOver announcement. VoiceOver could not be run in this environment, so the fix is verified as correct API usage and a clean build/test, not by hearing the spoken output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)