### PR TITLE
fix(xpc): close the unsynchronized write in the session cancel handler

### DIFF
--- a/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -82,67 +82,21 @@ extension MenuBarItemService {
         /// A session's underlying storage.
         ///
         /// Unchecked: the non-Sendable `XPCSession` is reached only through
-        /// ``Session/storage``, an `OSAllocatedUnfairLock` that serializes
-        /// `send(request:)` and `cancel(reason:)`. The one access that does not
-        /// hold that lock is the cancel handler installed in
-        /// `getOrCreateSession()`, which clears `session` from the target queue.
-        private final class Storage: @unchecked Sendable {
-            private let name = MenuBarItemService.name
-            private var session: XPCSession?
-            private let queue: DispatchQueue
-            private let logger: Logger
-
-            init(queue: DispatchQueue, logger: Logger) {
-                self.queue = queue
-                self.logger = logger
-            }
-
-            private func getOrCreateSession() throws -> XPCSession {
-                if let session {
-                    return session
-                }
-                let session = try XPCSession(xpcService: name, options: .inactive) { [weak self] error in
-                    guard let self else {
-                        return
-                    }
-                    logger.warning("Session was cancelled with error \(error.localizedDescription)")
-                    self.session = nil
-                }
-                // The `isFromSameTeam` requirement can only be satisfied when the
-                // process has a Team Identifier. Ad-hoc/local development builds
-                // have none, so skip the peer requirement for them.
-                if CodeSigning.hasTeamIdentifier {
-                    session.setPeerRequirement(.isFromSameTeam())
-                } else {
-                    logger.notice("Connecting without same-team peer requirement (no Team Identifier)")
-                }
-                session.setTargetQueue(queue)
-                try session.activate()
-                self.session = session
-                return session
-            }
-
-            func cancel(reason: String) {
-                guard let session = session.take() else {
-                    return
-                }
-                session.cancel(reason: reason)
-            }
-
-            func send(request: Request) -> Response? {
-                do {
-                    let session = try getOrCreateSession()
-                    let reply = try session.sendSync(request)
-                    return try reply.decode(as: Response.self)
-                } catch {
-                    logger.error("Session failed with error \(error)")
-                    return nil
-                }
-            }
+        /// ``Session/storage``, an `OSAllocatedUnfairLock` that serializes every
+        /// access — `send(request:)`, `cancel(reason:)`, and the cancel handler
+        /// installed in `getOrCreateSession(in:)`. The handler cannot deadlock
+        /// against the lock scope that installs it: XPC submits session events to
+        /// the target queue, which is set while the session is still inactive, so
+        /// the handler never runs inline on a thread that already holds the lock.
+        private struct Storage: @unchecked Sendable {
+            var session: XPCSession?
         }
 
+        /// The name of the XPC service the session connects to.
+        private let name = MenuBarItemService.name
+
         /// Protected storage for the underlying XPC session.
-        private let storage: OSAllocatedUnfairLock<Storage>
+        private let storage = OSAllocatedUnfairLock(initialState: Storage())
 
         /// The session's target queue.
         private let queue: DispatchQueue
@@ -152,7 +106,6 @@ extension MenuBarItemService {
 
         /// Creates a new session.
         init(queue: DispatchQueue, logger: Logger) {
-            self.storage = OSAllocatedUnfairLock(initialState: Storage(queue: queue, logger: logger))
             self.queue = queue
             self.logger = logger
         }
@@ -161,14 +114,56 @@ extension MenuBarItemService {
             cancel(reason: "Session deinitialized")
         }
 
+        /// Returns the underlying XPC session, creating and activating one if needed.
+        ///
+        /// - Important: Callers must hold ``storage``'s lock.
+        private func getOrCreateSession(in storage: inout Storage) throws -> XPCSession {
+            if let session = storage.session {
+                return session
+            }
+            let session = try XPCSession(xpcService: name, options: .inactive) { [weak self] error in
+                guard let self else {
+                    return
+                }
+                logger.warning("Session was cancelled with error \(error.localizedDescription)")
+                self.storage.withLock { $0.session = nil }
+            }
+            // The `isFromSameTeam` requirement can only be satisfied when the
+            // process has a Team Identifier. Ad-hoc/local development builds
+            // have none, so skip the peer requirement for them.
+            if CodeSigning.hasTeamIdentifier {
+                session.setPeerRequirement(.isFromSameTeam())
+            } else {
+                logger.notice("Connecting without same-team peer requirement (no Team Identifier)")
+            }
+            session.setTargetQueue(queue)
+            try session.activate()
+            storage.session = session
+            return session
+        }
+
         /// Cancels the session.
         func cancel(reason: String) {
-            storage.withLock { $0.cancel(reason: reason) }
+            storage.withLock { storage in
+                guard let session = storage.session.take() else {
+                    return
+                }
+                session.cancel(reason: reason)
+            }
         }
 
         /// Sends the given request to the service and returns the response.
         func send(request: Request) -> Response? {
-            storage.withLock { $0.send(request: request) }
+            storage.withLock { storage in
+                do {
+                    let session = try getOrCreateSession(in: &storage)
+                    let reply = try session.sendSync(request)
+                    return try reply.decode(as: Response.self)
+                } catch {
+                    logger.error("Session failed with error \(error)")
+                    return nil
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Follow-up to #72, which deliberately documented this defect rather than papering over it.

## The race

`MenuBarItemService.Session.Storage` is `@unchecked Sendable`, justified by "all access to `session` is serialized by `Session.storage`'s `OSAllocatedUnfairLock`". That held for `send(request:)` and `cancel(reason:)` — but not for the `XPCSession` cancel handler installed in `getOrCreateSession()`, which did `self.session = nil` from the session's target queue (a `.concurrent` global-targeting queue) **without** the lock. On XPC service interruption that store could race a lock-held read or write of the same field.

Impact is small — a pointer-sized store to nil, and in the explicit `cancel` path the field has usually already been `take()`n — but it is a genuine data race and a hard error under Swift 6 language mode.

## The fix

The handler couldn't take the lock before, because the lock *owned* the `Storage` object the handler ran on. So `Storage` becomes a plain box for the non-Sendable `XPCSession?`, and the session logic moves onto `Session`, which owns the lock and can therefore be captured by the handler. Every access — `send(request:)`, `cancel(reason:)`, and the cancel handler — now goes through `storage.withLock`. This is the same shape `EventMonitor` already uses: a Sendable wrapper owning `OSAllocatedUnfairLock<State>`, with the invariant documented above `State`.

## Re-entrancy / deadlock

`OSAllocatedUnfairLock` is not recursive, and the handler is installed *while the lock is held* (inside `send`'s lock scope), so it must not be able to fire on that same thread. It can't, per the SDK headers:

- `xpc_session_set_target_queue` — "The GCD queue onto which session events will be **submitted**". Events are dispatched to the queue, not run inline. The queue is installed while the session is still `.inactive`, so no event can be delivered before it is set.
- `xpc_session_cancel` — "Cancellation is **asynchronous and non-preemptive**." The handler never runs on the thread calling `cancel`.
- `xpc_session_send_message_with_reply_sync` — *crashes* when invoked from the target queue, rather than draining it on the caller. It does not borrow the calling thread for session events.

The handler can briefly block on the lock while a `sendSync` is in flight, but the target queue is concurrent (other events proceed on other threads) and the sync send never waits on the handler, so there is no cycle.

The doc comment on `Storage` now states the complete invariant *and* records this argument.

## Otherwise no behavior change

`send` is still fully serialized under one lock in the same order; `cancel` still takes the session out and cancels it under the lock. The change also drops the duplicate `queue`/`logger` that `Session` and `Storage` were each storing.

## Verification

- `swiftlint lint --strict` — 0 violations in 115 files
- `xcodebuild clean build -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'` — succeeded, still warning-free
- `xcodebuild test …` — 288 tests in 35 suites passed

Not verified at runtime: the race itself needs a real XPC service interruption against a TCC-granted build, which a local debug build can't reproduce. Static reasoning plus the above checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)