### PR TITLE
release: 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.13.0 - 2026-08-07
+
+### Internal
+
+- Ice 2 now builds against version 2.4.0 of the shared Dragon app framework. That release adds one thing — an option letting a system-managed input method keep Quit out of its settings menu bar — which Ice 2 is not and does not use. Nothing about the app behaves differently; this keeps Ice 2 current with the shared framework rather than drifting behind it.
+
 ## 2.12.1 - 2026-08-07
 
 ### Fixed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -714,7 +714,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.12.1;
+				MARKETING_VERSION = 2.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -750,7 +750,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.12.1;
+				MARKETING_VERSION = 2.13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
Bumps `MARKETING_VERSION` for the Ice target (Debug + Release) from 2.12.1 to 2.13.0 and adds the changelog entry. `CURRENT_PROJECT_VERSION` is left alone — the release pipeline stamps `CFBundleVersion` from `git rev-list --count HEAD`.

## What's in this release

Exactly one commit since v2.12.1:

- #79 — DragonKit pin moved to 2.4.0

That is a **currency bump, not a functional one**. DragonKit 2.4.0 adds one thing — an option letting a system-managed input method keep Quit out of its settings menu bar — which Ice 2 is not and does not use. No app source changed and nothing user-visible differs, so the changelog records it under **Internal** rather than claiming a fix.

Cut as a minor rather than a patch to mark the shared-framework adoption.

## Verification

- Release configuration resolves to `MARKETING_VERSION = 2.13.0`, `PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice`, `PRODUCT_NAME = Ice 2` — so the `assert_tag_matches_plist` guard will match tag `v2.13.0`.
- Only the two Ice target configs moved; the `MenuBarItemService` XPC target stays at `1.0`.
- The dragon-kit pin is untouched at 2.4.0, and no other package pin moved.
- Builds clean with zero compiler warnings; all 11 Settings panes verified visually against 2.12.1 on the merged pin (see #79).

Tag `v2.13.0` follows once this merges, which triggers the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)