### PR TITLE
chore: adopt DragonKit 2.3.0 and drop its deprecated layout arguments

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -890,7 +890,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.1.0;
+				minimumVersion = 2.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "d68e6693988cf2d23167ce4b9d4be5ab607b5d4e",
-        "version" : "2.1.0"
+        "revision" : "7ce7588d7d8869da2250e8023a65060575c44ddf",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
+++ b/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
@@ -343,7 +343,7 @@ private struct LabeledPartialEditor: View {
     let appearance: SystemAppearance
 
     var body: some View {
-        DragonSection(options: .plain) {
+        DragonSection {
             labelStack
         } content: {
             partialEditor

--- a/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -31,7 +31,7 @@ struct MenuBarLayoutSettingsPane: View {
         } else if appState.menuBarManager.isMenuBarHiddenBySystemUserDefaults {
             cannotArrange
         } else {
-            DragonForm(spacing: 20) {
+            DragonForm {
                 header
                 profiles
                 spacers


### PR DESCRIPTION
Two commits. No tag, no release — this only changes the dependency pin and two call sites.

## 1. `chore(deps)` — bump the DragonKit pin 2.1.0 → 2.3.0

2.2.0/2.3.0 fix a data-loss bug this app currently ships: Swift's synthesized `Decodable` does not fall back to a property's default for a missing key, so the first time a field is added to the settings struct, decoding the stored blob throws, `DragonSettingsStore` silently returns defaults, and the next change writes those defaults over the user's real settings. Also fixed upstream: restoring a malformed backup erased the whole settings suite instead of refusing, and a failed uninstall reported success after settings teardown had run.

Clears `dragon-conformance` **R10**, which was failing on the stale pin.

`Package.resolved` now records dragon-kit `2.3.0` (`7ce7588d`). Sparkle is a *transitive* dependency of DragonKit and has no `XCRemoteSwiftPackageReference` block in this project — it is unchanged at 2.9.4.

## 2. `refactor(settings)` — delete the arguments 2.3.0 deprecates

**Two call sites, not ~30:**

| File | Was |
|---|---|
| `MenuBarLayoutSettingsPane.swift:34` | `DragonForm(spacing: 20)` |
| `MenuBarAppearanceEditor.swift:346` | `DragonSection(options: .plain)` |

The other 15 `DragonForm`/`DragonSection` call sites in the repo already passed no deprecated argument. A clean build produced exactly 2 deprecation warnings, which matches.

Pure deletion — no compensating `padding`/`spacing` modifiers, since the values were already ignored at render time and adding them would *change* the layout rather than preserve it.

## Verification

- **Conformance:** `R10 ... pinned to DragonKit 2.1.0 but 2.3.0 is released` → **`PASS — no violations`**
- **Build:** `** BUILD SUCCEEDED **`, **zero warnings**. Both deprecations gone, none introduced. No pre-existing Swift warnings existed to begin with (`main` has been warning-free since #74); the only non-Swift output is the unrelated `appintentsmetadataprocessor` "No AppIntents.framework dependency found" tool notice, also present on `main`.
- **Lint:** 0 violations / 115 files
- **Tests:** 288 passed, 35 suites

### On the UI check

The requested click-through of every Settings pane **was not completed**, and I am not claiming it was. The isolated debug build (`com.dragonapp.ice.debug`) has no Accessibility or Screen Recording grant, so it opens its Permissions window and never reaches Settings; granting those is a system security change. Notably `MenuBarLayoutSettingsPane` — one of the two files changed here — renders a "missing screen recording permission" placeholder instead of the edited `DragonForm` without that grant, so even a granted run would not have exercised it.

Stronger evidence was used instead: at `v2.3.0` both deprecated initializers **discard the arguments outright**. `DragonForm`'s deprecated overload body is `self.content = content()`, identical to the bare overload; `DragonSection`'s assigns only `header`/`content`/`footer` in both. Those stored properties are the only input to `body`, so the two forms produce byte-identical state and the deletion cannot alter rendering.

Nothing looked different, because nothing can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)