### PR TITLE
Add Simplified Chinese localization and language picker

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"zh-Hans",
 			);
 			mainGroup = 716683212A767E6A006ABF84;
 			packageReferences = (

--- a/Ice/Main/Updates.swift
+++ b/Ice/Main/Updates.swift
@@ -51,7 +51,7 @@ final class UpdatesManager {
         #if DEBUG
         // Checking for updates hangs in debug mode.
         let alert = NSAlert()
-        alert.messageText = "Checking for updates is not supported in debug mode."
+        alert.messageText = String(localized: "Checking for updates is not supported in debug mode.")
         alert.runModal()
         #else
         guard let appState else {
@@ -92,8 +92,8 @@ final class UpdatesManager {
     /// Sparkle's delegate that ``DragonUpdaterConfig`` does not expose.
     private static func notifyUpdateAvailable() {
         let content = UNMutableNotificationContent()
-        content.title = "A new update is available"
-        content.body = "\(Constants.displayName) found a newer version."
+        content.title = String(localized: "A new update is available")
+        content.body = String(localized: "\(Constants.displayName) found a newer version.")
         UNUserNotificationCenter.current().add(
             UNNotificationRequest(identifier: "UpdateCheck", content: content, trigger: nil)
         )

--- a/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditorPanel.swift
+++ b/Ice/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditorPanel.swift
@@ -31,7 +31,7 @@ final class MenuBarAppearanceEditorPanel: NSPanel {
             backing: .buffered,
             defer: false
         )
-        self.title = "Menu Bar Appearance"
+        self.title = String(localized: "Menu Bar Appearance")
         self.titlebarAppearsTransparent = true
         self.allowsToolTipsWhenApplicationIsInactive = true
         self.isFloatingPanel = true

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -516,7 +516,7 @@ final class ControlItem {
         // Quick-actions zone: the Ice-specific items only. Settings and
         // Check-for-updates live in the App menu below (de-dup per spec).
         let searchItem = menuItem(
-            title: "Search Menu Bar Items",
+            title: String(localized: "Search Menu Bar Items"),
             symbolName: "magnifyingglass",
             action: #selector(showSearchPanel)
         )
@@ -539,7 +539,7 @@ final class ControlItem {
                 continue
             }
             let item = menuItem(
-                title: "\(section.isHidden ? "Show" : "Hide") \(name.displayString) Section",
+                title: String(localized: "\(section.isHidden ? "Show" : "Hide") \(name.displayString) Section"),
                 symbolName: section.isHidden ? "eye" : "eye.slash",
                 action: #selector(toggleMenuBarSection)
             )

--- a/Ice/MenuBar/IceBar/IceBar.swift
+++ b/Ice/MenuBar/IceBar/IceBar.swift
@@ -33,7 +33,7 @@ final class IceBarPanel: NSPanel {
             backing: .buffered,
             defer: false
         )
-        self.title = "Ice 2 Bar"
+        self.title = String(localized: "Ice 2 Bar")
         self.titlebarAppearsTransparent = true
         self.isMovableByWindowBackground = true
         self.allowsToolTipsWhenApplicationIsInactive = true

--- a/Ice/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Ice/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -158,15 +158,15 @@ final class LayoutBarItemView: NSView {
     /// Provides an alert to display when the item view is disabled.
     func provideAlertForDisabledItem() -> NSAlert {
         let alert = NSAlert()
-        alert.messageText = "Menu bar item is not movable."
-        alert.informativeText = "macOS prohibits \"\(item.displayName)\" from being moved."
+        alert.messageText = String(localized: "Menu bar item is not movable.")
+        alert.informativeText = String(localized: "macOS prohibits \"\(item.displayName)\" from being moved.")
         return alert
     }
 
     /// Provides an alert to display when a menu bar item is unresponsive.
     func provideAlertForUnresponsiveItem() -> NSAlert {
         let alert = provideAlertForDisabledItem()
-        alert.informativeText = "\(item.displayName) is unresponsive. Until it is restarted, it cannot be moved. Movement of other menu bar items may also be affected until this is resolved."
+        alert.informativeText = String(localized: "\(item.displayName) is unresponsive. Until it is restarted, it cannot be moved. Movement of other menu bar items may also be affected until this is resolved.")
         return alert
     }
 

--- a/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -106,10 +106,10 @@ struct MenuBarItem: CustomStringConvertible {
         }
 
         if tag.isSpacerItem {
-            return "Spacer"
+            return String(localized: "Spacer")
         }
 
-        lazy var fallbackName = "Menu Bar Item"
+        lazy var fallbackName = String(localized: "Menu Bar Item")
 
         guard let sourceApplication = sourcePID.flatMap({ NSRunningApplication(processIdentifier: $0) }) else {
             return fallbackName

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -524,21 +524,21 @@ extension MenuBarItemManager {
         var errorDescription: String? {
             switch self {
             case .cannotComplete:
-                "Operation could not be completed"
+                String(localized: "Operation could not be completed")
             case .invalidEventSource:
-                "Invalid event source"
+                String(localized: "Invalid event source")
             case .missingMouseLocation:
-                "Missing mouse location"
+                String(localized: "Missing mouse location")
             case .eventCreationFailure(let item):
-                "Could not create event for \"\(item.displayName)\""
+                String(localized: "Could not create event for \"\(item.displayName)\"")
             case .eventOperationTimeout(let item):
-                "Event operation timed out for \"\(item.displayName)\""
+                String(localized: "Event operation timed out for \"\(item.displayName)\"")
             case .itemNotMovable(let item):
-                "\"\(item.displayName)\" is not movable"
+                String(localized: "\"\(item.displayName)\" is not movable")
             case .itemResponseTimeout(let item):
-                "\"\(item.displayName)\" took too long to respond"
+                String(localized: "\"\(item.displayName)\" took too long to respond")
             case .missingItemBounds(let item):
-                "Missing bounds rectangle for \"\(item.displayName)\""
+                String(localized: "Missing bounds rectangle for \"\(item.displayName)\"")
             }
         }
 
@@ -1581,7 +1581,7 @@ extension MenuBarItemManager {
         guard let targetItem = items.first else {
             logger.warning("Not enough room to show \(item.logString, privacy: .public)")
             let alert = NSAlert()
-            alert.messageText = "Not enough room to show \"\(item.displayName)\""
+            alert.messageText = String(localized: "Not enough room to show \"\(item.displayName)\"")
             alert.runModal()
             return
         }

--- a/Ice/MenuBar/MenuBarManager.swift
+++ b/Ice/MenuBar/MenuBarManager.swift
@@ -274,7 +274,7 @@ final class MenuBarManager: ObservableObject {
         let menu = NSMenu(title: Constants.displayName)
 
         let editAppearanceItem = NSMenuItem(
-            title: "Edit Menu Bar Appearance…",
+            title: String(localized: "Edit Menu Bar Appearance…"),
             action: #selector(showAppearanceEditorPanel),
             keyEquivalent: ""
         )
@@ -284,7 +284,7 @@ final class MenuBarManager: ObservableObject {
         menu.addItem(.separator())
 
         let settingsItem = NSMenuItem(
-            title: "\(Constants.displayName) Settings…",
+            title: String(localized: "\(Constants.displayName) Settings…"),
             action: #selector(AppDelegate.openSettingsWindow),
             keyEquivalent: ","
         )

--- a/Ice/MenuBar/MenuBarSection.swift
+++ b/Ice/MenuBar/MenuBarSection.swift
@@ -17,9 +17,9 @@ final class MenuBarSection {
         /// A string to show in the interface.
         var displayString: String {
             switch self {
-            case .visible: "Visible"
-            case .hidden: "Hidden"
-            case .alwaysHidden: "Always-Hidden"
+            case .visible: String(localized: "Visible")
+            case .hidden: String(localized: "Hidden")
+            case .alwaysHidden: String(localized: "Always-Hidden")
             }
         }
 

--- a/Ice/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Ice/MenuBar/Search/MenuBarSearchPanel.swift
@@ -457,9 +457,9 @@ private struct ShowItemButton: View {
     private var actionTitle: String {
         switch mode {
         case .clickOrShow:
-            "\(Bridging.isWindowOnScreen(item.windowID) ? "Click" : "Show") Item"
+            String(localized: "\(Bridging.isWindowOnScreen(item.windowID) ? "Click" : "Show") Item")
         case .temporarilyShow:
-            "Show Item"
+            String(localized: "Show Item")
         }
     }
 }

--- a/Ice/MenuBar/Spacers/MenuBarSpacerManager.swift
+++ b/Ice/MenuBar/Spacers/MenuBarSpacerManager.swift
@@ -61,7 +61,7 @@ final class MenuBarSpacerManager: ObservableObject {
     func createSpacer() {
         let spacer = MenuBarSpacer(
             id: UUID(),
-            name: "Spacer \(spacers.count + 1)",
+            name: String(localized: "Spacer \(spacers.count + 1)"),
             width: 24
         )
         spacers.append(spacer)

--- a/Ice/MenuBar/Spacing/MenuBarItemSpacingManager.swift
+++ b/Ice/MenuBar/Spacing/MenuBarItemSpacingManager.swift
@@ -30,11 +30,11 @@ final class MenuBarItemSpacingManager {
         let failedApps: [String]
 
         var errorDescription: String? {
-            "The following applications failed to quit and were not restarted:\n" + failedApps.joined(separator: "\n")
+            String(localized: "The following applications failed to quit and were not restarted:") + "\n" + failedApps.joined(separator: "\n")
         }
 
         var recoverySuggestion: String? {
-            "You may need to log out for the changes to take effect."
+            String(localized: "You may need to log out for the changes to take effect.")
         }
     }
 

--- a/Ice/Permissions/Permission.swift
+++ b/Ice/Permissions/Permission.swift
@@ -197,10 +197,10 @@ class Permission: ObservableObject, Identifiable {
 final class AccessibilityPermission: Permission {
     init() {
         super.init(
-            title: "Accessibility",
+            title: String(localized: "Accessibility"),
             details: [
-                "Get real-time information about the menu bar.",
-                "Arrange menu bar items.",
+                String(localized: "Get real-time information about the menu bar."),
+                String(localized: "Arrange menu bar items."),
             ],
             isRequired: true,
             mayRequireRelaunch: false,
@@ -223,10 +223,10 @@ final class AccessibilityPermission: Permission {
 final class ScreenRecordingPermission: Permission {
     init() {
         super.init(
-            title: "Screen Recording",
+            title: String(localized: "Screen Recording"),
             details: [
-                "Change the menu bar's appearance.",
-                "Display images of individual menu bar items.",
+                String(localized: "Change the menu bar's appearance."),
+                String(localized: "Display images of individual menu bar items."),
             ],
             isRequired: false,
             mayRequireRelaunch: true,

--- a/Ice/Resources/Localizable.xcstrings
+++ b/Ice/Resources/Localizable.xcstrings
@@ -1,0 +1,2346 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "\"%@\" is not movable": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%1$@”无法移动"
+          }
+        }
+      }
+    },
+    "\"%@\" took too long to respond": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%1$@”响应超时"
+          }
+        }
+      }
+    },
+    "%@ %@ Section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@%2$@分区"
+          }
+        }
+      }
+    },
+    "%@ Item": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@项目"
+          }
+        }
+      }
+    },
+    "%@ Settings…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 设置…"
+          }
+        }
+      }
+    },
+    "%@ found a newer version.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ 发现了较新版本。"
+          }
+        }
+      }
+    },
+    "%@ is unresponsive. Until it is restarted, it cannot be moved. Movement of other menu bar items may also be affected until this is resolved.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%1$@”无响应。在它重新启动之前无法移动，其他菜单栏项目的移动也可能受到影响，直到问题解决。"
+          }
+        }
+      }
+    },
+    "%@ second": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 秒"
+          }
+        }
+      }
+    },
+    "%@ seconds": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 秒"
+          }
+        }
+      }
+    },
+    "%lld pt": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 点"
+          }
+        }
+      }
+    },
+    "%lld visible, %lld hidden, %lld always-hidden": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 个可见，%2$lld 个隐藏，%3$lld 个始终隐藏"
+          }
+        }
+      }
+    },
+    "A new update is available": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有新的更新可用"
+          }
+        }
+      }
+    },
+    "About": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关于"
+          }
+        }
+      }
+    },
+    "Absolutely no personal information is collected or stored.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "绝不会收集或存储任何个人信息。"
+          }
+        }
+      }
+    },
+    "Accessibility": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助功能"
+          }
+        }
+      }
+    },
+    "Add Current App": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加当前应用"
+          }
+        }
+      }
+    },
+    "Add Spacer": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加间隔"
+          }
+        }
+      }
+    },
+    "Add flexible space between menu bar items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏项目之间添加弹性间隔。"
+          }
+        }
+      }
+    },
+    "Advanced": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级"
+          }
+        }
+      }
+    },
+    "After granting this permission in System Settings, relaunch Ice 2 to enable capture on macOS 26.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在系统设置中授予此权限后，重新启动 Ice 2 以在 macOS 26 上启用截取。"
+          }
+        }
+      }
+    },
+    "Always-Hidden": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "始终隐藏"
+          }
+        }
+      }
+    },
+    "Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外观"
+          }
+        }
+      }
+    },
+    "Apply": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        }
+      }
+    },
+    "Apply different settings based on the current system appearance.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根据当前系统外观应用不同设置。"
+          }
+        }
+      }
+    },
+    "Apply the current spacing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用当前间距"
+          }
+        }
+      }
+    },
+    "Applying this setting will relaunch all apps with menu bar items. Some apps may need to be manually relaunched.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用此设置将重新启动所有带菜单栏项目的应用。某些应用可能需要手动重新启动。"
+          }
+        }
+      }
+    },
+    "Arrange menu bar items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排列菜单栏项目。"
+          }
+        }
+      }
+    },
+    "Auto-enable Ice 2 Bar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动启用 Ice 2 栏"
+          }
+        }
+      }
+    },
+    "Auto-enable when": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动启用条件"
+          }
+        }
+      }
+    },
+    "Automatic": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跟随系统"
+          }
+        }
+      }
+    },
+    "Automatic Ice 2 Bar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动 Ice 2 栏"
+          }
+        }
+      }
+    },
+    "Automatically back up when quitting": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出时自动备份"
+          }
+        }
+      }
+    },
+    "Automatically enable or disable Ice 2 Bar based on the current display.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "根据当前显示器自动启用或停用 Ice 2 栏。"
+          }
+        }
+      }
+    },
+    "Automatically rehide": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动重新隐藏"
+          }
+        }
+      }
+    },
+    "Back Up Now": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "立即备份"
+          }
+        }
+      }
+    },
+    "Backed up just now.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刚刚已备份。"
+          }
+        }
+      }
+    },
+    "Backup & Restore": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份与恢复"
+          }
+        }
+      }
+    },
+    "Backup Error": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份错误"
+          }
+        }
+      }
+    },
+    "Backup Folder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份文件夹"
+          }
+        }
+      }
+    },
+    "Backups": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "备份"
+          }
+        }
+      }
+    },
+    "Border": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "边框"
+          }
+        }
+      }
+    },
+    "Border Color": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "边框颜色"
+          }
+        }
+      }
+    },
+    "Border Width": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "边框宽度"
+          }
+        }
+      }
+    },
+    "Caches and support files": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缓存和支持文件"
+          }
+        }
+      }
+    },
+    "Cancel": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        }
+      }
+    },
+    "Change the menu bar's appearance.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改菜单栏的外观。"
+          }
+        }
+      }
+    },
+    "Change…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改…"
+          }
+        }
+      }
+    },
+    "Check Again": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新检查"
+          }
+        }
+      }
+    },
+    "Checking for updates is not supported in debug mode.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "调试模式不支持检查更新。"
+          }
+        }
+      }
+    },
+    "Chevron": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "箭头"
+          }
+        }
+      }
+    },
+    "Choose": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择"
+          }
+        }
+      }
+    },
+    "Choose a custom icon to show in the menu bar.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择要在菜单栏中显示的自定义图标。"
+          }
+        }
+      }
+    },
+    "Choose a folder inside Dropbox, iCloud Drive, or Google Drive to sync your settings across your Macs. Backups are also kept for restoring after a reinstall or on a new Mac.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择 Dropbox、iCloud 云盘或 Google 云端硬盘中的文件夹，以在多台 Mac 间同步设置。同时也会保留备份，供重新安装后或在新 Mac 上恢复使用。"
+          }
+        }
+      }
+    },
+    "Choose image…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择图像…"
+          }
+        }
+      }
+    },
+    "Clear": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
+          }
+        }
+      }
+    },
+    "Click inside an empty area of the menu bar to show hidden menu bar items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击菜单栏空白区域可显示隐藏的菜单栏项目。"
+          }
+        }
+      }
+    },
+    "Click to show hidden menu bar items. Right-click to access Ice 2's settings. Customize the icon in the Appearance settings.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击可显示隐藏的菜单栏项目。右键点击可访问 Ice 2 的设置。可在“外观”设置中自定义图标。"
+          }
+        }
+      }
+    },
+    "Continue": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续"
+          }
+        }
+      }
+    },
+    "Continue in Limited Mode": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以受限模式继续"
+          }
+        }
+      }
+    },
+    "Could not create event for \"%@\"": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法为“%1$@”创建事件"
+          }
+        }
+      }
+    },
+    "Custom icon uses dynamic appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义图标使用动态外观"
+          }
+        }
+      }
+    },
+    "Dark Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色外观"
+          }
+        }
+      }
+    },
+    "Delete": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "删除"
+          }
+        }
+      }
+    },
+    "Display images of individual menu bar items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示各个菜单栏项目的图像。"
+          }
+        }
+      }
+    },
+    "Done": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
+          }
+        }
+      }
+    },
+    "Drag to arrange your menu bar items into different sections.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖移菜单栏项目即可将它们排列到不同分区。"
+          }
+        }
+      }
+    },
+    "Dynamic": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "动态"
+          }
+        }
+      }
+    },
+    "ERROR": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "错误"
+          }
+        }
+      }
+    },
+    "Edit Menu Bar Appearance…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑菜单栏外观…"
+          }
+        }
+      }
+    },
+    "Enable Ice 2 Bar when the active menu bar screen has a notch.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当活动菜单栏所在屏幕带有刘海时启用 Ice 2 栏。"
+          }
+        }
+      }
+    },
+    "Enable Ice 2 Bar when the active menu bar screen is narrower than the threshold.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当活动菜单栏所在屏幕窄于阈值时启用 Ice 2 栏。"
+          }
+        }
+      }
+    },
+    "Enable Ice 2 context menus on right click": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在右键点击时启用 Ice 2 上下文菜单"
+          }
+        }
+      }
+    },
+    "Enable the Ice 2 Bar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用 Ice 2 栏"
+          }
+        }
+      }
+    },
+    "Enable the always-hidden section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用始终隐藏分区"
+          }
+        }
+      }
+    },
+    "Event operation timed out for \"%@\"": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%1$@”的事件操作超时"
+          }
+        }
+      }
+    },
+    "Focused app": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前应用"
+          }
+        }
+      }
+    },
+    "Full": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部"
+          }
+        }
+      }
+    },
+    "General": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通用"
+          }
+        }
+      }
+    },
+    "Get real-time information about the menu bar.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取菜单栏的实时信息。"
+          }
+        }
+      }
+    },
+    "Go to Advanced Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前往高级设置"
+          }
+        }
+      }
+    },
+    "Gradient": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "渐变"
+          }
+        }
+      }
+    },
+    "Grant Permission": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "授予权限"
+          }
+        }
+      }
+    },
+    "Hidden": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏"
+          }
+        }
+      }
+    },
+    "Hidden section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏分区"
+          }
+        }
+      }
+    },
+    "Hide app menus when showing menu bar items": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示菜单栏项目时隐藏应用菜单"
+          }
+        }
+      }
+    },
+    "Hold to Preview": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按住预览"
+          }
+        }
+      }
+    },
+    "Hotkey is reserved by macOS": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此快捷键被 macOS 占用"
+          }
+        }
+      }
+    },
+    "Hotkeys": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键"
+          }
+        }
+      }
+    },
+    "Hover over an empty area of the menu bar or the Ice 2 icon to show hidden menu bar items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将指针悬停在菜单栏空白区域或 Ice 2 图标上可显示隐藏的菜单栏项目。"
+          }
+        }
+      }
+    },
+    "Ice 2 Bar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 栏"
+          }
+        }
+      }
+    },
+    "Ice 2 Bar will be enabled when the active menu bar screen is narrower than this width in points.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当活动菜单栏所在屏幕窄于该宽度（点）时，将启用 Ice 2 栏。"
+          }
+        }
+      }
+    },
+    "Ice 2 can work in a limited mode without this permission.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 无需此权限也可以受限模式运行。"
+          }
+        }
+      }
+    },
+    "Ice 2 cannot arrange menu bar items in automatically hidden menu bars.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法在自动隐藏的菜单栏中排列菜单栏项目。"
+          }
+        }
+      }
+    },
+    "Ice 2 cannot display menu bar items for automatically hidden menu bars": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法为自动隐藏的菜单栏显示菜单栏项目"
+          }
+        }
+      }
+    },
+    "Ice 2 cannot edit the appearance of automatically hidden menu bars.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法编辑自动隐藏菜单栏的外观。"
+          }
+        }
+      }
+    },
+    "Ice 2 icon": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 图标"
+          }
+        }
+      }
+    },
+    "Ice 2 needs this to:": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 需要此权限以："
+          }
+        }
+      }
+    },
+    "Ice 2 needs your permission to manage the menu bar.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 需要你的权限才能管理菜单栏。"
+          }
+        }
+      }
+    },
+    "Invalid event source": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的事件源"
+          }
+        }
+      }
+    },
+    "Items can also be arranged by ⌘ Command + dragging them in the menu bar.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "也可以按住 ⌘ 键在菜单栏中拖移项目进行排列。"
+          }
+        }
+      }
+    },
+    "Keeps the backup folder current so a synced copy is always up to date.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "让备份文件夹保持最新，确保同步副本始终是最新的。"
+          }
+        }
+      }
+    },
+    "Language": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
+        }
+      }
+    },
+    "Launch at login": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登录时启动"
+          }
+        }
+      }
+    },
+    "Layout": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "布局"
+          }
+        }
+      }
+    },
+    "Leading End Cap": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前缘端帽"
+          }
+        }
+      }
+    },
+    "Light Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色外观"
+          }
+        }
+      }
+    },
+    "Loading menu bar items…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载菜单栏项目…"
+          }
+        }
+      }
+    },
+    "Location": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置"
+          }
+        }
+      }
+    },
+    "Manual backup": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动备份"
+          }
+        }
+      }
+    },
+    "Menu Bar Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏外观"
+          }
+        }
+      }
+    },
+    "Menu Bar Icon": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏图标"
+          }
+        }
+      }
+    },
+    "Menu Bar Item": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏项目"
+          }
+        }
+      }
+    },
+    "Menu Bar Items": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏项目"
+          }
+        }
+      }
+    },
+    "Menu Bar Sections": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏分区"
+          }
+        }
+      }
+    },
+    "Menu Bar Shape": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏形状"
+          }
+        }
+      }
+    },
+    "Menu bar item is not movable.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此菜单栏项目无法移动。"
+          }
+        }
+      }
+    },
+    "Menu bar item spacing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏项目间距"
+          }
+        }
+      }
+    },
+    "Menu bar items are rehidden after a fixed amount of time.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏项目会在固定时间后重新隐藏。"
+          }
+        }
+      }
+    },
+    "Menu bar items are rehidden using a smart algorithm.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏项目会通过智能算法重新隐藏。"
+          }
+        }
+      }
+    },
+    "Menu bar items are rehidden when the focused app changes.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏项目会在当前应用切换时重新隐藏。"
+          }
+        }
+      }
+    },
+    "Menu bar layout requires screen recording permissions.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "菜单栏布局需要屏幕录制权限。"
+          }
+        }
+      }
+    },
+    "Missing bounds rectangle for \"%@\"": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少“%1$@”的边界矩形"
+          }
+        }
+      }
+    },
+    "Missing mouse location": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "缺少鼠标位置"
+          }
+        }
+      }
+    },
+    "Mouse pointer": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鼠标指针"
+          }
+        }
+      }
+    },
+    "No backups yet.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无备份。"
+          }
+        }
+      }
+    },
+    "No manageable menu bar items found.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到可管理的菜单栏项目。"
+          }
+        }
+      }
+    },
+    "No saved layout profiles.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有已保存的布局方案。"
+          }
+        }
+      }
+    },
+    "No shape kind selected": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未选择形状类型"
+          }
+        }
+      }
+    },
+    "None": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无"
+          }
+        }
+      }
+    },
+    "Not enough room to show \"%@\"": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空间不足，无法显示“%1$@”"
+          }
+        }
+      }
+    },
+    "Note: You may need to log out and back in for this setting to apply properly.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注意：此设置可能需要注销后重新登录才能正确生效。"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        }
+      }
+    },
+    "On macOS 26, Ice 2 may need to relaunch after you grant this permission.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 macOS 26 上，授予此权限后 Ice 2 可能需要重新启动。"
+          }
+        }
+      }
+    },
+    "Open Ice 2 Settings": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Ice 2 设置"
+          }
+        }
+      }
+    },
+    "Operation could not be completed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作无法完成"
+          }
+        }
+      }
+    },
+    "Other": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他"
+          }
+        }
+      }
+    },
+    "Permission Granted": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限已授予"
+          }
+        }
+      }
+    },
+    "Permissions": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
+          }
+        }
+      }
+    },
+    "Profile name": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "方案名称"
+          }
+        }
+      }
+    },
+    "Profiles": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "布局方案"
+          }
+        }
+      }
+    },
+    "Quit": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出"
+          }
+        }
+      }
+    },
+    "Record": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制"
+          }
+        }
+      }
+    },
+    "Record Hotkey": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "录制快捷键"
+          }
+        }
+      }
+    },
+    "Rehide": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新隐藏"
+          }
+        }
+      }
+    },
+    "Relaunch Ice 2": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新启动 Ice 2"
+          }
+        }
+      }
+    },
+    "Remove menu bar background": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除菜单栏背景"
+          }
+        }
+      }
+    },
+    "Reset": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
+        }
+      }
+    },
+    "Reset Menu Bar Appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置菜单栏外观"
+          }
+        }
+      }
+    },
+    "Reset to the default spacing": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置为默认间距"
+          }
+        }
+      }
+    },
+    "Restore": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复"
+          }
+        }
+      }
+    },
+    "Restore Ice 2 Icon": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复 Ice 2 图标"
+          }
+        }
+      }
+    },
+    "Restore and Relaunch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复并重新启动"
+          }
+        }
+      }
+    },
+    "Restore settings?": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复设置？"
+          }
+        }
+      }
+    },
+    "Reveal in Finder": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中显示"
+          }
+        }
+      }
+    },
+    "Round Cap": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圆形端帽"
+          }
+        }
+      }
+    },
+    "Round cap": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圆形端帽"
+          }
+        }
+      }
+    },
+    "Round screen corners": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将屏幕边角设为圆角"
+          }
+        }
+      }
+    },
+    "Save Current Layout": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "存储当前布局"
+          }
+        }
+      }
+    },
+    "Saved application state": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存的应用状态"
+          }
+        }
+      }
+    },
+    "Screen Recording": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏幕录制"
+          }
+        }
+      }
+    },
+    "Screen notch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刘海屏幕"
+          }
+        }
+      }
+    },
+    "Screen width": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "屏幕宽度"
+          }
+        }
+      }
+    },
+    "Scroll or swipe in the menu bar to show hidden menu bar items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏中滚动或滑动可显示隐藏的菜单栏项目。"
+          }
+        }
+      }
+    },
+    "Search Menu Bar Items": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索菜单栏项目"
+          }
+        }
+      }
+    },
+    "Search menu bar items": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索菜单栏项目"
+          }
+        }
+      }
+    },
+    "Search menu bar items…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索菜单栏项目…"
+          }
+        }
+      }
+    },
+    "Section divider style": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分区分隔符样式"
+          }
+        }
+      }
+    },
+    "Settings, layout profiles, and hotkeys": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置、布局方案和快捷键"
+          }
+        }
+      }
+    },
+    "Shadow": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阴影"
+          }
+        }
+      }
+    },
+    "Shape Kind": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "形状类型"
+          }
+        }
+      }
+    },
+    "Show Hidden Items": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示隐藏的项目"
+          }
+        }
+      }
+    },
+    "Show Ice 2 icon": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示 Ice 2 图标"
+          }
+        }
+      }
+    },
+    "Show Item": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示项目"
+          }
+        }
+      }
+    },
+    "Show all sections when ⌘ Command + dragging menu bar items": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按住 ⌘ 键拖移菜单栏项目时显示所有分区"
+          }
+        }
+      }
+    },
+    "Show hidden menu bar items in a separate bar below the menu bar.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在菜单栏下方的独立栏中显示隐藏的菜单栏项目。"
+          }
+        }
+      }
+    },
+    "Show items for focused app": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示当前应用的项目"
+          }
+        }
+      }
+    },
+    "Show on click": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击时显示"
+          }
+        }
+      }
+    },
+    "Show on hover": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "悬停时显示"
+          }
+        }
+      }
+    },
+    "Show on scroll": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滚动时显示"
+          }
+        }
+      }
+    },
+    "Smart": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能"
+          }
+        }
+      }
+    },
+    "Solid": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "纯色"
+          }
+        }
+      }
+    },
+    "Spacer": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "间隔"
+          }
+        }
+      }
+    },
+    "Spacer %lld": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "间隔 %lld"
+          }
+        }
+      }
+    },
+    "Spacers": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "间隔"
+          }
+        }
+      }
+    },
+    "Split": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拆分"
+          }
+        }
+      }
+    },
+    "Square Cap": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "方形端帽"
+          }
+        }
+      }
+    },
+    "Square cap": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "方形端帽"
+          }
+        }
+      }
+    },
+    "Strategy": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "策略"
+          }
+        }
+      }
+    },
+    "Temporarily show a menu bar item": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "临时显示菜单栏项目"
+          }
+        }
+      }
+    },
+    "Temporarily show menu bar item…": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "临时显示菜单栏项目…"
+          }
+        }
+      }
+    },
+    "Temporarily shown item delay": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "临时显示项目延迟"
+          }
+        }
+      }
+    },
+    "The Ice 2 Bar is centered below the Ice 2 icon.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 栏会居中显示在 Ice 2 图标下方。"
+          }
+        }
+      }
+    },
+    "The Ice 2 Bar is centered below the mouse pointer.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 栏会居中显示在鼠标指针下方。"
+          }
+        }
+      }
+    },
+    "The Ice 2 Bar requires screen recording permissions.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 栏需要屏幕录制权限。"
+          }
+        }
+      }
+    },
+    "The Ice 2 Bar's location changes based on context.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ice 2 栏会根据上下文改变位置。"
+          }
+        }
+      }
+    },
+    "The amount of time to wait before hiding temporarily shown menu bar items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏临时显示的菜单栏项目前等待的时间。"
+          }
+        }
+      }
+    },
+    "The amount of time to wait before showing hidden items.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示隐藏项目前等待的时间。"
+          }
+        }
+      }
+    },
+    "The app and its login item": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用及其登录项"
+          }
+        }
+      }
+    },
+    "The following applications failed to quit and were not restarted:": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "以下应用未能退出，因此未重新启动："
+          }
+        }
+      }
+    },
+    "The newest %lld backups are kept; older ones are removed automatically.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅保留最新的 %1$lld 份备份；更早的备份将自动移除。"
+          }
+        }
+      }
+    },
+    "The newest \\(SettingsBackup.defaultRetentionLimit) backups are kept; older ones are removed automatically.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅保留最新的 \\(SettingsBackup.defaultRetentionLimit) 份备份；更早的备份将自动移除。"
+          }
+        }
+      }
+    },
+    "This action cannot be undone.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此操作无法撤销。"
+          }
+        }
+      }
+    },
+    "This replaces all current Ice 2 settings with the backup from %@, then relaunches Ice 2.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这会用 %1$@ 的备份替换当前所有 Ice 2 设置，然后重新启动 Ice 2。"
+          }
+        }
+      }
+    },
+    "This replaces all current Ice 2 settings with the backup from \\(Self.dateFormatter.string(from: item.date)), then relaunches Ice 2.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这会用 \\(Self.dateFormatter.string(from: item.date)) 的备份替换当前所有 Ice 2 设置，然后重新启动 Ice 2。"
+          }
+        }
+      }
+    },
+    "Timed": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "定时"
+          }
+        }
+      }
+    },
+    "Tint": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色调"
+          }
+        }
+      }
+    },
+    "Tip: You can also edit these settings by right-clicking in an empty area of the menu bar.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提示：你也可以在菜单栏空白区域右键点击来编辑这些设置。"
+          }
+        }
+      }
+    },
+    "Toggle application menus": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换应用菜单"
+          }
+        }
+      }
+    },
+    "Toggle auto rehide": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换自动重新隐藏"
+          }
+        }
+      }
+    },
+    "Toggle section divider icons": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换分区分隔符图标"
+          }
+        }
+      }
+    },
+    "Toggle the always-hidden section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换始终隐藏分区"
+          }
+        }
+      }
+    },
+    "Toggle the hidden section": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换隐藏分区"
+          }
+        }
+      }
+    },
+    "Trailing End Cap": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "后缘端帽"
+          }
+        }
+      }
+    },
+    "Triggers": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "触发方式"
+          }
+        }
+      }
+    },
+    "Type Hotkey": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入快捷键"
+          }
+        }
+      }
+    },
+    "Uninstall": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "卸载"
+          }
+        }
+      }
+    },
+    "Update": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Update checks are quiet and considerate again.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新检查重新变得安静且贴心。"
+          }
+        }
+      }
+    },
+    "Updates": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
+    "Use Ice 2 Bar": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 Ice 2 栏"
+          }
+        }
+      }
+    },
+    "Use dynamic appearance": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用动态外观"
+          }
+        }
+      }
+    },
+    "Use inset shape on screens with notch": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在带刘海的屏幕上使用内嵌形状"
+          }
+        }
+      }
+    },
+    "Visible": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可见"
+          }
+        }
+      }
+    },
+    "What's New": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新功能"
+          }
+        }
+      }
+    },
+    "When the app becomes focused, Ice shows the hidden section.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当应用成为当前应用时，Ice 2 会显示隐藏分区。"
+          }
+        }
+      }
+    },
+    "Width": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宽度"
+          }
+        }
+      }
+    },
+    "Width threshold": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宽度阈值"
+          }
+        }
+      }
+    },
+    "You may need to log out for the changes to take effect.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改可能需要注销后才会生效。"
+          }
+        }
+      }
+    },
+    "default": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
+        }
+      }
+    },
+    "left click": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左键点击"
+          }
+        }
+      }
+    },
+    "macOS prohibits \"%@\" from being moved.": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 不允许移动“%1$@”。"
+          }
+        }
+      }
+    },
+    "max": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大"
+          }
+        }
+      }
+    },
+    "none": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无"
+          }
+        }
+      }
+    },
+    "right click": {
+      "localizations": {
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右键点击"
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/Ice/Settings/IceUninstallConfig.swift
+++ b/Ice/Settings/IceUninstallConfig.swift
@@ -60,10 +60,10 @@ enum IceUninstallConfig {
             appName: Constants.displayName,
             bundleID: bundleID,
             checklistItems: [
-                "The app and its login item",
-                "Settings, layout profiles, and hotkeys",
-                "Saved application state",
-                "Caches and support files",
+                String(localized: "The app and its login item"),
+                String(localized: "Settings, layout profiles, and hotkeys"),
+                String(localized: "Saved application state"),
+                String(localized: "Caches and support files"),
             ],
             extraCleanupPaths: [
                 library.appending(path: "Application Support/\(bundleID)"),

--- a/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -18,9 +18,9 @@ struct AdvancedSettingsPane: View {
     private func formattedToSeconds(_ interval: TimeInterval) -> LocalizedStringKey {
         let formatted = interval.formatted()
         return if interval == 1 {
-            LocalizedStringKey(formatted + " second")
+            LocalizedStringKey("\(formatted) second")
         } else {
-            LocalizedStringKey(formatted + " seconds")
+            LocalizedStringKey("\(formatted) seconds")
         }
     }
 

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -49,9 +49,9 @@ struct GeneralSettingsPane: View {
     private var rehideIntervalKey: LocalizedStringKey {
         let formatted = settings.rehideInterval.formatted()
         if settings.rehideInterval == 1 {
-            return LocalizedStringKey(formatted + " second")
+            return LocalizedStringKey("\(formatted) second")
         } else {
-            return LocalizedStringKey(formatted + " seconds")
+            return LocalizedStringKey("\(formatted) seconds")
         }
     }
 
@@ -92,6 +92,36 @@ struct GeneralSettingsPane: View {
             }
         ))
         .onAppear { launchesAtLogin = LoginItem.isEnabled }
+
+        languagePicker
+    }
+
+    // MARK: Language Options
+
+    /// Lets the user choose the interface language. "Automatic" follows the system language
+    /// (English unless the system is set to a language the app ships strings for). Changing the
+    /// selection persists it through DragonKit's ``LocalizationManager`` and restarts the app so
+    /// both the app's own SwiftUI strings and DragonKit's panes switch together.
+    @ViewBuilder
+    private var languagePicker: some View {
+        Picker("Language", selection: Binding(
+            get: { LocalizationManager.shared.language },
+            set: { newValue in
+                LocalizationManager.shared.setLanguage(newValue)
+                // The app's SwiftUI strings resolve through the bundle's preferred
+                // localizations, so mirror the choice into AppleLanguages and relaunch.
+                if let code = newValue.localeCode {
+                    UserDefaults.standard.set([code], forKey: "AppleLanguages")
+                } else {
+                    UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+                }
+                appState.relaunch()
+            }
+        )) {
+            Text("Automatic").tag(DragonLanguage.system)
+            Text("English").tag(DragonLanguage.en)
+            Text("简体中文").tag(DragonLanguage.zhHans)
+        }
     }
 
     // MARK: Ice Icon Options

--- a/Ice/Settings/SettingsPanes/IceBackupSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/IceBackupSettingsPane.swift
@@ -160,7 +160,7 @@ struct IceBackupSettingsPane: View {
     private func backUpNow() {
         do {
             _ = try SettingsBackup.performBackup(date: Date())
-            status = "Backed up just now."
+            status = LocalizedStringKey("Backed up just now.")
             refresh()
         } catch {
             errorMessage = error.localizedDescription
@@ -187,7 +187,7 @@ struct IceBackupSettingsPane: View {
         panel.canChooseFiles = false
         panel.canCreateDirectories = true
         panel.allowsMultipleSelection = false
-        panel.prompt = "Choose"
+        panel.prompt = String(localized: "Choose")
         panel.directoryURL = folderURL
         guard panel.runModal() == .OK, let url = panel.url else {
             return

--- a/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -166,7 +166,7 @@ struct MenuBarLayoutSettingsPane: View {
         let visibleCount = profile.itemCount(for: .visible)
         let hiddenCount = profile.itemCount(for: .hidden)
         let alwaysHiddenCount = profile.itemCount(for: .alwaysHidden)
-        return "\(visibleCount) visible, \(hiddenCount) hidden, \(alwaysHiddenCount) always-hidden"
+        return LocalizedStringKey("\(visibleCount) visible, \(hiddenCount) hidden, \(alwaysHiddenCount) always-hidden")
     }
 
     private func applyProfile(_ profile: MenuBarLayoutProfile) {
@@ -218,7 +218,7 @@ struct MenuBarLayoutSettingsPane: View {
                 step: 1
             )
 
-            Text("\(Int(spacer.width)) pt")
+            Text(verbatim: String(localized: "\(Int(spacer.width)) pt"))
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
                 .frame(width: 42, alignment: .trailing)

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -15,14 +15,14 @@ enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
             date: "2026-08-04",
-            summary: "Update checks are quiet and considerate again.",
+            summary: String(localized: "Update checks are quiet and considerate again."),
             sections: [
                 ChangeSection(kind: .fixed, entries: [
-                    "Scheduled update checks stop interrupting you. When Ice 2 checks for updates on its own schedule, it shows the update window quietly instead of pulling you out of what you were doing. Version 2.10.0 moved updates onto the shared Dragon app framework and lost that, so a background check could take over the screen unprompted.",
-                    "Ice 2 tells you when a background check finds an update. The notification titled \"A new update is available\" is back. Because the update window deliberately does not steal focus, it can sit behind whatever you are working in — the notification is how you know it is there. It applies only if you have Automatically check for updates turned on, which is where macOS asks permission to show notifications; declining changes nothing about how updates work.",
+                    String(localized: "Scheduled update checks stop interrupting you. When Ice 2 checks for updates on its own schedule, it shows the update window quietly instead of pulling you out of what you were doing. Version 2.10.0 moved updates onto the shared Dragon app framework and lost that, so a background check could take over the screen unprompted."),
+                    String(localized: "Ice 2 tells you when a background check finds an update. The notification titled \"A new update is available\" is back. Because the update window deliberately does not steal focus, it can sit behind whatever you are working in — the notification is how you know it is there. It applies only if you have Automatically check for updates turned on, which is where macOS asks permission to show notifications; declining changes nothing about how updates work."),
                 ]),
                 ChangeSection(kind: .changed, entries: [
-                    "If you are coming from 2.9.x: uninstalling Ice 2 has moved into Settings. It used to be an Uninstall item in the Ice 2 menu that opened a separate window; since 2.10.0 it is the last pane in the Settings sidebar, with the confirmation right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state. That flow was rewritten in 2.10.0 on top of the shared framework — the same steps, covered by automated tests, but it is a rewrite of a destructive, one-way path, so please report anything that misbehaves.",
+                    String(localized: "If you are coming from 2.9.x: uninstalling Ice 2 has moved into Settings. It used to be an Uninstall item in the Ice 2 menu that opened a separate window; since 2.10.0 it is the last pane in the Settings sidebar, with the confirmation right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state. That flow was rewritten in 2.10.0 on top of the shared framework — the same steps, covered by automated tests, but it is a rewrite of a destructive, one-way path, so please report anything that misbehaves."),
                 ]),
             ]
         )

--- a/Ice/UI/IceUI/IceWindow.swift
+++ b/Ice/UI/IceUI/IceWindow.swift
@@ -134,7 +134,7 @@ enum IceWindowIdentifier: String, Sendable, CustomStringConvertible {
     var titleString: String {
         switch self {
         case .settings: Constants.displayName
-        case .permissions: "Permissions"
+        case .permissions: String(localized: "Permissions")
         }
     }
 

--- a/Ice/UI/Views/HotkeyRecorder.swift
+++ b/Ice/UI/Views/HotkeyRecorder.swift
@@ -102,11 +102,11 @@ struct HotkeyRecorder<Label: View>: View {
     @ViewBuilder
     private var trailingSegmentLabel: some View {
         let (name, label, padding) = if model.isRecording {
-            ("escape", "Cancel", 6.0)
+            ("escape", String(localized: "Cancel"), 6.0)
         } else if model.hotkey.isEnabled {
-            ("xmark", "Clear", 7.5)
+            ("xmark", String(localized: "Clear"), 7.5)
         } else {
-            ("record.circle", "Record", 5.5)
+            ("record.circle", String(localized: "Record"), 5.5)
         }
         Image(systemName: name)
             .resizable()


### PR DESCRIPTION
## Summary

Add Simplified Chinese (简体中文) localization for Ice 2, plus a language picker in Settings so users can choose between Automatic (follow the system), English, and 简体中文. English remains the source language, so the default experience is unchanged.

## What's included

- **`Ice/Resources/Localizable.xcstrings`** — a string catalog with 234 zh-Hans entries covering every user-facing string: settings panes, context menus, search, permissions, hotkey recorder, backup & restore, layout, appearance, About/What's New/Updates/Uninstall copy, alerts, and notifications.
- **`String(localized:)` conversions** — runtime-built strings (menu item titles, alerts, notifications, section/spacer names, error descriptions, update copy) now resolve through the catalog instead of being hardcoded English, so they translate without changing the English UI.
- **Language picker** in General settings (`Automatic` / `English` / `简体中文`). `Automatic` follows the system language. Explicit choices persist through DragonKit's `LocalizationManager`, are mirrored into `AppleLanguages`, and the app relaunches so both the app's SwiftUI strings and DragonKit-provided panes (About, What's New, Updates, Uninstall) switch together — DragonKit already ships zh-Hans strings.
- `knownRegions` updated to include `zh-Hans`; the catalog is picked up automatically by the synchronized `Ice` folder group.

## Testing

- Built with Xcode 26 (Release, arm64) — `BUILD SUCCEEDED`.
- Launched with `-AppleLanguages (zh-Hans)` to confirm the translated strings load without issues.
- The compiled `zh-Hans.lproj/Localizable.strings` contains all 234 translations, including the format-specifier keys (`%@`, `%lld`).

This is localization only — no functional behavior changes.

---

## 摘要

为 Ice 2 增加简体中文界面，并在设置中加入语言选项（跟随系统 / English / 简体中文）。英文仍为源语言，默认体验不变。

- 新增 `Localizable.xcstrings` 字符串目录（234 条简体中文翻译），覆盖设置、菜单、搜索、权限、快捷键、备份、布局、外观及各提示框/通知文案。
- 运行期拼接的字符串改为通过 `String(localized:)` 解析，避免破坏英文界面。
- 设置 → 通用 新增语言选择器；选择结果通过 DragonKit `LocalizationManager` 持久化并重启应用生效。
- 已用 Xcode 26 编译通过，并以中文语言参数启动验证。
