### PR TITLE
chore: make concurrency annotations match reality

### DIFF
--- a/Ice/Events/EventMonitor.swift
+++ b/Ice/Events/EventMonitor.swift
@@ -8,6 +8,10 @@ import Combine
 import os.lock
 
 struct EventMonitor: Sendable {
+    // Unchecked: the mutable `monitor` token and the non-Sendable `handler` are
+    // only reachable through ``EventMonitor/state``, whose lock serializes every
+    // `start()`/`stop()`. `deinit` calls `stop()` unlocked, but runs only once the
+    // last reference is gone, so nothing can race with it.
     private final class LocalMonitorState: @unchecked Sendable {
         private let mask: NSEvent.EventTypeMask
         private let handler: (NSEvent) -> NSEvent?
@@ -45,6 +49,9 @@ struct EventMonitor: Sendable {
         }
     }
 
+    // Unchecked: same invariant as ``LocalMonitorState`` — `monitor` and `handler`
+    // are reached only under ``EventMonitor/state``'s lock, and the unlocked
+    // `deinit` runs after the last reference is dropped.
     private final class GlobalMonitorState: @unchecked Sendable {
         private let mask: NSEvent.EventTypeMask
         private let handler: (NSEvent) -> Void
@@ -82,6 +89,9 @@ struct EventMonitor: Sendable {
         }
     }
 
+    // Unchecked: same invariant as ``LocalMonitorState`` — the `monitors` pair and
+    // both handlers are reached only under ``EventMonitor/state``'s lock, so the
+    // paired install/remove in `start()`/`stop()` is atomic with respect to callers.
     private final class UniversalMonitorState: @unchecked Sendable {
         private let mask: NSEvent.EventTypeMask
         private let localHandler: (NSEvent) -> NSEvent?
@@ -151,6 +161,9 @@ struct EventMonitor: Sendable {
         }
     }
 
+    // Unchecked: immutable, and every payload is itself a Sendable monitor state
+    // whose mutable storage is confined to ``EventMonitor/state``'s lock. This is
+    // the type that lock protects, so all of `start()`/`stop()` runs serialized.
     private enum State: @unchecked Sendable {
         case local(LocalMonitorState)
         case global(GlobalMonitorState)

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -629,7 +629,7 @@ extension MenuBarItemManager {
     }
 
     /// Returns an event source for a menu bar item event operation.
-    private nonisolated func getEventSource(
+    private func getEventSource(
         with stateID: CGEventSourceStateID = .hidSystemState
     ) throws -> CGEventSource {
         enum Context {
@@ -646,7 +646,7 @@ extension MenuBarItemManager {
     }
 
     /// Prevents local events from being suppressed.
-    private nonisolated func permitLocalEvents() throws {
+    private func permitLocalEvents() throws {
         let source = try getEventSource(with: .combinedSessionState)
         let states: [CGEventSuppressionState] = [
             .eventSuppressionStateRemoteMouseDrag,

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -80,6 +80,12 @@ extension MenuBarItemService {
     /// A wrapper around an XPC session.
     private final class Session: Sendable {
         /// A session's underlying storage.
+        ///
+        /// Unchecked: the non-Sendable `XPCSession` is reached only through
+        /// ``Session/storage``, an `OSAllocatedUnfairLock` that serializes
+        /// `send(request:)` and `cancel(reason:)`. The one access that does not
+        /// hold that lock is the cancel handler installed in
+        /// `getOrCreateSession()`, which clears `session` from the target queue.
         private final class Storage: @unchecked Sendable {
             private let name = MenuBarItemService.name
             private var session: XPCSession?

--- a/Ice/Utilities/ScreenCapture.swift
+++ b/Ice/Utilities/ScreenCapture.swift
@@ -34,6 +34,7 @@ enum ScreenCapture {
     /// This function caches its initial result and returns it on subsequent
     /// calls. Pass `true` to the `reset` parameter to replace the cached
     /// result with a newly computed value.
+    @MainActor
     static func cachedCheckPermissions(reset: Bool = false) -> Bool {
         enum Context {
             static var cachedResult: Bool?


### PR DESCRIPTION
Behavior-preserving. This corrects annotations that currently misstate isolation; it changes no runtime behavior. The project is still `SWIFT_VERSION = 5.0` with default (minimal) strict-concurrency checking, so none of this is compiler-enforced today — no build settings were touched.

## 1. Documented `@unchecked Sendable` invariants (5 sites)

All five conformances are legitimate; each now carries a comment stating the actual mechanism rather than an assertion.

**`Ice/Events/EventMonitor.swift`**

| Type | Invariant documented |
| --- | --- |
| `LocalMonitorState` | The mutable `monitor` token and the non-Sendable `handler` are only reachable through `EventMonitor.state`, an `OSAllocatedUnfairLock` whose `withLock` wraps every `start()`/`stop()`. `deinit` calls `stop()` without the lock, but only runs once the last reference is gone, so nothing can race with it. |
| `GlobalMonitorState` | Same invariant — lock-serialized `start()`/`stop()`, unlocked `deinit` runs after the last reference is dropped. |
| `UniversalMonitorState` | Same invariant, applied to the `monitors` local/global pair; the lock is what makes the paired install/remove atomic with respect to callers. |
| `State` | Immutable, and every payload is itself a `Sendable` monitor state whose mutable storage is confined to the same lock. This enum *is* the type that lock protects. |

**`Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift`**

| Type | Invariant documented |
| --- | --- |
| `Session.Storage` | The non-Sendable `XPCSession` is reached through `Session.storage`, an `OSAllocatedUnfairLock` that serializes `send(request:)` and `cancel(reason:)`. ⚠️ The comment also records the one access that does **not** hold that lock — see below. |

### Finding: `Session.Storage` is not fully sound

`getOrCreateSession()` installs an XPC cancel handler that writes `self.session = nil`:

```swift
let session = try XPCSession(xpcService: name, options: .inactive) { [weak self] error in
    guard let self else { return }
    logger.warning("Session was cancelled with error \(error.localizedDescription)")
    self.session = nil
}
```

That handler runs on the session's target queue (a `.concurrent` global-targeting queue), **not** under `Session.storage`'s unfair lock — so on service interruption it can write `session` while another thread reads/writes it inside `withLock`. Per the task brief this was reported rather than silently fixed; the doc comment states the invariant honestly instead of claiming full serialization. Practical impact is small (a pointer-sized store to nil, and in the explicit `cancel(reason:)` path the field has already been taken), but it is a real race. Worth a follow-up.

## 2. Removed misleading `nonisolated` on the event-source path

`Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift` (a `@MainActor final class`). `getEventSource(with:)` owns a function-local `enum Context { static var cache = [CGEventSourceStateID: CGEventSource]() }` — unsynchronized mutable static state behind a `nonisolated` façade, i.e. a latent data race.

Call-site analysis verified independently (`getEventSource` and `permitLocalEvents` are both `private`, so file-scope):

- `getEventSource` — called from `permitLocalEvents()` (L650), `postMoveEvents` (L1096), `postClickEvents` (L1266).
- `permitLocalEvents()` — called from `postMoveEvents` (L1098) and `postClickEvents` (L1268) only.
- `postMoveEvents` / `postClickEvents` are plain `private func`s in extensions of the `@MainActor` class (no `nonisolated` extension, no `@preconcurrency`), so both are main-actor isolated. Their own callers (L1220, L1356) `await` into them.

`nonisolated` was dropped from both, so the static cache is now main-actor confined and the annotation matches reality. The other `nonisolated` members in this file (`getCurrentBounds`, `getMouseLocation`, `getEventPID`, `getClickSubtypes`, `waitForMoveOperationBuffer`, `eventSleep`, `waitForMoveEventResponse`, `postEventWithBarrier`) are untouched.

## 3. Confined the screen-capture permission cache

`ScreenCapture.cachedCheckPermissions(reset:)` (`Ice/Utilities/ScreenCapture.swift`) holds `enum Context { static var cachedResult: Bool? }`. Its only two call sites — `MenuBarLayoutSettingsPane.swift:29` and `IceBar.swift:379` — are main-actor SwiftUI view bodies, so the function is now `@MainActor` and the cache is actually confined. Both call sites compile unchanged; no `import DragonKit` file was touched.

## Verification

- `swiftlint lint --strict` → **0 violations, 0 serious in 104 files**
- `xcodebuild clean build -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'` → **`** BUILD SUCCEEDED **`**, exactly 3 Swift warnings, all pre-existing in `MenuBarSection.swift` (L296, L298, L299). **Zero new warnings.**
- `xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'` → **`** TEST SUCCEEDED **`**, 288 tests in 35 suites passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)