### PR TITLE
feat(about): point the licenses row at dragonapp.com/ice-2/licenses

### DIFF
--- a/Ice/Settings/AboutConfig.swift
+++ b/Ice/Settings/AboutConfig.swift
@@ -38,9 +38,13 @@ enum AboutConfig {
             websiteURL: websiteURL,
             supportURL: issuesURL,
             license: "GPL-3.0",
-            // `licensesURL` is omitted: dragonapp.com/ice-2/licenses does not exist yet. Until it
-            // does, `Resources/Acknowledgements.pdf` stays in the bundle carrying the verbatim
-            // notices, and the libraries are named below.
+            // Third-party notices: the verbatim MIT text for the five packages below, plus
+            // DragonKit. Trailing slash: it is the path Pages serves, so the row does not point
+            // at a redirect. This replaces the row that opened `Resources/Acknowledgements.pdf`
+            // before DragonKit 3.0.0 removed `acknowledgementsURL` — the slot stayed empty rather
+            // than take a `file://` URL, because the kit derives a row's link text from its URL
+            // and would have rendered the PDF's absolute filesystem path.
+            licensesURL: URL(string: "https://www.dragonapp.com/ice-2/licenses/")!,
             originalWork: OriginalWork(name: "Ice", author: "Jordan Baird"),
             attributions: [
                 // Every third-party package Ice 2 links, as `name → licence`. Verified against


### PR DESCRIPTION
`https://www.dragonapp.com/ice-2/licenses/` is live (HTTP **200**), so the About pane's `licensesURL` slot can finally be filled. Until now it was omitted deliberately — the page 404'd — which meant **Ice 2 shipped with no licenses row at all**.

## The change

One line in `Ice/Settings/AboutConfig.swift`, plus the comment explaining why the slot was empty before.

```swift
licensesURL: URL(string: "https://www.dragonapp.com/ice-2/licenses/")!,
```

The row renders as **Open-source licenses · dragonapp.com/ice-2/licenses** with the `doc.text` symbol. That detail string is *derived* by the kit's own `AboutLinkDetail.detail(for:)` — it strips the scheme, `www.`, and the trailing slash — so it is never typed beside the URL, which is the canon `AboutCanonTests` pins.

**Trailing slash is deliberate:** that is the path GitHub Pages serves, so the row does not send anyone through a redirect.

`Resources/Acknowledgements.pdf` and `.rtf` stay in the bundle — nothing is deleted here. Worth knowing that document is *not* the source for the new page: it still names LaunchAtLogin, which was dropped as a dependency, and omits DragonKit. The page was generated from `Package.resolved` + the pbxproj instead.

## What the linked page contains

Six third-party notices plus Ice 2's own licence, each quoted verbatim from its source: AXSwift, CompactSlider, Ifrit, Semaphore (MIT, from each project's `LICENSE`), Sparkle (MIT, transitive via `DragonKitUpdates` rather than a direct dependency), DragonKit (MIT), and Ice 2 itself (GPL-3.0, linked rather than duplicated).

## Verification

Rebased onto the current `main` (`01c5133`, the DragonKit 3.2.0 cask commit) — it was one behind.

| Check | Result |
|---|---|
| `xcodebuild test -scheme Ice -destination 'platform=macOS,arch=arm64'` | **289 tests in 35 suites passed — TEST SUCCEEDED** |
| `dragon-conformance.py --app . --kit ~/git/dragon-kit` | **PASS — no violations** |
| `curl` the linked URL | **200** |

No release is needed; the link ships with Ice 2's next normal release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)