### PR TITLE
chore: bump the DragonKit pin to 2.4.0

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -890,7 +890,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.3.0;
+				minimumVersion = 2.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "7ce7588d7d8869da2250e8023a65060575c44ddf",
-        "version" : "2.3.0"
+        "revision" : "dbc3a4a80e3d83f0c0ce4f30100c6d1eddb976bf",
+        "version" : "2.4.0"
       }
     },
     {


### PR DESCRIPTION
Bumps the declared DragonKit pin from 2.3.0 to 2.4.0.

**This is a currency bump, not a fix.** Nothing in the app behaves differently.

Conformance rule R10 requires the declared pin to be at least the newest `dragon-kit` tag. 2.4.0 is released, so this repo was failing R10 on `main`:

```
FAIL — 1 violation(s):
  R10  Ice.xcodeproj/project.pbxproj: pinned to DragonKit 2.3.0 but 2.4.0 is released
```

DragonKit 2.4.0 adds exactly one thing — an option letting a system-managed input method keep Quit out of its settings menu bar. Ice 2 is not an input method and does not use it. There is no user-visible change here, so no changelog entry.

## Changes

- `Ice.xcodeproj/project.pbxproj` — `minimumVersion = 2.3.0` → `2.4.0` in the `dragon-kit` `XCRemoteSwiftPackageReference` block (the one whose `repositoryURL` is `https://github.com/teddychan/dragon-kit`)
- `Package.resolved` — regenerated by `xcodebuild -resolvePackageDependencies`; dragon-kit is the only pin that moved, to `2.4.0` @ `dbc3a4a` (matches the `v2.4.0` tag)

No app source changed.

## Verification

- **Builds clean.** Full `clean build` succeeds with **zero compiler warnings**. (The only 2 warnings in the log are the benign `No AppIntents.framework dependency found` metadata note, one per target.) None expected — this repo already dropped every DragonForm/DragonSection argument 2.3.0 deprecated.
- **Conformance flips FAIL → PASS.** Verified both directions against the same checkout: pre-bump reports the R10 violation above; post-bump reports `PASS — no violations.`
- **No other pin moved.** Sparkle stays at 2.9.4, AXSwift 0.3.2, CompactSlider 1.2.1, Ifrit 2.0.6, Semaphore 0.1.0.
- **UI unchanged.** Launched the isolated debug build and clicked through all 11 Settings panes — General, Appearance, Layout, Hotkeys, Advanced, Permissions, Backup & Restore, What's New, Updates, About, Uninstall. Each was confirmed by window title and inspected; all render identically.

Not tagged, not released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)