### PR TITLE
feat(about)!: migrate to DragonKit 3.1.0 and its fixed-slot About pane

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -890,7 +890,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.0;
+				minimumVersion = 3.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "dbc3a4a80e3d83f0c0ce4f30100c6d1eddb976bf",
-        "version" : "2.4.0"
+        "revision" : "fe315656db572b88e7f5db89d2ace463cc13513a",
+        "version" : "3.1.0"
       }
     },
     {

--- a/Ice/Resources/Info.plist
+++ b/Ice/Resources/Info.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- The commit this build came from, which DragonKit renders after the build number:
+	     "v2.13.0 (1346) · 2026-Aug-09 12:00:00 UTC". The release workflow passes
+	     `git log -1 --format=%cI` as the DRAGON_COMMIT_DATE build setting; mapping it here is
+	     what makes it reach the app, because xcodebuild hands back a SIGNED bundle and editing
+	     Info.plist afterwards would break the signature. Expands to empty in a plain local
+	     build, and DragonKit then shows no timestamp at all rather than a misleading one. -->
+	<key>DragonCommitDate</key>
+	<string>$(DRAGON_COMMIT_DATE)</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/Ice/Settings/AboutConfig.swift
+++ b/Ice/Settings/AboutConfig.swift
@@ -3,43 +3,55 @@
 //  Ice
 //
 
-import AppKit
 import DragonKit
+import Foundation
 
-/// App-owned About content for Ice 2, rendered by DragonKit's ``AboutPane``.
+/// Ice 2's content for DragonKit's shared About pane.
 ///
-/// Only Ice 2's own content lives here — the layout is owned by DragonKit. The version is
-/// single-sourced from the bundle (``Constants/versionString``) and the copyright from the
-/// bundle's `NSHumanReadableCopyright` (``Constants/copyrightString``).
+/// The kit owns every row title, SF Symbol, ordering and detail string — ``AboutContent``
+/// assembles them and ``AboutPane`` renders them. Ice 2 supplies only URLs and proper nouns.
+/// This used to pass free-form `links`/`credits` arrays; five apps used them to ship five
+/// visibly different panes, so DragonKit 3.0.0 replaced them with fixed slots.
+///
+/// The version is single-sourced from the bundle via ``DragonAbout/versionString(bundle:)`` —
+/// never hardcoded.
 enum AboutConfig {
+    /// The canonical marketing page. The kit's `websiteMatchesSupportRepo` checks this path
+    /// against the support URL's repo name, so it must be `/ice-2/`, not the bare hub.
+    private static let websiteURL = URL(string: "https://www.dragonapp.com/ice-2/")!
+
+    /// Support goes straight to the GitHub issues page.
+    private static let issuesURL = URL(string: "https://github.com/teddychan/ice-2/issues")!
+
     static var content: AboutContent {
         AboutContent(
             appName: Constants.displayName,
             versionString: DragonAbout.versionString(),
-            copyright: Constants.copyrightString,
-            links: [
-                // Primary link: the app's marketing page on dragonapp.com.
-                AboutLink(
-                    title: "Website",
-                    detail: "dragonapp.com/ice-2",
-                    systemImage: "globe",
-                    url: URL(string: "https://www.dragonapp.com/ice-2/")!
-                ),
-                // Support goes straight to the GitHub issues page.
-                AboutLink(
-                    title: "Support on GitHub",
-                    detail: "teddychan/ice-2",
-                    systemImage: "lifepreserver",
-                    url: URL(string: "https://github.com/teddychan/ice-2/issues")!
-                ),
-            ],
-            credits: [
-                (label: "Created by", value: "Teddy Chan"),
-                (label: "Original Ice", value: "Jordan Baird"),
-                (label: "License", value: "GPL-3.0"),
-            ],
-            // Bundled acknowledgements document (opened via the About pane's button).
-            acknowledgementsURL: Bundle.main.url(forResource: "Acknowledgements", withExtension: "pdf")
+            // Assembled by the kit so the format matches every other Dragon app. Ice 2 was the
+            // app that spelled out "Copyright ©" where the others used the symbol alone; the
+            // years and holders are unchanged from `NSHumanReadableCopyright`.
+            copyright: DragonAbout.copyright(
+                original: (years: "2025", holder: "Jordan Baird"),
+                years: "2026",
+                holder: "Teddy Chan"
+            ),
+            websiteURL: websiteURL,
+            supportURL: issuesURL,
+            license: "GPL-3.0",
+            // `licensesURL` is omitted: dragonapp.com/ice-2/licenses does not exist yet. Until it
+            // does, `Resources/Acknowledgements.pdf` stays in the bundle carrying the verbatim
+            // notices, and the libraries are named below.
+            originalWork: OriginalWork(name: "Ice", author: "Jordan Baird"),
+            attributions: [
+                // Every third-party package Ice 2 links, as `name → licence`. Verified against
+                // each project's own LICENSE, not the bundled Acknowledgements document, which
+                // still lists LaunchAtLogin — dropped as a dependency since it was written.
+                Attribution(name: "AXSwift", license: "MIT"),
+                Attribution(name: "CompactSlider", license: "MIT"),
+                Attribution(name: "Ifrit", license: "MIT"),
+                Attribution(name: "Semaphore", license: "MIT"),
+                Attribution(name: "Sparkle", license: "MIT"),
+            ]
         )
     }
 }

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -7,13 +7,13 @@ import DragonKit
 
 /// App-owned "What's New" content for Ice 2, rendered by DragonKit's ``WhatsNewPane``.
 ///
-/// Only the app's own content lives here — the layout is owned by DragonKit. The version is
-/// single-sourced from the bundle (``Constants/versionString``, i.e. `CFBundleShortVersionString`)
-/// so it always matches About and the update checker; update the `date` and `sections` per release.
+/// Only the app's own content lives here — the layout is owned by DragonKit. The version is not
+/// passed at all: ``WhatsNewContent`` reads `CFBundleShortVersionString` itself and renders it
+/// through ``DragonVersion/display(_:)``, so it always matches About and the update checker and
+/// carries the same single `v` prefix. Update the `date` and `sections` per release.
 enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
-            version: Constants.versionString,
             date: "2026-08-04",
             summary: "Update checks are quiet and considerate again.",
             sections: [

--- a/scripts/run-debug.sh
+++ b/scripts/run-debug.sh
@@ -79,6 +79,16 @@ sleep 1
 build_number="$(git rev-list --count HEAD 2>/dev/null || echo 1)"
 "$pb" -c "Set :CFBundleVersion $build_number" "$plist"
 
+# The commit's own timestamp, which DragonKit renders after the build number. The
+# release workflow passes it as the DRAGON_COMMIT_DATE build setting; a plain local
+# build defines no such setting, so stamp it here or a debug About pane shows the
+# build number with no date beside it.
+commit_date="$(git log -1 --format=%cI 2>/dev/null || true)"
+if [[ -n "$commit_date" ]]; then
+  "$pb" -c "Set :DragonCommitDate $commit_date" "$plist" 2>/dev/null \
+    || "$pb" -c "Add :DragonCommitDate string $commit_date" "$plist"
+fi
+
 # Mark the version itself, not just the name: the About pane and any log line that
 # reports a version should say "(Debug)" outright, so a screenshot or a log excerpt
 # can never be mistaken for the release build. Derived from whatever the project's


### PR DESCRIPTION
Migrates Ice 2 from DragonKit **2.4.0** to **3.1.0**. Breaking upgrade, not a pin bump.

## The breaking change

DragonKit 3.0.0 removed `AboutLink`, `AboutContent.links`, `.credits` and `.acknowledgementsURL`. Five apps had used those free-form arrays to ship five visibly different About panes, so the kit now assembles every row title, SF Symbol, ordering and detail string. The app supplies only URLs and proper nouns. 3.1.0 then settled attributions on `name → licence` (`Attribution(component:source:)` is deprecated).

## Mapping applied

| Before | After |
|---|---|
| `links[0]` Website, detail `"dragonapp.com/ice-2"` | `websiteURL:` — same URL; the kit derives the identical detail |
| `links[1]` Support on GitHub, detail `"teddychan/ice-2"` | `supportURL:` — same URL, identical derived detail |
| `credits` `("Created by", "Teddy Chan")` | omitted — already the `createdBy:` default |
| `credits` `("Original Ice", "Jordan Baird")` | `originalWork: OriginalWork(name: "Ice", author: "Jordan Baird")` |
| `credits` `("License", "GPL-3.0")` | `license: "GPL-3.0"` |
| `copyright: Constants.copyrightString` | `DragonAbout.copyright(original: ("2025", "Jordan Baird"), years: "2026", holder: "Teddy Chan")` |
| `acknowledgementsURL:` (bundled PDF) | **not** mapped to `licensesURL` — see below |
| — | `attributions:` the five linked packages |

Verified against the released kit by constructing this exact `AboutContent` and printing the assembled rows:

```
copyright: © 2025 Jordan Baird · © 2026 Teddy Chan
websiteMatchesSupportRepo: true
-- links --   Website [globe] -> dragonapp.com/ice-2
              Support on GitHub [lifepreserver] -> teddychan/ice-2
-- credits -- Created by · Teddy Chan
              Based on · Ice by Jordan Baird
              Built with · DragonKit v3.1.0
              License · GPL-3.0
              AXSwift · MIT / CompactSlider · MIT / Ifrit · MIT / Semaphore · MIT / Sparkle · MIT
```

## User-visible changes

1. **The copyright line loses the word "Copyright".** `Copyright © 2025 Jordan Baird · © 2026 Teddy Chan` → `© 2025 Jordan Baird · © 2026 Teddy Chan`. Years and holders are unchanged. This is deliberate — the kit's design spec names Ice 2 as the one app that spelled it out — but it is a real change, so it is called out rather than buried. `NSHumanReadableCopyright` in the project is left as-is, so Finder's Get Info still reads "Copyright ©"; say the word and I'll align it.
2. **The Acknowledgements link is gone from About.** There is no slot for a bundled document any more. `licensesURL` expects a hosted page and `dragonapp.com/ice-2/licenses` does not exist yet, and passing the PDF's `file://` URL would render its absolute filesystem path as the row's link text, because the kit derives link detail from the URL. `Resources/Acknowledgements.pdf` is therefore **kept** in the bundle (still shipping the verbatim MIT notices) rather than deleted as the kit spec assumed, and the five libraries are now named in Credits. Follow-up: publish the licences page in `www.dragonapp.com`, then set `licensesURL` and delete the bundled document.
3. **Credits gains rows**: `Based on`, `Built with · DragonKit v3.1.0`, and the five attributions.

## Also in this PR

- **Conformance R12 (`DragonCommitDate`), failing before this change.** The shared release workflow passes `DRAGON_COMMIT_DATE` as an xcodebuild build setting, but only lands if the app's `Info.plist` maps it — Ice 2's did not, so released builds show the build number with no timestamp. `Ice/Resources/Info.plist` now maps it and `scripts/run-debug.sh` stamps it for local builds. Not caused by the About migration; fixing it is what gets the repo to a clean PASS.
- **What's New** no longer passes `version:`. `WhatsNewContent` reads `CFBundleShortVersionString` itself and normalizes to exactly one `v`. Compiles either way — the parameter still exists with a default — so this is intent, not a build fix. Ice 2 was passing the bare plist value, not `"v2.13.0"`, so nothing rendered differently.

## Verification

- `xcodebuild build` — **BUILD SUCCEEDED**, no new warnings (only the pre-existing SwiftLint run-script note and an unrelated AppIntents metadata note).
- `xcodebuild test` — **TEST SUCCEEDED**, 288 tests in 35 suites.
- `dragon-conformance.py --app . --kit ~/git/dragon-kit`:
  - before: `FAIL — 2 violation(s)` (R10 pinned to 2.4.0, R12 no `DragonCommitDate`)
  - after: `PASS — no violations.`
- `Package.resolved` records `dragon-kit 3.1.0`; Sparkle untouched at 2.9.4.

## Not verified / judgement calls

- **The app was not launched and the About pane was not looked at.** The row data above was verified as data, not on screen. Someone should open Settings ▸ About once.
- **The release build's timestamp is unverified.** It depends on `dragon-release-ci@v5` passing `DRAGON_COMMIT_DATE`, which it does in the workflow source, but only a real tagged release proves the plist mapping works end to end.
- **Attributions list five packages, not just Sparkle.** The kit's design spec says Ice 2 should name its bundled libraries as attributions; with the acknowledgements link gone, Credits is the only attribution surface left. Licences verified via each project's own LICENSE (Sparkle's is MIT with external notices appended, which is why GitHub reports it as NOASSERTION). Trim to Sparkle alone if that is too much for the pane.
- **`originalProjectURL` is left unset** — Ice 2 has an obvious upstream (`jordanbaird/Ice`) and the kit has an optional "Original project" slot for it, but the pane has never shown that row, so adding it was not assumed.
- **Adoption gap this upgrade exposes, deliberately not taken:** DragonKit 3.x added `UninstallConfig.homebrewCask`, which makes an in-app uninstall clear the Homebrew receipt it otherwise leaves dangling. Ice 2 ships as the cask `ice-2` but does not set it, so it does not get the fix. One line in `IceUninstallConfig` (`homebrewCask: "ice-2"`), but it arms a destructive, one-way path, so it wants its own PR and a sign-off.
- **The premise that this recovers a data-loss fix does not hold.** The `Decodable`-missing-key settings-loss fix landed in DragonKit 2.3.0 (`19e063e`), is an ancestor of the 2.4.0 Ice 2 was already on, and is documented in this repo's CHANGELOG under 2.12.1. Between 2.4.0 and 3.1.0 the only behavioural addition is the Homebrew receipt cleanup above; the rest is the About canon.
- **CHANGELOG.md is untouched**, matching how the last pin bump (#79) was handled — the entry is written at release time. The next release note should mention the copyright line and the Acknowledgements link, since users can see both.
- `Constants.versionString` and `Constants.copyrightString` are now unused (this change orphaned them), as is `Constants.buildString` (already dead before this change). Left in place: deleting them cascades into the `Bundle` extensions that exist only to feed them, which belongs in its own cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
