### PR TITLE
release: 2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.14.1 - 2026-08-10
+
+### Internal
+
+- Nothing about the app behaves differently. All four Dragon apps were audited together to confirm they depend on the shared Dragon app framework the same way — version 3.2.0, or any later 3.x — and are being released in step. Ice 2 needed no change to make that true: its Xcode project already expressed exactly that rule, in the only form Xcode has for writing it, and the dependency lock committed alongside the project already resolves to 3.2.0. This release is a version bump and nothing else, so that Ice 2's number lines up with its siblings.
+
 ## 2.14.0 - 2026-08-10
 
 ### Added

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.0;
+				MARKETING_VERSION = 2.14.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.0;
+				MARKETING_VERSION = 2.14.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
**Version bump only — no functional change, no pin change.**

The four Dragon apps are being unified on a single DragonKit pin form, `from: "3.2.0"`, and released in step. **Ice 2 required no pin change.** `Ice.xcodeproj/project.pbxproj` already declares:

```
kind = upToNextMajorVersion;
minimumVersion = 3.2.0;
```

which is exactly the `.pbxproj` encoding of SwiftPM's `from: "3.2.0"` — Xcode has no other spelling for it. `Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` already locks `dragon-kit` at **3.2.0**, revision `1cc443bd58ff49a2e530feccf66b6f5f72a9fc55`. Both files are deliberately left untouched by this PR.

So this release exists only to keep Ice 2's version number in step with its siblings. There is no feature and no fix here, and the changelog says so rather than inventing one.

## Changes

- `Ice.xcodeproj/project.pbxproj` — `MARKETING_VERSION` 2.14.0 → 2.14.1, in the app target's **Debug** (`com.dragonapp.ice.debug`) and **Release** (`com.dragonapp.ice`) configurations. Exactly two lines.
- `CHANGELOG.md` — a `## 2.14.1 - 2026-08-10` section with an `### Internal` entry stating plainly that nothing about the app behaves differently.

## Deliberately not changed

- The DragonKit pin and `Package.resolved` — already correct, per above.
- `MARKETING_VERSION = 1.0` on the **MenuBarItemService** target — that target versions independently.
- `CURRENT_PROJECT_VERSION = 1346` — release CI overrides it with the git commit count.

## Verification

- DragonKit conformance run locally against `dragon-kit@main` (`1cc443b`, the same commit CI's `@main` pin resolves to): **PASS — no violations**, 116 Swift files / 45 kit types.
- No Swift files touched, so the SwiftLint workflow's path filter skips this PR by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)