### PR TITLE
chore: fix two non-Sendable captures ahead of strict concurrency

### DIFF
--- a/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -299,10 +299,18 @@ final class MenuBarItemImageCache: ObservableObject {
 
         let validKeys = await Set(appState.itemManager.itemCache.managedItems.map(ImageKey.init))
 
-        await MainActor.run { [newImages, validKeys] in
-            images = images.filter { validKeys.contains($0.key) }
-            images.merge(newImages) { (_, new) in new }
-        }
+        await mergeIntoCache(newImages, validKeys: validKeys)
+    }
+
+    /// Drops every cached image whose key is no longer valid, then merges in the
+    /// given images.
+    ///
+    /// ``images`` is `@Published` and read from SwiftUI, so it is only ever
+    /// mutated on the main actor.
+    @MainActor
+    private func mergeIntoCache(_ newImages: [ImageKey: CapturedImage], validKeys: Set<ImageKey>) {
+        images = images.filter { validKeys.contains($0.key) }
+        images.merge(newImages) { (_, new) in new }
     }
 
     /// Returns whether the cache should be updated for the given presentation state.

--- a/Ice/MenuBar/MenuBarSection.swift
+++ b/Ice/MenuBar/MenuBarSection.swift
@@ -233,6 +233,36 @@ final class MenuBarSection {
         if isHidden { show() } else { hide() }
     }
 
+    /// Returns a Boolean value that indicates whether the mouse is below the
+    /// menu bar on the given screen.
+    private func isMouseBelowMenuBar(on screen: NSScreen) -> Bool {
+        guard let mouseLocation = MouseHelpers.locationAppKit else {
+            return false
+        }
+        return mouseLocation.y < screen.visibleFrame.maxY
+    }
+
+    /// Returns a Boolean value that indicates whether the mouse is inside the
+    /// given Ice Bar panel.
+    private func isMouseInsideIceBar(useIceBar: Bool, panel: NSPanel?) -> Bool {
+        guard
+            useIceBar,
+            let panel,
+            panel.isVisible,
+            let mouseLocation = MouseHelpers.locationAppKit
+        else {
+            return false
+        }
+        return panel.frame.insetBy(dx: -8, dy: -8).contains(mouseLocation)
+    }
+
+    /// Returns a Boolean value that indicates whether the section should be
+    /// rehidden, given the current location of the mouse.
+    private func shouldRehide(on screen: NSScreen, useIceBar: Bool, iceBarPanel: NSPanel?) -> Bool {
+        isMouseBelowMenuBar(on: screen)
+            && !isMouseInsideIceBar(useIceBar: useIceBar, panel: iceBarPanel)
+    }
+
     /// Starts running checks to determine when to rehide the section.
     private func startRehideChecks() {
         rehideTimer?.invalidate()
@@ -244,30 +274,6 @@ final class MenuBarSection {
             case .timed = appState.settings.general.rehideStrategy
         else {
             return
-        }
-
-        func isMouseBelowMenuBar(on screen: NSScreen) -> Bool {
-            guard let mouseLocation = MouseHelpers.locationAppKit else {
-                return false
-            }
-            return mouseLocation.y < screen.visibleFrame.maxY
-        }
-
-        func isMouseInsideIceBar(useIceBar: Bool, panel: NSPanel?) -> Bool {
-            guard
-                useIceBar,
-                let panel,
-                panel.isVisible,
-                let mouseLocation = MouseHelpers.locationAppKit
-            else {
-                return false
-            }
-            return panel.frame.insetBy(dx: -8, dy: -8).contains(mouseLocation)
-        }
-
-        func shouldRehide(on screen: NSScreen, useIceBar: Bool, iceBarPanel: NSPanel?) -> Bool {
-            isMouseBelowMenuBar(on: screen)
-                && !isMouseInsideIceBar(useIceBar: useIceBar, panel: iceBarPanel)
         }
 
         rehideMonitor = EventMonitor.universal(for: .mouseMoved) { [weak self] event in
@@ -296,7 +302,7 @@ final class MenuBarSection {
                             else {
                                 return
                             }
-                            if shouldRehide(
+                            if self.shouldRehide(
                                 on: screen,
                                 useIceBar: self.useIceBar,
                                 iceBarPanel: self.menuBarManager?.iceBarPanel


### PR DESCRIPTION
Preparatory work for a future strict-concurrency migration. Two latent
`@Sendable`-capture defects are fixed so that flipping the flag later is a
build-setting change rather than a code change made under pressure.

**No build setting changed.** The project stays on `SWIFT_VERSION = 5.0`
with `SWIFT_STRICT_CONCURRENCY` at the default `minimal`, so neither of
these warnings is visible in a normal build. They were found by passing
`SWIFT_STRICT_CONCURRENCY=targeted` on the command line as a measurement
tool only. Flipping that flag for real remains separate, deferred work.

## The two fixes

**`MenuBarItemImageCache.swift`** — the trailing `await MainActor.run { ... }`
mutated the `images` property, which implicitly captured the whole
non-Sendable cache object inside a `@Sendable` closure. The two statements
moved into a `@MainActor private func mergeIntoCache(_:validKeys:)` that the
same `await` now calls. Still one hop to the main actor, same filter-then-merge
in the same order — which images get cached is unchanged.

**`MenuBarSection.swift`** — `shouldRehide(on:useIceBar:iceBarPanel:)` was a
local function inside `startRehideChecks()`, and the rehide timer's
`Task { @MainActor in }` (added in #71) captured it as a non-Sendable
function value. Marking it `@Sendable` was checked and rejected: it reads
`NSPanel.isVisible`, which is main actor-isolated in the current SDK, and
the compiler refuses `@Sendable` on a main actor-isolated synchronous local
function ("cannot be marked as `@Sendable`; this is an error in the Swift 6
language mode"). Instead it and its two helpers are hoisted to private
methods on `MenuBarSection`, which is already `@MainActor` — so the closure
captures `self` (implicitly Sendable) rather than a function value. The
function bodies are moved verbatim and both call sites are unchanged, so
when the rehide fires is unchanged. The one added token is an explicit
`self.` on the call inside the `Task`, which that closure requires.

## Deliberately out of scope

Seven warnings remain, all in `MenuBarItemManager.swift`, all captures of
`EventTap` / `EventContinuation`. That code posts the CGEvents that drag the
user's real menu bar items, it can't be covered by tests, and it is being
left alone on purpose.

## Verification

- `swiftlint lint --strict` → 0 violations in 104 files
- Default clean build (no override) → `** BUILD SUCCEEDED **`, zero Swift
  warnings — `main` was warning-clean and stays warning-clean
- Measurement build with `SWIFT_STRICT_CONCURRENCY=targeted` →
  `** BUILD SUCCEEDED **`, warnings drop from 9 to exactly 7, and all 7 are
  the `MenuBarItemManager.swift` ones above
- `xcodebuild test` → `** TEST SUCCEEDED **`, 288 tests in 35 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
