### PR TITLE
feat(uninstall): declare the ice-2 Homebrew cask on DragonKit 3.2.0, and remove the orphans

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -890,7 +890,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.0;
+				minimumVersion = 3.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "fe315656db572b88e7f5db89d2ace463cc13513a",
-        "version" : "3.1.0"
+        "revision" : "1cc443bd58ff49a2e530feccf66b6f5f72a9fc55",
+        "version" : "3.2.0"
       }
     },
     {

--- a/Ice/Settings/IceUninstallConfig.swift
+++ b/Ice/Settings/IceUninstallConfig.swift
@@ -23,9 +23,33 @@ import Foundation
 /// in `README.md`, and the Homebrew cask's `zap trash:` all remove the same five paths —
 /// keeping those three from drifting is the point, and removing an absent folder is a no-op.
 enum IceUninstallConfig {
-    /// The release build's bundle id: the fallback for the running bundle's id below, and the
-    /// gate on `homebrewCask`.
+    /// The bundle id Homebrew installed: the fallback for the running bundle's id below, and the
+    /// gate the cask token is issued against — deliberately not both at once, see
+    /// ``homebrewCask(forBundleID:)``.
     private static let releaseBundleID = "com.dragonapp.ice"
+
+    /// The Homebrew cask token for `actual`, or `nil` when that isn't the bundle brew installed.
+    ///
+    /// Ice 2 ships as the cask `ice-2` — the token declared by `Casks/ice-2.rb` in
+    /// teddychan/homebrew-tap, not inferred from the repo name. Homebrew never watches the
+    /// filesystem, so an app that deletes itself leaves brew's receipt still claiming the cask is
+    /// installed and `Caskroom/ice-2/<version>/Ice 2.app` a dangling symlink; `brew install --cask
+    /// ice-2` then refuses outright — "already installed" — for an app that isn't there, pointing
+    /// at nothing that would fix it. Naming the token lets the kit's post-exit shell run
+    /// `brew uninstall --cask --force ice-2` and clear that record.
+    ///
+    /// The comparison is the kit's (``UninstallConfig/caskToken(_:ifBundleIs:actual:)``, DragonKit
+    /// 3.2.0) rather than a local `==`, because it has to fail closed and Ice 2's own version
+    /// didn't. `brew uninstall --cask` is not bundle-scoped: it deletes whatever the receipt points
+    /// at — the *release* app in /Applications — and the cask carries `uninstall quit:`, so it
+    /// quits that app first. A debug build (com.dragonapp.ice.debug), which brew never installed,
+    /// must issue nothing; so must a build that can't state its id at all. Ice 2 used to compare
+    /// `Bundle.main.bundleIdentifier ?? releaseBundleID`, so a missing id fell back to the release
+    /// id and handed the delete to the one build least entitled to it. Hence the raw identifier
+    /// here, never `config`'s fallen-back `bundleID`.
+    static func homebrewCask(forBundleID actual: String?) -> String? {
+        UninstallConfig.caskToken("ice-2", ifBundleIs: releaseBundleID, actual: actual)
+    }
 
     static var config: UninstallConfig {
         // The running bundle's id, so a debug build (com.dragonapp.ice.debug) cleans its OWN
@@ -46,21 +70,10 @@ enum IceUninstallConfig {
                 library.appending(path: "Caches/\(bundleID)"),
                 library.appending(path: "HTTPStorages/\(bundleID)"),
             ],
-            // Ice 2 ships as the Homebrew cask `ice-2` — the token declared by `Casks/ice-2.rb`
-            // in teddychan/homebrew-tap, not inferred from the repo name. Homebrew never watches
-            // the filesystem, so an app that deletes itself leaves brew's receipt still claiming
-            // the cask is installed and `Caskroom/ice-2/<version>/Ice 2.app` a dangling symlink;
-            // `brew install --cask ice-2` then refuses outright — "already installed" — for an app
-            // that isn't there, pointing at nothing that would fix it. The kit's detached
-            // post-exit shell runs `brew uninstall --cask --force ice-2` to clear that record,
-            // *after* the bundle is already in the Trash: `brew uninstall --cask` deletes the app
-            // bundle itself, so running it first would make `NSWorkspace.recycle` fail on a bundle
-            // that was already gone and raise "Uninstall Incomplete" on an uninstall that worked.
-            //
-            // Release build only, for the same reason `bundleID` above is the *running* bundle's:
-            // a debug build (com.dragonapp.ice.debug) was never installed by brew, and clearing
-            // the `ice-2` receipt from one would delete the installed release app, not itself.
-            homebrewCask: bundleID == releaseBundleID ? "ice-2" : nil
+            // The *raw* identifier, never `bundleID` above: that one falls back to the release id
+            // so a build which can't state its own still cleans a sensible domain, which is
+            // harmless there and authorises a delete of the installed release here.
+            homebrewCask: homebrewCask(forBundleID: Bundle.main.bundleIdentifier)
         )
     }
 }

--- a/Ice/Settings/IceUninstallConfig.swift
+++ b/Ice/Settings/IceUninstallConfig.swift
@@ -23,10 +23,14 @@ import Foundation
 /// in `README.md`, and the Homebrew cask's `zap trash:` all remove the same five paths —
 /// keeping those three from drifting is the point, and removing an absent folder is a no-op.
 enum IceUninstallConfig {
+    /// The release build's bundle id: the fallback for the running bundle's id below, and the
+    /// gate on `homebrewCask`.
+    private static let releaseBundleID = "com.dragonapp.ice"
+
     static var config: UninstallConfig {
         // The running bundle's id, so a debug build (com.dragonapp.ice.debug) cleans its OWN
         // domain/state/caches and never the installed release's.
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.dragonapp.ice"
+        let bundleID = Bundle.main.bundleIdentifier ?? releaseBundleID
         let library = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library")
         return UninstallConfig(
             appName: Constants.displayName,
@@ -41,7 +45,22 @@ enum IceUninstallConfig {
                 library.appending(path: "Application Support/\(bundleID)"),
                 library.appending(path: "Caches/\(bundleID)"),
                 library.appending(path: "HTTPStorages/\(bundleID)"),
-            ]
+            ],
+            // Ice 2 ships as the Homebrew cask `ice-2` — the token declared by `Casks/ice-2.rb`
+            // in teddychan/homebrew-tap, not inferred from the repo name. Homebrew never watches
+            // the filesystem, so an app that deletes itself leaves brew's receipt still claiming
+            // the cask is installed and `Caskroom/ice-2/<version>/Ice 2.app` a dangling symlink;
+            // `brew install --cask ice-2` then refuses outright — "already installed" — for an app
+            // that isn't there, pointing at nothing that would fix it. The kit's detached
+            // post-exit shell runs `brew uninstall --cask --force ice-2` to clear that record,
+            // *after* the bundle is already in the Trash: `brew uninstall --cask` deletes the app
+            // bundle itself, so running it first would make `NSWorkspace.recycle` fail on a bundle
+            // that was already gone and raise "Uninstall Incomplete" on an uninstall that worked.
+            //
+            // Release build only, for the same reason `bundleID` above is the *running* bundle's:
+            // a debug build (com.dragonapp.ice.debug) was never installed by brew, and clearing
+            // the `ice-2` receipt from one would delete the installed release app, not itself.
+            homebrewCask: bundleID == releaseBundleID ? "ice-2" : nil
         )
     }
 }

--- a/Ice/Utilities/Constants.swift
+++ b/Ice/Utilities/Constants.swift
@@ -8,15 +8,6 @@ import Foundation
 enum Constants {
     // swiftlint:disable force_unwrapping
 
-    /// The version string in the app's bundle.
-    static let versionString = Bundle.main.versionString!
-
-    /// The build string in the app's bundle.
-    static let buildString = Bundle.main.buildString!
-
-    /// The user-readable copyright string in the app's bundle.
-    static let copyrightString = Bundle.main.copyrightString!
-
     /// The app's bundle identifier.
     static let bundleIdentifier = Bundle.main.bundleIdentifier!
 

--- a/Ice/Utilities/Extensions.swift
+++ b/Ice/Utilities/Extensions.swift
@@ -9,15 +9,6 @@ import SwiftUI
 // MARK: - Bundle
 
 extension Bundle {
-    /// The bundle's copyright string.
-    ///
-    /// This accessor checks the bundle's `Info.plist` for a string value associated
-    /// with the "NSHumanReadableCopyright" key. If a valid value cannot be found for
-    /// the key, this accessor returns `nil`.
-    var copyrightString: String? {
-        object(forInfoDictionaryKey: "NSHumanReadableCopyright") as? String
-    }
-
     /// The bundle's display name.
     ///
     /// This accessor checks the bundle's `Info.plist` for a string value associated
@@ -27,24 +18,6 @@ extension Bundle {
     var displayName: String? {
         object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ??
         object(forInfoDictionaryKey: "CFBundleName") as? String
-    }
-
-    /// The bundle's version string.
-    ///
-    /// This accessor checks the bundle's `Info.plist` for a string value associated
-    /// with the "CFBundleShortVersionString" key. If a valid value cannot be found
-    /// for the key, this accessor returns `nil`.
-    var versionString: String? {
-        object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-    }
-
-    /// The bundle's build string.
-    ///
-    /// This accessor checks the bundle's `Info.plist` for a string value associated
-    /// with the "CFBundleVersion" key. If a valid value cannot be found for the key,
-    /// this accessor returns `nil`.
-    var buildString: String? {
-        object(forInfoDictionaryKey: "CFBundleVersion") as? String
     }
 }
 

--- a/IceTests/UninstallConfigTests.swift
+++ b/IceTests/UninstallConfigTests.swift
@@ -96,12 +96,24 @@ struct UninstallConfigTests {
         // Gated on the running bundle id for the same reason every path above is: `brew uninstall
         // --cask` deletes the app *brew* recorded, so a debug build (com.dragonapp.ice.debug),
         // which brew never installed, would delete the installed release instead of itself.
-        if Bundle.main.bundleIdentifier == "com.dragonapp.ice" {
-            #expect(config.homebrewCask == "ice-2")
-        } else {
-            #expect(config.homebrewCask == nil)
+        //
+        // The identity is passed in rather than read from the test host, because the host is
+        // always the Debug build: the previous version of this test asked
+        // `Bundle.main.bundleIdentifier` and could therefore only ever exercise the `nil` branch,
+        // asserting as a fact about Ice 2 something that was only a fact about CI.
+        func token(for bundleID: String?) -> String? {
+            IceUninstallConfig.homebrewCask(forBundleID: bundleID)
         }
-        #expect(config.homebrewCask == nil) // the test host is the Debug build
+
+        #expect(token(for: "com.dragonapp.ice") == "ice-2")
+        #expect(token(for: "com.dragonapp.ice.debug") == nil, "the debug re-id is why this gate exists")
+        #expect(token(for: "com.dragonapp.clipmenu-2") == nil)
+        #expect(token(for: nil) == nil, "a build that can't state its id must authorise nothing")
+
+        // And that `config` actually asks: without this, hardcoding the token back into the
+        // initializer would leave every case above still passing. Holds in either build — it
+        // pins the wiring, not a configuration-specific answer.
+        #expect(config.homebrewCask == token(for: Bundle.main.bundleIdentifier))
     }
 
     @Test func deletesNothingBeyondTheBundlesOwnFolders() {

--- a/IceTests/UninstallConfigTests.swift
+++ b/IceTests/UninstallConfigTests.swift
@@ -88,6 +88,22 @@ struct UninstallConfigTests {
         #expect(!defaultFolder.path.hasPrefix(library.path + "/"))
     }
 
+    @Test func clearsHomebrewsReceiptOnlyForTheReleaseBuild() {
+        // Ice 2 ships as the cask `ice-2` (`Casks/ice-2.rb` in teddychan/homebrew-tap), so the
+        // teardown clears brew's receipt too — left behind, it claims the cask is still installed
+        // and `brew install --cask ice-2` refuses for an app that isn't there.
+        //
+        // Gated on the running bundle id for the same reason every path above is: `brew uninstall
+        // --cask` deletes the app *brew* recorded, so a debug build (com.dragonapp.ice.debug),
+        // which brew never installed, would delete the installed release instead of itself.
+        if Bundle.main.bundleIdentifier == "com.dragonapp.ice" {
+            #expect(config.homebrewCask == "ice-2")
+        } else {
+            #expect(config.homebrewCask == nil)
+        }
+        #expect(config.homebrewCask == nil) // the test host is the Debug build
+    }
+
     @Test func deletesNothingBeyondTheBundlesOwnFolders() {
         // Ice 2's settings live in `UserDefaults.standard` (`Defaults.store`), i.e. the
         // bundle-id domain the uninstaller already wipes — so no extra suites.


### PR DESCRIPTION
Three commits: the cask token, the orphan removals, then the 3.2.0 adoption that made the guard
safe.

## 1 — declare the Homebrew cask

Ice 2 ships as cask `ice-2` but didn't declare it, so an in-app uninstall left Homebrew's records
behind: the receipt still claimed the cask was installed and the `Caskroom` symlink dangled, so
`brew install --cask ice-2` refused outright for an app that wasn't there.

Token verified from `Casks/ice-2.rb` in `teddychan/homebrew-tap`, not assumed from the repo name.

## 2 — remove six orphans

`Constants.versionString` / `buildString` / `copyrightString` and the three `Bundle` extensions
that existed only to feed them, all left unreferenced by the v3 About migration. Each confirmed
unreferenced by repo-wide `git grep -w`. Kept: `Bundle.displayName` (10 call sites),
`Constants.bundleIdentifier` (4).

## 3 — DragonKit 3.2.0, and a fail-closed guard

Pinned to **3.2.0**, resolving to revision `1cc443bd58ff49a2e530feccf66b6f5f72a9fc55`.

That release is the prerequisite: DragonKit's post-exit Homebrew cleanup is now scheduled **only
from inside a successful `NSWorkspace.recycle` callback**. Before it, the cleanup was spawned
ahead of the Trash move and merely slept two seconds — so a failed move showed "Uninstall
Incomplete", kept the app running, and was overruled seconds later by `brew uninstall --cask
--force` deleting the app anyway.

**The guard now fails closed.** It previously compared `bundleID`, which is
`Bundle.main.bundleIdentifier ?? releaseBundleID` — so a *missing* identifier fell back to the
release id and **authorised** the delete. It now passes the raw identifier to the kit's
`UninstallConfig.caskToken(_:ifBundleIs:actual:)`: release → `"ice-2"`; debug, alternate and nil
→ `nil`. Using the kit helper rather than a local comparison is deliberate — that's what stops
each app reinventing this and getting it wrong.

The test is now deterministic. It previously read the ambient bundle id, and CI only ever
exercises Debug, so its unconditional trailing `nil` assertion passed for the wrong reason and
would have contradicted the release branch. It now passes identities in explicitly, plus one
assertion tying the config to the helper — without it, hardcoding the token back into the
initializer would leave all four cases green.

## Verification

| | |
|---|---|
| Build | `** BUILD SUCCEEDED **`, 0 errors; 2 warnings, both pre-existing `appintentsmetadataprocessor` toolchain notes |
| Tests | **289 in 35 suites**, pass |
| SwiftLint | `--strict` exit 0, 0 violations in 115 files |
| DragonKit conformance | **PASS — no violations** |
| Resolved dependency | `dragon-kit 3.2.0 @ 1cc443bd58ff49a2e530feccf66b6f5f72a9fc55` |

## Not verified

**The uninstall path was never executed** — destructive and one-way. The guard is covered by unit
test and static reading, not by an actual `brew uninstall`.

## Notes

- `kind = upToNextMajorVersion` makes the pin a floor, so a future `v3.x` is picked up on the next
  resolve; `Package.resolved` holds 3.2.0 until then. That matches how the other four dependencies
  are pinned here — a policy choice, not a defect.
- Pre-existing and left alone: `namesTheRunningBuildNotTheReleaseName()` asserts
  `appName == "Ice 2 Debug"`, the same environment-dependent defect class, but it's on `main` and
  outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)