### PR TITLE
release: 2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.12.1 - 2026-08-07
+
+### Fixed
+
+- **VoiceOver can tell the menu bar shape buttons apart.** In Settings ▸ Appearance, the buttons that choose how each end of the menu bar shape is drawn — squared off or rounded — were pictures with no name attached. VoiceOver described the picture rather than what the button does, so picking a shape without looking at the screen meant guessing. They now read as "Square cap" and "Round cap". The tooltips you see on hover are unchanged.
+
+- **Hardened the connection to Ice 2's bundled helper.** Ice 2 asks a small helper process which app each menu bar item belongs to. When that connection was interrupted, the code that cleared it skipped the lock that guards every other use of it, so a cleanup and an in-flight request could overlap. Nobody reported this and the timing needed to hit it is narrow, but the result would have been undefined — a dropped request at best, a crash at worst. Every access now goes through the same lock.
+
+### Internal
+
+- Ice 2 now builds with no compiler warnings, and the shared and helper sources are covered by the linter alongside the main app. Groundwork for moving to Swift's stricter data-race checking; no change to how the app behaves.
+
 ## 2.12.0 - 2026-08-06
 
 ### Fixed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -714,7 +714,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 2.12.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -750,7 +750,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 2.12.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
Patch release. Bumps `MARKETING_VERSION` 2.12.0 → 2.12.1 for the Ice target (Debug + Release configs only — `MenuBarItemService` stays at 1.0) and adds the changelog entry.

`CURRENT_PROJECT_VERSION` is deliberately untouched: the release pipeline stamps `CFBundleVersion` from `git rev-list --count HEAD`.

## What ships

**User-visible**
- #70 — VoiceOver labels on the menu bar end cap pickers in Settings ▸ Appearance
- #75 — the XPC session cancel handler no longer writes outside the lock that guards every other access to the connection

**Internal, no behavior change**
- #71, #72, #74 — concurrency annotations corrected; build is now warning-free
- #73 — SwiftLint covers all three source roots (104 → 115 files)

Versioned as a patch rather than a minor: the only thing a user can perceive is the two VoiceOver labels.

## Verification

- `swiftlint --strict` — 0 violations / 115 files
- Clean build — `** BUILD SUCCEEDED **`, 0 Swift warnings
- `xcodebuild test` — 288 tests / 35 suites passed
- Release-config build reports `CFBundleShortVersionString = 2.12.1`, so CI's `assert_tag_matches_plist` will accept tag `v2.12.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)