### PR TITLE
chore(lint): cover all three source roots with SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,7 @@
 included:
   - Ice
+  - Shared
+  - MenuBarItemService
 
 disabled_rules:
   - cyclomatic_complexity
@@ -56,7 +58,7 @@ file_header:
   required_pattern: |-
     //
     //  SWIFTLINT_CURRENT_FILENAME
-    //  Ice
+    //  (Ice|Shared|MenuBarItemService)
     //
 
 modifier_order:


### PR DESCRIPTION
## Problem

`.swiftlint.yml` started with:

```yaml
included:
  - Ice
```

But `.dragon-conformance.json` declares three source roots — `Ice`, `Shared`, `MenuBarItemService`. The 11 Swift files under `Shared/` and `MenuBarItemService/` were never linted, so the `--strict` SwiftLint job in `.github/workflows/lint.yml` never gated them.

## Change

Config-only. Two parts:

1. Add `Shared` and `MenuBarItemService` to `included:`.
2. Relax the `file_header` `required_pattern` so line 3 accepts any of the three module names.

## Why the pattern was relaxed instead of the headers rewritten

Adding the roots alone fails CI with 11 violations — every one of them `file_header`, hitting 100% of the newly-covered files. The rule hardcoded the module name:

```
//
//  SWIFTLINT_CURRENT_FILENAME
//  Ice
//
```

Those 11 files are **not** malformed. They correctly name their own build target — `Shared/Utilities/Logging.swift` reads `//  Shared`, `MenuBarItemService/main.swift` reads `//  MenuBarItemService`. `Shared` and `MenuBarItemService` are genuinely separate targets from `Ice`.

So there were two ways to close the gap: change the config, or change the code. Rewriting the 11 headers to say `Ice` would make every one of them a false statement about which target the file belongs to — trading a real lint gap for 11 small lies in the source. Relaxing the pattern keeps the headers truthful.

The accepted cost: a file under `Ice/` could now write `//  Shared` and pass. That is a narrow weakening, and it buys `--strict` coverage of 11 previously ungated files. A per-directory nested-config approach would be stricter but is disproportionate machinery for 11 files.

`file_header` was the *only* rule that fired. Every other rule, opt-in, and custom rule already passed across all three roots — verified separately by running the new scope with `file_header` disabled (0 violations).

## Verification

**Positive** — `swiftlint lint --strict` (0.65.0, matching CI) from the repo root:

| | files linted | violations |
|---|---|---|
| before | 104 | 0 |
| after | **115** | **0** |

The +11 confirms the new roots are actually being picked up, not silently skipped.

**Negative** — a relaxed regex that silently matched everything would be worse than the status quo, so the rule was confirmed to still fire. Each case below was applied temporarily to `Shared/Utilities/Logging.swift`, then reverted:

| header line 2 / 3 | result |
|---|---|
| `//  Logging.swift` / `//  Bogus` | violation, exit 2 |
| `//  Logging.swift` / `//  SharedExtras` | violation, exit 2 |
| `//  WrongName.swift` / `//  Shared` | violation, exit 2 |

The `SharedExtras` case matters most: it proves the alternation is properly anchored and is not a loose substring match. Wrong filenames are still caught too.

No `xcodebuild` was run, and none is claimed — a SwiftLint config change cannot affect compilation.

`git diff --stat` is `.swiftlint.yml | 4 +++-`, 1 file changed. No Swift files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)