### PR TITLE
feat(menu bar): place newly created items in the visible section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.14.0 - 2026-08-10
+
+### Added
+
+- **A newly installed app's menu bar icon now appears where you can see it.** macOS hands every brand-new menu bar item the leftmost slot, which in Ice 2's layout sits inside the always-hidden section. So the first time you installed an app with a menu bar icon, that icon was invisible from the moment it was created, and the app looked like it had never added one at all. Ice 2 now recognises an item it has never seen before and moves it into the visible section.
+
+  Items you have already arranged are left alone. Updating to this version does not move anything: Ice 2 takes a note of everything currently in your menu bar first, so only icons that turn up afterwards count as new. If you then drag one of those into Hidden or Always-Hidden, it stays where you put it.
+
+  This needs screen recording permission, which is what lets Ice 2 tell one menu bar item from another. Without it, nothing is moved.
+
 ## 2.13.0 - 2026-08-07
 
 ### Internal

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		50F5DAA3F785CC10CAC28750 /* AppearanceConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD2B847F99761CDED955A3A /* AppearanceConfigTests.swift */; };
 		532D0E5212D395B68CA7F31E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC782BAB2CBAE725214BC3D2 /* Cocoa.framework */; };
 		58AB34D95A7DF7474565BA28 /* AcknowledgementsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C0D62701AD4D98A47CC601 /* AcknowledgementsTests.swift */; };
+		2F7C41A80B9E4D3286C15DA9 /* NewMenuBarItemPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D93B2E5C08A47F19E2340BC /* NewMenuBarItemPlacementTests.swift */; };
 		5EE79BA2367FDAA95AF9CF2C /* IceGradientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C73F7445CA6F2C87AB22FC /* IceGradientTests.swift */; };
 		6AA9FF5BA60A12C390EECE31 /* WindowInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF413CD9CC7D016105A22EF0 /* WindowInfoTests.swift */; };
 		6BA9AD8CA208DCE48761A132 /* ConcurrencyHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99044B6F44B0A594C1C1812A /* ConcurrencyHelpersTests.swift */; };
@@ -84,6 +85,7 @@
 /* Begin PBXFileReference section */
 		12990E4E70C4107E87D970D7 /* SettingsBackupTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsBackupTests.swift; sourceTree = "<group>"; };
 		19C0D62701AD4D98A47CC601 /* AcknowledgementsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AcknowledgementsTests.swift; sourceTree = "<group>"; };
+		6D93B2E5C08A47F19E2340BC /* NewMenuBarItemPlacementTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewMenuBarItemPlacementTests.swift; sourceTree = "<group>"; };
 		2D3EE3A5FEDD60DB5B5DF93F /* UtilityHelpersTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UtilityHelpersTests.swift; sourceTree = "<group>"; };
 		371FFD52849B676061381844 /* CGImageProcessingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGImageProcessingTests.swift; sourceTree = "<group>"; };
 		3DD2B847F99761CDED955A3A /* AppearanceConfigTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppearanceConfigTests.swift; sourceTree = "<group>"; };
@@ -282,6 +284,7 @@
 				C4E01B7739AD62F08C15D4B3 /* UninstallConfigTests.swift */,
 				A70E2C41B96D5387F04A1DE3 /* ScratchDefaults.swift */,
 				19C0D62701AD4D98A47CC601 /* AcknowledgementsTests.swift */,
+				6D93B2E5C08A47F19E2340BC /* NewMenuBarItemPlacementTests.swift */,
 			);
 			name = IceTests;
 			path = IceTests;
@@ -492,6 +495,7 @@
 				ED2C71A45B90F3186AC4D027 /* UninstallConfigTests.swift in Sources */,
 				B1C4E7A20D53F8916AE2C094 /* ScratchDefaults.swift in Sources */,
 				58AB34D95A7DF7474565BA28 /* AcknowledgementsTests.swift in Sources */,
+				2F7C41A80B9E4D3286C15DA9 /* NewMenuBarItemPlacementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1862,8 +1862,19 @@ extension MenuBarItemManager {
         // list that is never positionally sorted, so left-to-right order is an
         // assumption. Every other positional decision in this file is made from
         // bounds, and this follows suit.
+        //
+        // Live bounds, not `MenuBarItem.bounds`, which is a snapshot taken when
+        // the window list was read and can be stale for off-screen windows —
+        // which is every item in the landing zone. `CacheContext.bestBounds(for:)`
+        // makes the same correction for the same reason. Resolved once per item
+        // rather than inside the comparator, which would re-read on every
+        // comparison.
         let items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
-            .sorted { $0.bounds.minX < $1.bounds.minX }
+            .map { item in
+                (item: item, minX: (Bridging.getWindowBounds(for: item.windowID) ?? item.bounds).minX)
+            }
+            .sorted { $0.minX < $1.minX }
+            .map(\.item)
 
         guard let hiddenControlItem = items.first(matching: .hiddenControlItem) else {
             // The same signal `applyLayoutProfile` treats as fatal. Acting on a

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -38,6 +38,13 @@ final class MenuBarItemManager: ObservableObject {
     /// Cached timeouts for move operations.
     private var moveOperationTimeouts = [MenuBarItemTag: Duration]()
 
+    /// A Boolean value that indicates whether a new item placement pass is
+    /// currently running.
+    ///
+    /// The pass re-caches when it finishes, and caching runs the pass, so this
+    /// is what stops the two from recurring into each other.
+    private var isPlacingNewItems = false
+
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
@@ -100,6 +107,26 @@ final class MenuBarItemManager: ObservableObject {
         appState.navigationState.$settingsNavigationIdentifier
             .sink { [weak self] identifier in
                 guard let self, identifier == .rendersMenuBarItemImages else {
+                    return
+                }
+                Task {
+                    await self.cacheItemsRegardless()
+                }
+            }
+            .store(in: &c)
+
+        // New item placement is inert without screen recording permission, and
+        // being granted it changes nothing the cache watches. Without this, a
+        // user who grants the permission without relaunching gets no placement
+        // until something else happens to change the menu bar item set — and if
+        // the known-items registry is still absent, the next app to launch would
+        // become the seed, recording that genuinely new icon as pre-existing.
+        appState.permissions.screenRecording.$hasPermission
+            .removeDuplicates()
+            .dropFirst() // Only transitions; the initial value is handled by setup.
+            .filter { $0 }
+            .sink { [weak self] _ in
+                guard let self else {
                     return
                 }
                 Task {
@@ -392,6 +419,11 @@ extension MenuBarItemManager {
             await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
             hasCompletedInitialCache = true
         }
+
+        // Outside the cache task on purpose: the pass re-caches when it has moved
+        // something, and `runCacheTask` cancels the previous task before starting
+        // a new one, so a nested call would cancel the task it was called from.
+        await placeNewItemsIfNeeded()
     }
 
     /// Caches the current menu bar items, if the items have changed
@@ -1755,6 +1787,211 @@ extension MenuBarItemManager {
         } catch {
             logger.error("Error enforcing control item order: \(error, privacy: .public)")
         }
+    }
+}
+
+// MARK: - New Item Placement
+
+extension MenuBarItemManager {
+    /// The result of a single placement pass.
+    private struct PlacementOutcome {
+        /// Whether at least one item was moved and verified in its destination.
+        var placedAny = false
+
+        /// Whether the pass left work undone, and so needs another pass.
+        var needsRetry = false
+    }
+
+    /// Moves menu bar items that Ice has never seen before into the visible
+    /// section.
+    ///
+    /// macOS puts every new status item in the leftmost slot, which lands in the
+    /// always-hidden section, so without this a newly installed app's icon is
+    /// invisible and looks like it was never installed.
+    func placeNewItemsIfNeeded() async {
+        guard !isPlacingNewItems else {
+            return // The outer pass is running; it will handle the retry.
+        }
+
+        // Tags are a namespace plus a window title, and titles read as empty
+        // without this permission. Seeding from that state would record
+        // identities that change the moment it is granted, and the user's
+        // existing items would then look new and be moved. Deliberately does not
+        // request a retry: nothing will change until the permission is granted,
+        // and the sink in `configureCancellables` covers that.
+        guard ScreenCapture.cachedCheckPermissions() else {
+            return
+        }
+
+        // A menu bar that was being rearranged a moment ago, or that has items
+        // parked in their temporarily shown positions, is not one to read item
+        // positions from. Every workflow that moves items stamps the move
+        // timestamp, so this one check covers all of them without any of them
+        // needing to know placement exists.
+        guard
+            !lastMoveOperationOccurred(within: .seconds(1)),
+            temporarilyShownItemContexts.isEmpty
+        else {
+            logger.debug("Deferring new item placement")
+            await cacheActor.clearCachedItemWindowIDs()
+            return
+        }
+
+        isPlacingNewItems = true
+        let outcome = await runPlacementPass()
+        if outcome.placedAny {
+            // The flag is still set, so the pass this triggers returns immediately.
+            await refreshCacheAfterItemMoves()
+        }
+        isPlacingNewItems = false
+
+        // Must be the last awaited operation. The refresh above re-caches, which
+        // rewrites the cached window IDs, so clearing any earlier would be undone
+        // and the unplaced items would be stranded by the very mechanism meant to
+        // rescue them.
+        if outcome.needsRetry {
+            await cacheActor.clearCachedItemWindowIDs()
+        }
+    }
+
+    /// Runs a single placement pass and reports what it managed to do.
+    private func runPlacementPass() async -> PlacementOutcome {
+        var outcome = PlacementOutcome()
+
+        // Sorted rather than taken as-is: `getMenuBarItems` reverses a window
+        // list that is never positionally sorted, so left-to-right order is an
+        // assumption. Every other positional decision in this file is made from
+        // bounds, and this follows suit.
+        let items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            .sorted { $0.bounds.minX < $1.bounds.minX }
+
+        guard let hiddenControlItem = items.first(matching: .hiddenControlItem) else {
+            // The same signal `applyLayoutProfile` treats as fatal. Acting on a
+            // read this degraded is how a working menu bar gets damaged.
+            logger.warning("Skipping new item placement, as the read found no hidden control item")
+            outcome.needsRetry = true
+            return outcome
+        }
+
+        let orderedTags = items.map(\.tag)
+
+        guard let knownTags = loadKnownItemTags() else {
+            outcome.needsRetry = !(await seedKnownItemTags())
+            return outcome
+        }
+
+        let candidateTags = NewMenuBarItemPlacement.candidateTags(in: orderedTags, known: knownTags)
+
+        var placedTags = Set<MenuBarItemTag>()
+        if !candidateTags.isEmpty {
+            var itemsByTag = [MenuBarItemTag: MenuBarItem]()
+            for item in items where itemsByTag[item.tag] == nil {
+                itemsByTag[item.tag] = item
+            }
+
+            // Chained off the divider, in order, so the first candidate ends up
+            // immediately right of it and they keep their relative order.
+            var previousItem = hiddenControlItem
+            for tag in candidateTags {
+                guard let item = itemsByTag[tag] else {
+                    continue
+                }
+                let destination = MoveDestination.rightOfItem(previousItem)
+                do {
+                    try await move(item: item, to: destination)
+                    // `move` returns as soon as the item's origin changes; it
+                    // never re-checks the destination. A drag beginning after
+                    // its input-pause wait can satisfy that while leaving the
+                    // item somewhere else entirely.
+                    guard try await itemHasCorrectPosition(item: item, for: destination) else {
+                        logger.warning("Placed \(item.logString, privacy: .public) did not land at its destination")
+                        outcome.needsRetry = true
+                        continue
+                    }
+                    placedTags.insert(tag)
+                    previousItem = item
+                } catch {
+                    logger.error(
+                        """
+                        Error placing new menu bar item \(item.logString, privacy: .public): \
+                        \(error, privacy: .public)
+                        """
+                    )
+                    outcome.needsRetry = true
+                }
+            }
+        }
+
+        let tagsToRecord = NewMenuBarItemPlacement.tagsToRecord(
+            seen: orderedTags,
+            candidates: candidateTags,
+            placed: placedTags
+        )
+        // Only grows, never replaces: one pass sees a single Space, so dropping
+        // the tags it didn't see would re-classify items parked elsewhere as new
+        // the next time they come back. Written only when it actually changed —
+        // the steady state is a pass that learns nothing, and this runs on every
+        // cache.
+        let updatedTags = knownTags.union(tagsToRecord)
+        if updatedTags != knownTags {
+            storeKnownItemTags(updatedTags)
+        }
+
+        outcome.placedAny = !placedTags.isEmpty
+        return outcome
+    }
+
+    /// Records every placeable item currently in the menu bar, without moving
+    /// anything, so that only items appearing afterwards count as new.
+    ///
+    /// - Returns: Whether the seed was written.
+    private func seedKnownItemTags() async -> Bool {
+        // No `.activeSpace`: unlike a normal pass, this one read decides forever
+        // which items count as pre-existing, so it must also see items parked on
+        // other Spaces.
+        let items = await MenuBarItem.getMenuBarItems(option: [])
+
+        guard items.contains(where: { $0.tag == .hiddenControlItem }) else {
+            // Storing an unvalidated seed is the one way this can damage a
+            // working menu bar: a partial set makes the next pass, no longer a
+            // first run, treat the user's own always-hidden items as new.
+            logger.warning("Skipping known menu bar item seed, as the read found no hidden control item")
+            return false
+        }
+
+        let tags = Set(items.map(\.tag).filter(NewMenuBarItemPlacement.isPlaceable))
+        storeKnownItemTags(tags)
+        logger.info("Seeded \(tags.count, privacy: .public) known menu bar items")
+        return true
+    }
+
+    /// Loads the tags of the menu bar items Ice has already seen, or `nil` if
+    /// this is a first run.
+    private func loadKnownItemTags() -> Set<MenuBarItemTag>? {
+        // Not `Defaults.data(forKey:)`, which returns nil for an absent key and
+        // for a present value of the wrong type alike. A corrupted registry is
+        // worth logging; a fresh install is not.
+        guard let object = Defaults.object(forKey: .knownMenuBarItems) else {
+            return nil
+        }
+        guard let data = object as? Data else {
+            logger.error("Known menu bar items are not data; treating as a first run")
+            return nil
+        }
+        guard let tags = NewMenuBarItemPlacement.decodeKnownTags(from: data) else {
+            logger.error("Couldn't decode known menu bar items; treating as a first run")
+            return nil
+        }
+        return tags
+    }
+
+    /// Stores the tags of the menu bar items Ice has seen.
+    private func storeKnownItemTags(_ tags: Set<MenuBarItemTag>) {
+        guard let data = NewMenuBarItemPlacement.encode(tags) else {
+            logger.error("Couldn't encode known menu bar items")
+            return
+        }
+        Defaults.set(data, forKey: .knownMenuBarItems)
     }
 }
 

--- a/Ice/MenuBar/MenuBarItems/NewMenuBarItemPlacement.swift
+++ b/Ice/MenuBar/MenuBarItems/NewMenuBarItemPlacement.swift
@@ -1,0 +1,111 @@
+//
+//  NewMenuBarItemPlacement.swift
+//  Ice
+//
+
+import Foundation
+
+/// The rules that decide which menu bar items were newly created, and which
+/// items Ice should remember having seen.
+///
+/// macOS gives every new status item the leftmost slot in the menu bar, which
+/// falls past Ice's always-hidden divider, so a newly installed app's icon is
+/// invisible until the user goes looking for it. Ice remembers the items it has
+/// already seen so it can move only the genuinely new ones.
+///
+/// These rules work on tags rather than items because ``MenuBarItem``'s
+/// initializers are private: a tag is directly constructible, so the decisions
+/// that drive placement can be tested without a live menu bar.
+enum NewMenuBarItemPlacement {
+    /// Returns a Boolean value that indicates whether the item identified by
+    /// `tag` may be placed automatically.
+    ///
+    /// Items macOS pins in place, items that cannot be hidden, Ice's own control
+    /// items and spacers are all excluded, as is anything whose identity is not
+    /// durable. A UUID namespace is minted per process launch and cached by
+    /// window ID, so the same item can be tagged differently after a relaunch;
+    /// moving such an item on every launch is worse than leaving it alone. That
+    /// test also covers system clones, which are the UUID namespace with a known
+    /// title. An empty title is the same problem for titles: an untitled item
+    /// cannot be told apart from its siblings in the same namespace.
+    static func isPlaceable(_ tag: MenuBarItemTag) -> Bool {
+        tag.isMovable &&
+        tag.canBeHidden &&
+        !tag.isControlItem &&
+        !tag.isSpacerItem &&
+        !tag.namespace.isUUID &&
+        !tag.title.isEmpty
+    }
+
+    /// Returns the tags of the items that appear to have been newly created.
+    ///
+    /// `orderedTags` must run left to right across the menu bar. The landing
+    /// zone is the prefix before the leftmost control item — the always-hidden
+    /// divider when that section is enabled, the hidden divider when it is not —
+    /// because that is where macOS puts a brand-new item. The walk stops at the
+    /// first placeable tag it already knows: everything beyond that point is
+    /// sitting where the user left it, not in the slot handed to new items.
+    ///
+    /// That positional test is what makes "new" mean *newly created* rather than
+    /// merely *unrecorded*. An item that Ice has never recorded because it lives
+    /// on another Space is unrecorded too, but it is not in the landing zone.
+    ///
+    /// - Returns: The candidate tags, in left-to-right order, de-duplicated.
+    ///   Empty if there is no control item, which means the read failed.
+    static func candidateTags(
+        in orderedTags: [MenuBarItemTag],
+        known: Set<MenuBarItemTag>
+    ) -> [MenuBarItemTag] {
+        guard let boundary = orderedTags.firstIndex(where: { $0.isControlItem }) else {
+            return []
+        }
+        var candidates = [MenuBarItemTag]()
+        var alreadyCollected = Set<MenuBarItemTag>()
+        for tag in orderedTags[..<boundary] {
+            guard isPlaceable(tag) else {
+                continue // Not our business; doesn't end the walk.
+            }
+            guard !known.contains(tag) else {
+                break
+            }
+            if alreadyCollected.insert(tag).inserted {
+                candidates.append(tag)
+            }
+        }
+        return candidates
+    }
+
+    /// Returns the tags to add to the known set after a placement pass.
+    ///
+    /// Every placeable tag the pass saw is recorded, minus the candidates it
+    /// identified, plus the candidates it verified as placed. A candidate whose
+    /// move failed stays unknown so the next pass retries it; recording it would
+    /// let one transient event failure permanently defeat placement for that
+    /// icon.
+    ///
+    /// Subtracting only the candidates — rather than recording only what lies
+    /// outside the landing zone — is what stops a delayed false positive. An
+    /// unknown item sitting behind the item that stopped the walk is neither
+    /// placed nor a candidate. Left unrecorded, it would become a candidate the
+    /// day the blocking item's app quit and the walk ran further, dragging an
+    /// item the user had deliberately parked out of the always-hidden section.
+    static func tagsToRecord(
+        seen orderedTags: [MenuBarItemTag],
+        candidates: [MenuBarItemTag],
+        placed: Set<MenuBarItemTag>
+    ) -> Set<MenuBarItemTag> {
+        Set(orderedTags.filter(isPlaceable))
+            .subtracting(candidates)
+            .union(placed)
+    }
+
+    /// Decodes a known-items set, or returns `nil` if the payload is unreadable.
+    static func decodeKnownTags(from data: Data) -> Set<MenuBarItemTag>? {
+        try? JSONDecoder().decode(Set<MenuBarItemTag>.self, from: data)
+    }
+
+    /// Encodes a known-items set for storage.
+    static func encode(_ tags: Set<MenuBarItemTag>) -> Data? {
+        try? JSONEncoder().encode(tags)
+    }
+}

--- a/Ice/Settings/Backup/SettingsBackup.swift
+++ b/Ice/Settings/Backup/SettingsBackup.swift
@@ -37,12 +37,17 @@ enum SettingsBackup {
     static let fileExtension = "icebackup"
 
     /// Keys NOT included in a backup: deprecated keys (so a restore can't
-    /// resurrect state the app has migrated away from) and the backup feature's
-    /// own meta-settings (which are machine-specific and shouldn't travel).
+    /// resurrect state the app has migrated away from), the backup feature's
+    /// own meta-settings (which are machine-specific and shouldn't travel), and
+    /// local state that records what has happened on this Mac rather than what
+    /// the user has chosen.
     static let excludedKeys: Set<Defaults.Key> = [
         .showSectionDividers, .canToggleAlwaysHiddenSection, .sections,
         .menuBarItemGroups,
         .backupFolderPath, .automaticBackupEnabled,
+        // Carrying this to another Mac would mark that Mac's items as already
+        // seen, suppressing placement there.
+        .knownMenuBarItems,
     ]
 
     /// The settings keys carried in a backup.

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -182,6 +182,11 @@ extension Defaults {
         case backupFolderPath = "BackupFolderPath"
         case automaticBackupEnabled = "AutomaticBackupEnabled"
 
+        // MARK: Local State (not settings; excluded from the backup payload)
+        // A record of which menu bar items have appeared on this Mac, used to
+        // tell a newly created item from one the user has already arranged.
+        case knownMenuBarItems = "KnownMenuBarItems"
+
         // MARK: Deprecated (Advanced Settings)
         case showSectionDividers = "ShowSectionDividers"
         case canToggleAlwaysHiddenSection = "CanToggleAlwaysHiddenSection"

--- a/IceTests/NewMenuBarItemPlacementTests.swift
+++ b/IceTests/NewMenuBarItemPlacementTests.swift
@@ -1,0 +1,209 @@
+//
+//  NewMenuBarItemPlacementTests.swift
+//  IceTests
+//
+
+import Foundation
+import Testing
+@testable import Ice_2
+
+struct NewMenuBarItemPlacementTests {
+    // MARK: Helpers
+
+    private func tag(_ title: String, namespace: String = "com.example.app") -> MenuBarItemTag {
+        MenuBarItemTag(namespace: .string(namespace), title: title)
+    }
+
+    // MARK: isPlaceable
+
+    @Test func placeableAcceptsOrdinaryItem() {
+        #expect(NewMenuBarItemPlacement.isPlaceable(tag("Widget")))
+    }
+
+    @Test func placeableRejectsControlItems() {
+        for controlItem in MenuBarItemTag.controlItems {
+            #expect(!NewMenuBarItemPlacement.isPlaceable(controlItem))
+        }
+    }
+
+    @Test func placeableRejectsImmovableItems() {
+        // Pinned to the trailing end of the menu bar by macOS.
+        #expect(!NewMenuBarItemPlacement.isPlaceable(.clock))
+        #expect(!NewMenuBarItemPlacement.isPlaceable(.controlCenter))
+    }
+
+    @Test func placeableRejectsNonHideableItems() {
+        #expect(!NewMenuBarItemPlacement.isPlaceable(.audioVideoModule))
+        #expect(!NewMenuBarItemPlacement.isPlaceable(.faceTime))
+    }
+
+    @Test func placeableRejectsSpacers() {
+        let spacer = MenuBarItemTag(
+            namespace: .ice,
+            title: MenuBarSpacer.autosaveNamePrefix + "1"
+        )
+        #expect(!NewMenuBarItemPlacement.isPlaceable(spacer))
+    }
+
+    // A UUID namespace is minted per process launch, so the same item can carry
+    // a different tag after a relaunch. Placing on that identity would move the
+    // item every single launch.
+    @Test func placeableRejectsUnstableUUIDNamespace() {
+        let unstable = MenuBarItemTag(namespace: .uuid(UUID()), title: "Widget")
+        #expect(!NewMenuBarItemPlacement.isPlaceable(unstable))
+    }
+
+    @Test func placeableRejectsSystemClone() {
+        let clone = MenuBarItemTag(
+            namespace: .uuid(UUID()),
+            title: "System Status Item Clone"
+        )
+        #expect(clone.isSystemClone)
+        #expect(!NewMenuBarItemPlacement.isPlaceable(clone))
+    }
+
+    // An untitled item can't be told apart from its siblings in the same namespace.
+    @Test func placeableRejectsEmptyTitle() {
+        #expect(!NewMenuBarItemPlacement.isPlaceable(tag("")))
+    }
+
+    // MARK: candidateTags
+
+    @Test func candidatesAreTheUnknownLeadingRun() {
+        let ordered = [
+            tag("New A"),
+            tag("New B"),
+            MenuBarItemTag.alwaysHiddenControlItem,
+            tag("Parked"),
+            MenuBarItemTag.hiddenControlItem,
+            tag("Visible"),
+        ]
+        let candidates = NewMenuBarItemPlacement.candidateTags(in: ordered, known: [])
+        #expect(candidates == [tag("New A"), tag("New B")])
+    }
+
+    // Everything beyond a known item is sitting where the user left it, not in
+    // the slot macOS hands to brand-new items.
+    @Test func walkStopsAtFirstKnownTag() {
+        let ordered = [
+            tag("New"),
+            tag("Known"),
+            tag("Behind The Known One"),
+            MenuBarItemTag.alwaysHiddenControlItem,
+        ]
+        let candidates = NewMenuBarItemPlacement.candidateTags(
+            in: ordered,
+            known: [tag("Known")]
+        )
+        #expect(candidates == [tag("New")])
+    }
+
+    @Test func nonPlaceableTagsDoNotEndTheWalk() {
+        let ordered = [
+            tag("New A"),
+            MenuBarItemTag.clock, // Not placeable; must be skipped, not stop the walk.
+            tag("New B"),
+            MenuBarItemTag.alwaysHiddenControlItem,
+        ]
+        let candidates = NewMenuBarItemPlacement.candidateTags(in: ordered, known: [])
+        #expect(candidates == [tag("New A"), tag("New B")])
+    }
+
+    @Test func candidatesAreDeduplicatedAndKeepOrder() {
+        let ordered = [
+            tag("B"),
+            tag("A"),
+            tag("B"),
+            MenuBarItemTag.hiddenControlItem,
+        ]
+        let candidates = NewMenuBarItemPlacement.candidateTags(in: ordered, known: [])
+        #expect(candidates == [tag("B"), tag("A")])
+    }
+
+    @Test func noCandidatesWhenEverythingIsKnown() {
+        let ordered = [tag("A"), tag("B"), MenuBarItemTag.hiddenControlItem]
+        let candidates = NewMenuBarItemPlacement.candidateTags(
+            in: ordered,
+            known: [tag("A"), tag("B")]
+        )
+        #expect(candidates.isEmpty)
+    }
+
+    // No control item means the read failed. Treating the whole menu bar as a
+    // landing zone would move everything into the visible section.
+    @Test func noCandidatesWithoutAControlItem() {
+        let ordered = [tag("A"), tag("B")]
+        #expect(NewMenuBarItemPlacement.candidateTags(in: ordered, known: []).isEmpty)
+    }
+
+    @Test func noCandidatesWhenControlItemIsLeftmost() {
+        let ordered = [MenuBarItemTag.hiddenControlItem, tag("Visible")]
+        #expect(NewMenuBarItemPlacement.candidateTags(in: ordered, known: []).isEmpty)
+    }
+
+    // MARK: tagsToRecord
+
+    @Test func recordsPlacedCandidatesButNotFailedOnes() {
+        let ordered = [tag("Placed"), tag("Failed"), MenuBarItemTag.hiddenControlItem]
+        let recorded = NewMenuBarItemPlacement.tagsToRecord(
+            seen: ordered,
+            candidates: [tag("Placed"), tag("Failed")],
+            placed: [tag("Placed")]
+        )
+        #expect(recorded.contains(tag("Placed")))
+        // Still in the landing zone, so the next pass finds and retries it.
+        #expect(!recorded.contains(tag("Failed")))
+    }
+
+    // The case that matters: an unknown item behind the tag that stopped the
+    // walk is neither placed nor a candidate. If it were left unrecorded, the
+    // day the blocking item's app quit the walk would run further and drag it
+    // out of the always-hidden section.
+    @Test func recordsUnknownTagsBehindTheStoppingPoint() {
+        let ordered = [
+            tag("Known"),
+            tag("Parked But Unrecorded"),
+            MenuBarItemTag.alwaysHiddenControlItem,
+        ]
+        let recorded = NewMenuBarItemPlacement.tagsToRecord(
+            seen: ordered,
+            candidates: [],
+            placed: []
+        )
+        #expect(recorded.contains(tag("Parked But Unrecorded")))
+    }
+
+    @Test func recordsNeverIncludeNonPlaceableTags() {
+        let ordered = [
+            tag("Widget"),
+            MenuBarItemTag.clock,
+            MenuBarItemTag.hiddenControlItem,
+        ]
+        let recorded = NewMenuBarItemPlacement.tagsToRecord(
+            seen: ordered,
+            candidates: [],
+            placed: []
+        )
+        #expect(recorded == [tag("Widget")])
+    }
+
+    // MARK: Persistence
+
+    @Test func knownTagsRoundTrip() throws {
+        let tags: Set<MenuBarItemTag> = [tag("A"), tag("B"), .timeMachine]
+        let data = try #require(NewMenuBarItemPlacement.encode(tags))
+        #expect(NewMenuBarItemPlacement.decodeKnownTags(from: data) == tags)
+    }
+
+    @Test func emptySetRoundTripsAndIsNotNil() throws {
+        let data = try #require(NewMenuBarItemPlacement.encode([]))
+        // Distinguishable from an unreadable payload: an empty set is a real
+        // answer, whereas nil sends the manager down the first-run path.
+        #expect(NewMenuBarItemPlacement.decodeKnownTags(from: data) == [])
+    }
+
+    @Test func undecodablePayloadYieldsNil() {
+        let garbage = Data("not json".utf8)
+        #expect(NewMenuBarItemPlacement.decodeKnownTags(from: garbage) == nil)
+    }
+}

--- a/IceTests/SettingsBackupTests.swift
+++ b/IceTests/SettingsBackupTests.swift
@@ -57,6 +57,7 @@ struct SettingsBackupTests {
         defer { ScratchDefaults.destroy(sSuite) }
         source.set("/tmp/x", forKey: Defaults.Key.backupFolderPath.rawValue)
         source.set(true, forKey: Defaults.Key.automaticBackupEnabled.rawValue)
+        source.set(Data("known".utf8), forKey: Defaults.Key.knownMenuBarItems.rawValue)
 
         let payload = SettingsBackup.makePayload(
             from: source, appVersion: "1", createdDate: Date(timeIntervalSince1970: 0)
@@ -65,6 +66,27 @@ struct SettingsBackupTests {
         let stored = payload["defaults"] as? [String: Any] ?? [:]
         #expect(stored[Defaults.Key.backupFolderPath.rawValue] == nil)
         #expect(stored[Defaults.Key.automaticBackupEnabled.rawValue] == nil)
+        #expect(stored[Defaults.Key.knownMenuBarItems.rawValue] == nil)
+    }
+
+    // Restoring on another Mac must not mark that Mac's items as already seen,
+    // which would suppress new item placement there.
+    @Test func restoreLeavesKnownMenuBarItemsAlone() {
+        let (source, sSuite) = makeScratch()
+        defer { ScratchDefaults.destroy(sSuite) }
+        let (target, tSuite) = makeScratch()
+        defer { ScratchDefaults.destroy(tSuite) }
+
+        source.set(Data("from the other mac".utf8), forKey: Defaults.Key.knownMenuBarItems.rawValue)
+        let existing = Data("from this mac".utf8)
+        target.set(existing, forKey: Defaults.Key.knownMenuBarItems.rawValue)
+
+        let payload = SettingsBackup.makePayload(
+            from: source, appVersion: "1", createdDate: Date(timeIntervalSince1970: 0)
+        )
+        SettingsBackup.apply(payload, to: target)
+
+        #expect(target.data(forKey: Defaults.Key.knownMenuBarItems.rawValue) == existing)
     }
 
     @Test func serializeDeserializeRoundTrip() throws {

--- a/docs/superpowers/specs/2026-08-08-new-menu-bar-item-section-design.md
+++ b/docs/superpowers/specs/2026-08-08-new-menu-bar-item-section-design.md
@@ -1,0 +1,426 @@
+# New menu bar items go to the visible section
+
+**Date:** 2026-08-08
+**Status:** Design, pending implementation
+
+## Problem
+
+macOS assigns every newly created status item the leftmost slot in the menu
+bar. Ice's sections run left to right as:
+
+```
+[always-hidden items] ⟨AH control item⟩ [hidden items] ⟨H control item⟩ [visible items] … clock
+```
+
+so "leftmost" always falls past the always-hidden divider. Ice never
+repositions the item, so the first time a user installs an app with a menu bar
+extra, its icon is invisible and appears — to the user — not to have been
+installed at all.
+
+Ice should move a genuinely new item into the visible section instead.
+
+## Scope
+
+In scope:
+
+- Detecting items Ice has never seen, persisted across launches.
+- Moving those items into the visible section.
+
+Out of scope:
+
+- **Any user setting.** The destination is the visible section, always. An
+  earlier draft had a picker over the three sections; it was cut. The default is
+  right for essentially every user, and if the choice is ever wanted, it is a
+  property, a defaults key, a picker and one `switch` on top of everything
+  below — the detection machinery, which is the whole of the risk, is identical
+  either way.
+- Per-application rules.
+- Any change to how existing, already-seen items are positioned.
+- Multi-display correctness. `MenuBarItem.getMenuBarItems(on:option:)` returns
+  items across *all* displays when no display is passed, which is how both the
+  item cache and `applyLayoutProfile` read the menu bar today: the cache records
+  the active display's identifier but never filters by it, and nothing
+  correlates an item with the divider on its own display. Placement reads the
+  menu bar exactly as `applyLayoutProfile` does and inherits that limitation
+  unchanged. Filtering by display is not available here —
+  `getMenuBarItemWindows(on:option:)` forces `.onScreen` when a display is
+  passed, which drops every hidden and always-hidden item, i.e. the entire
+  landing zone. Placement de-duplicates candidates by tag, so an item mirrored
+  onto a second display is moved once.
+- Running without Screen Recording permission: the feature is inert (§1).
+
+## Design
+
+### 1. The known-items registry
+
+A new `Defaults.Key` case, `knownMenuBarItems = "KnownMenuBarItems"`, holds the
+JSON-encoded set of `MenuBarItemTag`s Ice has ever seen on this Mac.
+`MenuBarItemTag` is already `Codable` and `Hashable`. It is local state, not a
+preference, so it goes under a new `// MARK: Local State` group in
+`Defaults.Key` rather than with the settings.
+
+An item is **new** when its tag is placeable (§2), absent from that set, and in
+the landing zone (§3).
+
+Four properties make this safe:
+
+- **Key absent means first run.** When the key does not exist, Ice seeds it from
+  the current layout and moves nothing. Existing users upgrading to this build
+  therefore keep their arrangement untouched; only items that appear *after* the
+  upgrade are placed. This is distinct from "the decoded set is empty", which is
+  why the load path yields `Set<MenuBarItemTag>?` rather than defaulting to
+  `[]`. A key that is present but fails to decode is logged at error level and
+  treated as a first run — re-seeding is inert, whereas treating it as an empty
+  set would rearrange the user's whole menu bar.
+- **The set only grows.** Every pass unions the placeable tags it saw into the
+  stored set; it never replaces it. A single pass sees only the active Space, so
+  replacing would drop tags for items parked elsewhere and re-classify them as
+  new when they come back.
+- **It needs Screen Recording permission.** A tag is a namespace plus the item's
+  window title, and the title comes from `kCGWindowName`, which is `nil` without
+  that permission — `MenuBarItem` degrades it to `""`
+  ([MenuBarItem.swift:327](../../../Ice/MenuBar/MenuBarItems/MenuBarItem.swift)),
+  and some namespaces degrade to a per-launch UUID. Screen Recording is optional
+  in Ice (`isRequired: false`,
+  [Permission.swift:231](../../../Ice/Permissions/Permission.swift)), so Ice does
+  run without it. Seeding from that state would record identities that change the
+  moment the permission is granted, and the user's existing items would then look
+  new and be moved. So: no permission, no seeding, no placement, and the key stays
+  absent.
+- **It is excluded from settings backups.** Add it to
+  `SettingsBackup.excludedKeys`, alongside the existing deprecated and
+  machine-specific keys. It is a record of what has appeared on *this* Mac, not
+  a preference; carrying it to another machine would suppress placement there.
+  The comment above `excludedKeys` gains this third category.
+
+The load path reads `Defaults.object(forKey:)` and casts, rather than
+`Defaults.data(forKey:)`, which returns `nil` for both an absent key and a
+present value of the wrong type. A wrong-typed value is a corrupted registry, not
+a fresh install, and is logged as such before being treated as a first run.
+
+Unbounded growth is accepted: entries are a namespace plus a title, and the
+realistic ceiling is tens of entries over the life of an install.
+
+### 2. Placement eligibility
+
+A tag is placeable when all of the following hold:
+
+```swift
+tag.isMovable && tag.canBeHidden && !tag.isControlItem
+    && !tag.isSpacerItem && !tag.namespace.isUUID && !tag.title.isEmpty
+```
+
+This excludes items macOS pins in place (Clock, Control Center), items that
+cannot be hidden at all, Ice's own control items and spacers, and anything whose
+identity is not durable: a UUID namespace is minted per process launch and
+cached by window ID
+([MenuBarItem.swift:400](../../../Ice/MenuBar/MenuBarItems/MenuBarItem.swift)),
+so the same item can be tagged differently after a relaunch — moving such an
+item every launch is worse than leaving it alone. That test subsumes
+`isSystemClone`, which is just the UUID namespace with a known title. The
+empty-title test is the same reasoning for titles: an untitled item cannot be
+told apart from its siblings in the same namespace.
+
+Two distinct items sharing a namespace and title collapse to one entry in the
+set, so the second is never recognised as new. That is a deliberate
+false-negative: it leaves an item alone rather than moving the wrong one.
+
+### 3. The placement pass
+
+A new `// MARK: - New Item Placement` extension on `MenuBarItemManager`, with
+one entry point:
+
+```swift
+func placeNewItemsIfNeeded() async
+```
+
+**Where it is called.** At the end of `cacheItemsRegardless(_:)`, **outside**
+the `cacheActor.runCacheTask { … }` closure. Calling it inside would be a bug:
+the pass re-caches at the end, and `runCacheTask` cancels the previous task
+before starting a new one, so a nested `cacheItemsRegardless` would cancel the
+very task it was called from.
+
+The pass does **not** read `itemCache`. It performs its own
+`MenuBarItem.getMenuBarItems` read, because it needs the hidden and
+always-hidden control items and `ItemCache` deliberately discards them
+(`CacheContext.isValidForCaching`). Being independent of the cache is what keeps
+this simple: there is no question of whether the pass is acting on a cache some
+other invocation produced, because it is not acting on a cache at all.
+`cacheItemsRegardless` is merely the existing "something changed, re-examine the
+menu bar" trigger — it already fires on app launch/quit, Space change, screen
+parameter change, frontmost app change, and a 30 s fallback poll.
+
+**When it defers.** One synchronous check on entry, with no `await` before it:
+
+- `isPlacingNewItems` is already true. This is what terminates the recursion in
+  step 6: the refresh re-enters `cacheItemsRegardless`, which calls this pass
+  again, and the nested call returns at once. Set for the whole pass, cleared in
+  a `defer`.
+- Screen Recording permission is missing
+  (`ScreenCapture.cachedCheckPermissions()`).
+- `lastMoveOperationOccurred(within: .seconds(1))`. Every move by every workflow
+  stamps `lastMoveOperationTimestamp` inside `postMoveEvents`
+  ([MenuBarItemManager.swift:1120](../../../Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift)),
+  so this one existing signal covers `applyLayoutProfile`, `temporarilyShow`,
+  `rehideTemporarilyShownItems`, `enforceControlItemOrder` and layout bar drags
+  without any of them being modified. A menu bar that was being rearranged a
+  moment ago is not one to read positions from. (A `move` that finds the item
+  already correctly positioned returns before posting anything and so does not
+  stamp — harmless, since nothing moved.)
+- `temporarilyShownItemContexts` is non-empty — those items are parked in their
+  shown positions, cached as if they were in their original ones, and the rehide
+  will move them back to destinations computed before this pass.
+
+**Deferring must not strand the item.** Nothing is recorded when the pass
+defers, but that alone does not guarantee another pass. `cacheItemsRegardless`
+records the current window-ID list *inside* `runCacheTask`, before placement runs
+after it, and every routine trigger goes through `cacheItemsIfNeeded`, which
+skips the re-cache entirely while those IDs match. A new item that arrives during
+a temporary show, or within a second of any move, would therefore defer once and
+then sit in the always-hidden section indefinitely — the 30 s fallback poll
+included, because it too runs through `cacheItemsIfNeeded`.
+
+So any path that returns with candidates unplaced — the two defer conditions
+above, the failed-read returns in steps 1 and 2, and a candidate whose move
+failed or could not be verified in step 4 — calls
+`cacheActor.clearCachedItemWindowIDs()` on the way out, which forces the next
+trigger to re-cache and re-run the pass. `uncheckedCacheItems` already uses this
+exact mechanism for the same purpose ("Ensure next cache isn't skipped").
+
+The clear must be the **last awaited operation** of the pass, after the step 6
+refresh. A pass in which some candidates were placed and others were not does
+both, and `refreshCacheAfterItemMoves()` runs `cacheItemsRegardless`, which writes
+the window-ID list again — undoing an earlier clear. Its nested placement call
+returns through the recursion guard without clearing, so the failed candidate
+would be stranded by exactly the mechanism meant to rescue it.
+
+Two paths deliberately do *not* clear. The `isPlacingNewItems` guard, because the
+outer pass is still running and will do it. And the missing-permission gate,
+because clearing there would force a full re-cache on every poll for as long as
+permission is denied, which is indefinite.
+
+That second carve-out needs its own trigger, because the grant itself changes
+nothing the cache watches: if the window-ID list happens not to change afterwards,
+the pass never runs again, and — worse, with the registry still absent — the next
+app to launch becomes the seed, so that genuinely new icon is recorded as
+pre-existing and never placed. `MenuBarItemManager.configureCancellables` gains a
+sink on `appState.permissions.screenRecording.$hasPermission` that calls
+`cacheItemsRegardless()` once on a false → true transition. This is the same shape
+as the `settingsNavigationIdentifier` sink already there.
+
+**Residual risk, accepted.** A workflow that starts *after* the entry check and
+interleaves with the pass's own moves is not detected — once the pass starts
+moving, its own moves stamp the same timestamp the entry check reads, so the
+signal cannot distinguish them. Closing this would mean bracketing every existing
+move workflow with a shared counter, i.e. modifying five working call sites to
+serve one opt-in convenience — not a trade worth making.
+
+What makes the residue tolerable is that interference is *detected after the
+fact* rather than prevented: step 4 verifies each item's final position, so an
+item that was knocked elsewhere is not recorded, and the pass clears the cached
+window IDs so a later pass retries it. The user-visible failure is therefore a
+delay, not a permanently mislaid icon.
+
+The verification is per-item and immediate, so it cannot see interference that
+arrives *after* that item's check — an item can be verified in place and then
+dragged away a moment later, and it will already have been recorded. That case is
+indistinguishable from the user simply moving an item afterwards, which is theirs
+to do and which the feature must not undo.
+
+**The pass:**
+
+1. **Read the menu bar once, and order it explicitly.**
+   `MenuBarItem.getMenuBarItems(option: .activeSpace)`, the same read
+   `applyLayoutProfile` uses, then **sorted ascending by `bounds.minX`**. Return,
+   recording nothing, if it contains no hidden control item — that is the "the
+   read failed" signal `applyLayoutProfile` already treats as fatal, and it is
+   the check that makes a degraded read inert instead of destructive.
+
+   The sort is not redundant. `getMenuBarItems` returns
+   `Bridging.getProcessMenuBarWindowList()` filtered and `.reversed()`, with no
+   positional sort anywhere in the chain. That it comes out left to right is
+   inferred only from the fact that `applyVisibleLayout` would otherwise rebuild
+   saved profiles backwards. Every positional decision elsewhere in the manager is
+   made from bounds, not array order — `CacheContext.findSection` compares `minX`
+   and `maxX`, `enforceControlItemOrder` compares `hidden.bounds.maxX` against
+   `alwaysHidden.bounds.minX`. Sorting here follows that idiom and removes the
+   assumption rather than depending on it.
+2. **Load the known set** (§1). On a first run — absent or undecodable key —
+   seed from a second, unfiltered read, `MenuBarItem.getMenuBarItems(option: [])`,
+   which drops the `.activeSpace` filter and so also sees items parked on other
+   Spaces, record its placeable tags, and return without moving anything. That
+   read is validated exactly as step 1's is: no hidden control item means it
+   failed, so the pass logs and returns with the key still absent, and the next
+   pass seeds again. Writing an unvalidated seed is the one way this design can
+   damage an existing menu bar — a failed read stores a partial set, and the next
+   pass, no longer a first run, finds the user's own always-hidden items
+   unrecorded in the landing zone and moves them.
+3. **Pick the candidates.** Because step 1 sorted by `minX`, the landing zone is
+   simply the prefix of the read that precedes the leftmost control item — the
+   always-hidden divider when that section is enabled, the hidden divider when it
+   is not. (The sort is what makes "prefix" mean the same thing as
+   `CacheContext.findSection`'s bounds comparison; without it, "prefix" would be
+   an assumption about window-list order.) Within that prefix, walk left to right
+   and collect placeable tags that are not in the known set, stopping at the first
+   placeable tag that *is* known. Non-placeable tags are skipped without ending
+   the walk; repeated tags are de-duplicated; each surviving tag maps back to the
+   first item in the read that carries it.
+
+   The positional test is what makes "new" mean *newly created* rather than
+   merely *unrecorded*, and it is what lets the concurrency guard stay cheap. A
+   single pass sees only the active Space, so an existing item first encountered
+   on another Space is unrecorded too — but it is sitting where the user left it,
+   not in the slot macOS hands to brand-new items, so the walk stops before it
+   and it is recorded untouched.
+
+   This is not airtight: an app that was installed before the upgrade but not
+   running during seeding is absent from the seed, and if it later launches into
+   the landing zone ahead of any known item, it is moved. It is a new item as far
+   as Ice can tell, and the result — its icon becomes visible — is what the
+   feature does anyway.
+4. **Move.** Destination is the visible section: `.rightOfItem` the hidden
+   control item, items in order, each chained off the previous one, so the first
+   candidate ends up immediately right of the divider and they keep their
+   relative order.
+
+   The existing `applyVisibleLayout` cannot be reused: it is `throws` and aborts
+   the remaining items on the first failure. Placement uses its own loop, which
+   logs and swallows per-item errors like `enforceControlItemOrder` does,
+   continues with the chain re-anchored on the last item that actually moved (the
+   divider, if none did), and returns the tags it placed.
+
+   A `move` that returns is not proof that the item arrived. `move` checks
+   `itemHasCorrectPosition` *before* posting on each attempt, then returns as soon
+   as `postMoveEvents` reports the item's origin changed — it never re-checks the
+   destination
+   ([MenuBarItemManager.swift:1220](../../../Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift)).
+   A drag that begins after `waitForUserToPauseInput` can satisfy that
+   origin-changed wait while leaving the item somewhere else entirely. So the loop
+   calls `itemHasCorrectPosition(item:for:)` itself after each `move` returns, and
+   counts the item as placed only if it holds. It is `private nonisolated` and the
+   new extension lives in the same file, so it is directly callable. The check has
+   to happen immediately, before the chain advances, because each subsequent move
+   shifts the bounds it reads.
+5. **Record.** Union into the known set every placeable tag in the step 1 read,
+   *minus* the candidates, *plus* the candidates verified as placed. A candidate
+   whose move failed or could not be verified is **not** recorded — it is still in
+   the landing zone, so the next pass finds it and retries; recording it would let
+   one transient event failure permanently defeat the feature for that icon.
+
+   Subtracting only the candidates, rather than recording only what lies outside
+   the landing zone, is what stops a delayed false positive. An unknown item
+   sitting *behind* the item that stopped the walk is neither placed nor a
+   candidate; if it were left unrecorded, then the day the blocking item's app
+   quits, the walk would run further, reach it, and drag an item the user had
+   deliberately parked out of always-hidden. Recording it now means it is never a
+   candidate again.
+6. **Refresh.** If any candidate was verified as placed, call
+   `refreshCacheAfterItemMoves()` so the layout bar reflects the new arrangement
+   instead of waiting for the 30 s fallback poll.
+
+### 4. Pure logic in its own file
+
+`Ice/MenuBar/MenuBarItems/NewMenuBarItemPlacement.swift` holds the parts that
+need no live menu bar:
+
+```swift
+enum NewMenuBarItemPlacement {
+    static func isPlaceable(_ tag: MenuBarItemTag) -> Bool
+    static func candidateTags(in orderedTags: [MenuBarItemTag], known: Set<MenuBarItemTag>) -> [MenuBarItemTag]
+    static func tagsToRecord(
+        seen orderedTags: [MenuBarItemTag],
+        candidates: [MenuBarItemTag],
+        placed: Set<MenuBarItemTag>
+    ) -> Set<MenuBarItemTag>
+    static func decodeKnownTags(from data: Data) -> Set<MenuBarItemTag>?
+    static func encode(_ tags: Set<MenuBarItemTag>) -> Data?
+}
+```
+
+The layer works on tags rather than items on purpose: `MenuBarItem`'s
+initializers are private, so tests cannot build one, whereas
+`MenuBarItemTag(namespace:title:)` is directly constructible. The manager maps
+the returned tags back to items — deterministically, since candidates all precede
+the first control item, so the first occurrence of a tag is the right one.
+`candidateTags` implements the whole of step 3 — the control-item boundary, the
+walk, the de-duplication — over the ordered tags of the read; `tagsToRecord`
+implements step 5's rule, keeping the set algebra that a delayed false positive
+turns on out of the manager and under test.
+
+This mirrors how `MenuBarLayoutProfile` is factored away from
+`MenuBarItemManager`, and is what makes the feature testable in `IceTests`,
+which cannot drive real status items.
+
+## Testing
+
+`IceTests/NewMenuBarItemPlacementTests.swift`:
+
+- the placeable predicate accepts an ordinary app item and rejects control
+  items, spacers, immovable and non-hideable items, UUID-namespace tags
+  (including the system clone), and empty-title tags;
+- `candidateTags` bounds the walk at the leftmost control item, stops at the
+  first known placeable tag, skips non-placeable tags without ending the walk,
+  de-duplicates repeated tags, preserves input order, returns empty when every
+  placeable tag is known, and returns empty when the input has no control item;
+- `tagsToRecord` excludes every non-placeable tag and every unplaced candidate,
+  includes the placed candidates, and — the case that matters — includes an
+  unknown placeable tag that sits inside the landing zone *behind* the tag that
+  stopped the walk, so it can never become a candidate on a later pass;
+- first-run semantics: `decodeKnownTags` yields `nil` for an undecodable payload,
+  distinguishable from a decoded empty set, and encode/decode round-trips. The
+  absent-key and wrong-typed cases are decided by the manager's load path against
+  `Defaults.object(forKey:)`, not by this helper, and are covered by the manual
+  checks rather than unit tests.
+
+`IceTests/SettingsBackupTests.swift`: extend the excluded-keys test to assert
+`knownMenuBarItems` never enters a payload, and that applying a payload leaves a
+value already stored under that key in the target untouched.
+
+`IceTests` is a manually enumerated Xcode group — 31 explicit children in the
+`PBXGroup` and a matching `Sources` build phase — so the new test file must be
+added to `Ice.xcodeproj/project.pbxproj`, or it silently does not compile or run.
+
+Not covered by automated tests: the move itself, and the manager-level
+sequencing around it (the deferral checks, the window-ID clearing that guarantees
+a retry, the post-move position verification, per-item failure continuation).
+Repositioning needs granted screen-recording TCC, which a debug build cannot
+inherit; injecting a fake mover to reach the rest would mean adding a test-only
+seam to the class that performs the moves, while the decisions that loop
+consumes — which items, in which order, towards which divider — are already pure
+and covered above.
+
+Live verification is manual, on a build with Screen Recording granted:
+
+- upgrading with the key absent seeds and moves nothing — the existing
+  arrangement is untouched;
+- installing an app with a menu bar extra lands its icon immediately right of
+  the hidden divider, and it stays there across a relaunch of both apps;
+- launching two menu bar apps at once places both, in order;
+- an item deliberately dragged back into always-hidden stays there — it is
+  recorded, so it is never a candidate again;
+- a new item appearing during a layout profile apply, a temporary show, or a
+  layout bar drag is not moved during that workflow and **is** placed on a later
+  pass, with the other workflow's result intact — specifically, an item that
+  arrives while an item is temporarily shown still gets placed once the rehide
+  completes and nothing else about the menu bar changes, which is the case the
+  window-ID clearing exists for;
+- an item dragged away by hand mid-placement is not recorded, and a later pass
+  puts it where it belongs;
+- with Screen Recording denied, nothing is seeded, recorded or moved — and
+  granting it, without relaunching and without otherwise disturbing the menu bar,
+  seeds immediately rather than waiting for the next app to launch.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `Ice/Utilities/Defaults.swift` | One new `Key` case in a new "Local State" group |
+| `Ice/MenuBar/MenuBarItems/NewMenuBarItemPlacement.swift` | New — pure logic |
+| `Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift` | New extension; call site at the end of `cacheItemsRegardless`; permission-grant sink in `configureCancellables` |
+| `Ice/Settings/Backup/SettingsBackup.swift` | Exclude `knownMenuBarItems` |
+| `Ice.xcodeproj/project.pbxproj` | Register the new test file in the `IceTests` group and `Sources` phase |
+| `IceTests/NewMenuBarItemPlacementTests.swift` | New — tests |
+| `IceTests/SettingsBackupTests.swift` | Cover the new excluded key |
+| `CHANGELOG.md` | Added entry |
+
+No settings model, settings pane, or `SettingsView` change: there is no setting.

--- a/docs/superpowers/specs/2026-08-08-new-menu-bar-item-section-design.md
+++ b/docs/superpowers/specs/2026-08-08-new-menu-bar-item-section-design.md
@@ -231,7 +231,16 @@ to do and which the feature must not undo.
 
 1. **Read the menu bar once, and order it explicitly.**
    `MenuBarItem.getMenuBarItems(option: .activeSpace)`, the same read
-   `applyLayoutProfile` uses, then **sorted ascending by `bounds.minX`**. Return,
+   `applyLayoutProfile` uses, then **sorted ascending by live `minX`**, read via
+   `Bridging.getWindowBounds(for:)` with the item's stored `bounds` as a fallback.
+   `MenuBarItem.bounds` is a snapshot taken when the window list was read and can
+   be stale for off-screen windows — which is every item in the landing zone, the
+   always-hidden section being off-screen by construction. A stale rectangle
+   reorders the sort, and since the landing zone is the prefix before the leftmost
+   control item, a bad order can put the divider in the wrong place and make items
+   the user deliberately parked look like candidates.
+   `CacheContext.bestBounds(for:)` makes the same correction on the caching path.
+   Resolve it once per item, not inside the comparator. Return,
    recording nothing, if it contains no hidden control item — that is the "the
    read failed" signal `applyLayoutProfile` already treats as fatal, and it is
    the check that makes a degraded read inert instead of destructive.


### PR DESCRIPTION
## What

macOS gives every new status item the leftmost slot in the menu bar, which falls inside Ice 2's always-hidden section. Ice never repositioned it, so **the first time you installed an app with a menu bar extra, its icon was invisible** and the app looked like it had never added one.

Ice now records every menu bar item it has seen on this Mac and moves the genuinely new ones to the leading edge of the visible section, next to the hidden divider.

## Scope note

An earlier draft of the design added a Layout setting choosing among the three sections. **It was cut** — the default suits essentially everyone, and the detection machinery, which is the whole of the risk, is identical either way. Adding the picker later is a property, a key, a picker and one `switch`. Nothing is foreclosed.

## How detection works

Historical *and* positional. Only items in the landing zone — the run to the left of the leftmost control item, where macOS drops new items — are candidates, and the walk stops at the first item already known. An item that is merely *unrecorded*, because it lives on another Space, is sitting where you left it, so it is recorded untouched rather than moved.

That positional test is also what lets the concurrency guard stay cheap. The pass defers on the existing `lastMoveOperationOccurred` signal, which every move workflow already stamps inside `postMoveEvents` — so `applyLayoutProfile`, `temporarilyShow`, rehide, control-order repair and layout-bar drags are all covered **without modifying any of them**.

## Correctness details worth reviewing

- **Seeding requires screen recording permission.** A tag is a namespace plus a window title, and titles read as empty without it. Seeding from that state would record identities that change the moment permission is granted, and your existing items would then look new and be moved. A sink on the permission handles the grant, which otherwise changes nothing the cache watches.
- **The read is sorted by `bounds.minX`.** `getMenuBarItems` reverses a window list that is never positionally sorted, so left-to-right order was an inference, not a guarantee — and the landing-zone walk depends on it entirely. Every other positional decision in the manager reads bounds.
- **`move` returning is not proof the item arrived.** It returns as soon as the origin changes and never re-checks the destination, so each placement is verified afterwards. An unverified item stays unrecorded and is retried.
- **A pass that leaves work undone clears the cached window IDs — last, after the refresh.** Otherwise the refresh rewrites them and the item is stranded by the mechanism meant to rescue it.
- **UUID-namespace and empty-title tags are excluded.** UUID namespaces are minted per process launch, so placing on that identity would move the item on every launch.

## Upgrade behaviour

Nothing moves. The first run records the current layout — across all Spaces, not just the active one — and only items appearing afterwards count as new.

## Verification

- `xcodebuild test`: **317 tests pass**, including 21 new ones
- `swiftlint --strict`: clean

**Not covered by tests:** the moving itself, and the manager-level sequencing around it. That needs granted screen-recording TCC, which a debug build cannot inherit. The manual checklist is in the [spec](docs/superpowers/specs/2026-08-08-new-menu-bar-item-section-design.md#testing) — worth running before release.

`MARKETING_VERSION` is deliberately left at 2.13.0 and nothing is tagged; the changelog entry is staged under a `2.14.0` heading to match the file's convention.

## Design

The spec is committed first, in `docs/superpowers/specs/`. It was reviewed across several rounds and records the rejected alternatives too — notably a cache generation token and movement-workflow counters bracketing five call sites, both declined as disproportionate, with the residual risk they leave written down rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)