### PR TITLE
release: 2.14.0

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.13.0;
+				MARKETING_VERSION = 2.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.13.0;
+				MARKETING_VERSION = 2.14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
Bump `MARKETING_VERSION` for the Ice target (Debug + Release) from 2.13.0 to 2.14.0.

`CURRENT_PROJECT_VERSION` is left alone — the release pipeline stamps `CFBundleVersion` from `git rev-list --count HEAD`. The caller passes `assert_tag_matches_plist: true`, so this bump has to land before `v2.14.0` is tagged or the release fails before notarization.

The changelog entry landed with the feature in #87.

## What ships in 2.14.0

**Newly created menu bar items now go to the visible section.** macOS hands every new status item the leftmost slot, which falls inside Ice 2's always-hidden section — so the first time you installed an app with a menu bar extra, its icon was invisible and the app looked like it had never added one.

Existing arrangements are untouched. The first run after updating records the current layout, across all Spaces, so only items appearing afterwards count as new. Requires screen recording permission; without it nothing is seeded, recorded or moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)