### PR TITLE
release: 2.14.2 — isolate Debug builds, and catch What's New up four releases

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -781,7 +781,7 @@
 				INFOPLIST_FILE = MenuBarItemService/Resources/Info.plist;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.MenuBarItemService;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug.MenuBarItemService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
 				SKIP_INSTALL = YES;
@@ -898,7 +898,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.2.0;
+				minimumVersion = 3.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.1;
+				MARKETING_VERSION = 2.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.1;
+				MARKETING_VERSION = 2.14.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "1cc443bd58ff49a2e530feccf66b6f5f72a9fc55",
-        "version" : "3.2.0"
+        "revision" : "9ebd5e50ee72706625aae2c0170f028135631e33",
+        "version" : "3.3.0"
       }
     },
     {

--- a/Ice/Main/Updates.swift
+++ b/Ice/Main/Updates.swift
@@ -3,6 +3,7 @@
 //  Ice
 //
 
+import DragonKit
 import DragonKitUpdates
 import OSLog
 import SwiftUI
@@ -31,9 +32,39 @@ final class UpdatesManager {
         onUpdateFoundInBackground: { UpdatesManager.notifyUpdateAvailable() }
     ))
 
+    /// Whether this build must leave the production updater alone entirely.
+    ///
+    /// Primarily the build channel `scripts/run-debug.sh` stamps into `Info.plist`, read through
+    /// DragonKit 3.3.0's ``DragonAbout/isDebugBuild(bundle:)``: `MAC-APP-RELEASE-LIFECYCLE.md`
+    /// scopes the rule to the *bundle* someone is running hands-on beside their installed Ice 2,
+    /// and the channel is the only thing that describes that bundle.
+    ///
+    /// `#if DEBUG` is kept alongside it rather than replaced by it. A build launched straight
+    /// from Xcode is never stamped, so the channel alone would let ⌘R reach the production
+    /// appcast — which the `#if DEBUG` guard this replaced did block. Two conditions, because
+    /// they answer different questions: how the binary was compiled, and what the bundle says
+    /// it is.
+    ///
+    /// "Disabled" means never initializing Sparkle either, not just never checking:
+    /// ``DragonUpdater`` creates its `SPUUpdater` lazily on first property access, so merely
+    /// reading ``DragonUpdater/automaticallyChecksForUpdates`` would start it and its
+    /// scheduled-check timer.
+    static var updatingIsDisabled: Bool {
+        #if DEBUG
+        return true
+        #else
+        return DragonAbout.isDebugBuild()
+        #endif
+    }
+
     /// Performs the initial setup of the manager.
     func performSetup(with appState: AppState) {
         self.appState = appState
+        guard !Self.updatingIsDisabled else {
+            // Not even `updater.start()`: a debug build must never read the production appcast.
+            Logger.default.notice("Debug build - skipping updater setup")
+            return
+        }
         // Starting the updater at launch is what lets Sparkle schedule its background update
         // checks, exactly as `SPUStandardUpdaterController(startingUpdater: true)` did.
         updater.start()
@@ -47,13 +78,17 @@ final class UpdatesManager {
     }
 
     /// Checks for app updates.
+    ///
+    /// Unreachable from the menu in a debug build — ``ControlItem`` passes
+    /// `onCheckForUpdates: nil`, so DragonKit omits the item rather than showing an inert one.
+    /// The guard stays because the menu is not the only caller a future change could add, and
+    /// this used to be an `#if DEBUG` alert saying the check "is not supported in debug mode",
+    /// which described a hang rather than the policy.
     func checkForUpdates() {
-        #if DEBUG
-        // Checking for updates hangs in debug mode.
-        let alert = NSAlert()
-        alert.messageText = "Checking for updates is not supported in debug mode."
-        alert.runModal()
-        #else
+        guard !Self.updatingIsDisabled else {
+            Logger.default.notice("Debug build - ignoring check for updates")
+            return
+        }
         guard let appState else {
             return
         }
@@ -61,7 +96,6 @@ final class UpdatesManager {
         appState.activate(withPolicy: .regular)
         appState.openWindow(.settings)
         updater.checkForUpdates()
-        #endif
     }
 
     /// Asks for permission to post ``notifyUpdateAvailable()``.

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -563,11 +563,18 @@ final class ControlItem {
         // drifting. `items(_:)` supplies the divider before Quit itself, so the
         // separator above is the only one added here. Uninstall is deliberately
         // absent — it lives in Settings ▸ Uninstall (see `IceUninstallConfig`).
+        //
+        // A debug build passes `nil` and DragonKit omits "Check for Updates…"
+        // outright. The lifecycle spec bars a debug build from the production
+        // appcast, and an item that is present but does nothing reads as a bug —
+        // absent is the state the kit already models for a build without Sparkle.
         for item in DragonAppMenu.items(DragonAppMenu.Config(
             appName: Constants.displayName,
             onAbout: { [weak self] in self?.openAbout() },
             onSettings: { [weak self] in self?.openSettings() },
-            onCheckForUpdates: { [weak self] in self?.checkForUpdates() }
+            onCheckForUpdates: UpdatesManager.updatingIsDisabled
+                ? nil
+                : { [weak self] in self?.checkForUpdates() }
         )) {
             menu.addItem(item)
         }

--- a/Ice/MenuBar/Spacing/MenuBarItemSpacingManager.swift
+++ b/Ice/MenuBar/Spacing/MenuBarItemSpacingManager.swift
@@ -197,6 +197,17 @@ final class MenuBarItemSpacingManager {
                     logger.debug("applyOffset: skipping pid \(pid, privacy: .public) (self)")
                     continue
                 }
+                // The *other* build of Ice 2, which `.current` doesn't cover: an installed
+                // release (com.dragonapp.ice) and a local debug build (com.dragonapp.ice.debug)
+                // are two processes with two status items. A relaunch is a terminate, and
+                // MAC-APP-RELEASE-LIFECYCLE.md requires that changing a setting in the debug
+                // build never terminates the installed release — the two must survive being
+                // run at once. Only ever matches while both are running, so a Mac with one
+                // build installed is unaffected.
+                guard !Self.isAnIceBundleID(app.bundleIdentifier) else {
+                    logger.debug("applyOffset: skipping pid \(pid, privacy: .public) (another Ice 2 build)")
+                    continue
+                }
                 logger.debug("applyOffset: relaunching pid \(pid, privacy: .public) bundle=\(app.bundleIdentifier ?? "<nil>", privacy: .public)")
                 group.addTask { @MainActor in
                     do {
@@ -237,6 +248,19 @@ final class MenuBarItemSpacingManager {
         if !failedApps.isEmpty {
             throw GroupedRelaunchError(failedApps: failedApps)
         }
+    }
+
+    /// Whether `bundleID` belongs to any build of Ice 2 — the installed release or a
+    /// `.debug` build beside it.
+    ///
+    /// Matched on a dot boundary rather than a bare prefix, so an unrelated app whose id merely
+    /// starts with the same letters is still relaunched like any other menu bar app.
+    static func isAnIceBundleID(_ bundleID: String?) -> Bool {
+        guard let bundleID else {
+            return false
+        }
+        let release = IceUninstallConfig.releaseBundleID
+        return bundleID == release || bundleID.hasPrefix("\(release).")
     }
 }
 

--- a/Ice/MenuBar/Spacing/MenuBarItemSpacingManager.swift
+++ b/Ice/MenuBar/Spacing/MenuBarItemSpacingManager.swift
@@ -204,7 +204,7 @@ final class MenuBarItemSpacingManager {
                 // build never terminates the installed release — the two must survive being
                 // run at once. Only ever matches while both are running, so a Mac with one
                 // build installed is unaffected.
-                guard !Self.isAnIceBundleID(app.bundleIdentifier) else {
+                guard !Constants.isIceBundleID(app.bundleIdentifier) else {
                     logger.debug("applyOffset: skipping pid \(pid, privacy: .public) (another Ice 2 build)")
                     continue
                 }
@@ -248,19 +248,6 @@ final class MenuBarItemSpacingManager {
         if !failedApps.isEmpty {
             throw GroupedRelaunchError(failedApps: failedApps)
         }
-    }
-
-    /// Whether `bundleID` belongs to any build of Ice 2 — the installed release or a
-    /// `.debug` build beside it.
-    ///
-    /// Matched on a dot boundary rather than a bare prefix, so an unrelated app whose id merely
-    /// starts with the same letters is still relaunched like any other menu bar app.
-    static func isAnIceBundleID(_ bundleID: String?) -> Bool {
-        guard let bundleID else {
-            return false
-        }
-        let release = IceUninstallConfig.releaseBundleID
-        return bundleID == release || bundleID.hasPrefix("\(release).")
     }
 }
 

--- a/Ice/Settings/Backup/SettingsBackup.swift
+++ b/Ice/Settings/Backup/SettingsBackup.swift
@@ -153,7 +153,7 @@ enum SettingsBackup {
         home: URL = FileManager.default.homeDirectoryForCurrentUser,
         bundleID: String? = Bundle.main.bundleIdentifier
     ) -> URL {
-        let name = bundleID == IceUninstallConfig.releaseBundleID ? "Ice Backups" : "Ice Backups (Debug)"
+        let name = bundleID == Constants.releaseBundleIdentifier ? "Ice Backups" : "Ice Backups (Debug)"
         return home.appending(path: "Documents/\(name)", directoryHint: .isDirectory)
     }
 

--- a/Ice/Settings/Backup/SettingsBackup.swift
+++ b/Ice/Settings/Backup/SettingsBackup.swift
@@ -136,9 +136,25 @@ enum SettingsBackup {
 
     // MARK: - Files & retention
 
-    /// Default backup folder when the user hasn't chosen one: ~/Documents/Ice Backups.
-    static func defaultFolder(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
-        home.appending(path: "Documents/Ice Backups", directoryHint: .isDirectory)
+    /// Default backup folder when the user hasn't chosen one: `~/Documents/Ice Backups`, or
+    /// `~/Documents/Ice Backups (Debug)` for anything that isn't the installed release.
+    ///
+    /// The `.debug` bundle id separates `UserDefaults.standard` and the per-bundle-id Library
+    /// folders on its own; it does nothing for a path spelled out in source like this one. Both
+    /// builds shared the folder, and ``prune(in:keeping:)`` keeps the newest *files* rather than
+    /// the newest per build — so with automatic backups on by default, ten quits of a debug
+    /// build deleted every backup the installed Ice 2 had written, and "restore the newest
+    /// backup" in the release app could restore debug settings.
+    ///
+    /// An unknown id falls to the Debug folder rather than the release one, the same direction
+    /// ``IceUninstallConfig/homebrewCask(forBundleID:)`` fails in: a build that can't state its
+    /// identity is the last one that should be writing into, and pruning, the release's backups.
+    static func defaultFolder(
+        home: URL = FileManager.default.homeDirectoryForCurrentUser,
+        bundleID: String? = Bundle.main.bundleIdentifier
+    ) -> URL {
+        let name = bundleID == IceUninstallConfig.releaseBundleID ? "Ice Backups" : "Ice Backups (Debug)"
+        return home.appending(path: "Documents/\(name)", directoryHint: .isDirectory)
     }
 
     /// A lexically-sortable timestamp, e.g. "2026-06-29-013045".

--- a/Ice/Settings/IceUninstallConfig.swift
+++ b/Ice/Settings/IceUninstallConfig.swift
@@ -26,7 +26,11 @@ enum IceUninstallConfig {
     /// The bundle id Homebrew installed: the fallback for the running bundle's id below, and the
     /// gate the cask token is issued against — deliberately not both at once, see
     /// ``homebrewCask(forBundleID:)``.
-    private static let releaseBundleID = "com.dragonapp.ice"
+    ///
+    /// Not `private`: ``SettingsBackup/defaultFolder(home:bundleID:)`` asks the same question
+    /// this type does — "is this the installed release, or the isolated debug build?" — and a
+    /// second copy of the release id is exactly the kind of literal that drifts.
+    static let releaseBundleID = "com.dragonapp.ice"
 
     /// The Homebrew cask token for `actual`, or `nil` when that isn't the bundle brew installed.
     ///

--- a/Ice/Settings/IceUninstallConfig.swift
+++ b/Ice/Settings/IceUninstallConfig.swift
@@ -27,10 +27,10 @@ enum IceUninstallConfig {
     /// gate the cask token is issued against — deliberately not both at once, see
     /// ``homebrewCask(forBundleID:)``.
     ///
-    /// Not `private`: ``SettingsBackup/defaultFolder(home:bundleID:)`` asks the same question
-    /// this type does — "is this the installed release, or the isolated debug build?" — and a
-    /// second copy of the release id is exactly the kind of literal that drifts.
-    static let releaseBundleID = "com.dragonapp.ice"
+    /// Aliases ``Constants/releaseBundleIdentifier`` rather than repeating the literal: three
+    /// places now ask "is this the installed release, or the isolated debug build?", and a
+    /// second copy of that id is exactly the kind of literal that drifts.
+    private static let releaseBundleID = Constants.releaseBundleIdentifier
 
     /// The Homebrew cask token for `actual`, or `nil` when that isn't the bundle brew installed.
     ///

--- a/Ice/Settings/Models/MenuBarTriggerSettings.swift
+++ b/Ice/Settings/Models/MenuBarTriggerSettings.swift
@@ -149,10 +149,13 @@ final class MenuBarTriggerSettings: ObservableObject {
             .store(in: &cancellables)
     }
 
+    /// Offering the frontmost app as a trigger candidate skips *any* Ice 2 build, not just this
+    /// process: with a debug build running beside the installed release, each would otherwise
+    /// offer the other as "the app to trigger on", which is never something a user means.
     private func updateCandidate(with app: NSRunningApplication?) {
         guard
             let app,
-            app.bundleIdentifier != Constants.bundleIdentifier,
+            !Constants.isIceBundleID(app.bundleIdentifier),
             let bundleIdentifier = app.bundleIdentifier
         else {
             return
@@ -170,7 +173,7 @@ final class MenuBarTriggerSettings: ObservableObject {
         guard
             let appState,
             let bundleIdentifier = app?.bundleIdentifier,
-            bundleIdentifier != Constants.bundleIdentifier
+            !Constants.isIceBundleID(bundleIdentifier)
         else {
             return
         }

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -11,18 +11,42 @@ import DragonKit
 /// passed at all: ``WhatsNewContent`` reads `CFBundleShortVersionString` itself and renders it
 /// through ``DragonVersion/display(_:)``, so it always matches About and the update checker and
 /// carries the same single `v` prefix. Update the `date` and `sections` per release.
+///
+/// This pane went four releases without an update — it still described 2.11.0 while 2.14.1
+/// shipped — so 2.12.0 through 2.14.0 were never announced to anyone who reads the app rather
+/// than the changelog, including the removal of item groups. The notes below are cumulative for
+/// that reason, and each entry names the release it came from. `MAC-APP-RELEASE-LIFECYCLE.md`
+/// now makes updating this file part of every public release, gated on the tag.
 enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
-            date: "2026-08-04",
-            summary: "Update checks are quiet and considerate again.",
+            date: "2026-08-10",
+            summary: """
+                A maintenance release: nothing you can see behaves differently. Its fixes \
+                all concern keeping a development build of Ice 2 separate from the copy you \
+                have installed. These notes also catch up on 2.12.0 through 2.14.0, which \
+                shipped without being announced here.
+                """,
             sections: [
+                ChangeSection(kind: .added, entries: [
+                    "A newly installed app's menu bar icon now appears where you can see it (2.14.0). macOS hands every brand-new menu bar item the leftmost slot, which in Ice 2's layout sits inside the always-hidden section — so the first time you installed an app with a menu bar icon, that icon was invisible from the moment it was created, and the app looked like it had never added one. Ice 2 now recognises an item it has never seen before and moves it into the visible section. Items you have already arranged are left alone, and updating does not move anything: Ice 2 takes a note of everything currently in your menu bar first, so only icons that turn up afterwards count as new. If you then drag one into Hidden or Always-Hidden, it stays where you put it. This needs Screen Recording permission, which is what lets Ice 2 tell one menu bar item from another; without it, nothing is moved.",
+                ]),
+                ChangeSection(kind: .removed, entries: [
+                    "Item groups are gone (2.12.0). The Groups section in Settings ▸ Layout — saving a set of hidden items under a name and revealing them with Show — has been removed, along with the option to point a trigger at a group. It saw very little use for the amount of the app it occupied, and layout profiles already cover arranging your menu bar. Any groups you had saved were deleted from your settings when you updated. Triggers still work: a trigger now always shows the hidden section when its app comes to the front, so the Target menu is gone. Existing hidden-section triggers are untouched; only a trigger that pointed at a group was dropped.",
+                ]),
                 ChangeSection(kind: .fixed, entries: [
-                    "Scheduled update checks stop interrupting you. When Ice 2 checks for updates on its own schedule, it shows the update window quietly instead of pulling you out of what you were doing. Version 2.10.0 moved updates onto the shared Dragon app framework and lost that, so a background check could take over the screen unprompted.",
-                    "Ice 2 tells you when a background check finds an update. The notification titled \"A new update is available\" is back. Because the update window deliberately does not steal focus, it can sit behind whatever you are working in — the notification is how you know it is there. It applies only if you have Automatically check for updates turned on, which is where macOS asks permission to show notifications; declining changes nothing about how updates work.",
+                    "A future update can no longer wipe your settings (2.12.1). Ice 2 saves your preferences as a single encoded record. Because of a flaw in the shared Dragon framework, the next version that added a setting would have failed to read the record you already had, quietly fallen back to defaults, and then written those defaults over your real preferences the moment anything changed — every setting reset, with no warning and no way back. Nothing was lost: the flaw needed a future version to trigger it, and this closed it first.",
+                    "Restoring a backup, or using either Relaunch Ice 2 button, brings Ice 2 back (2.12.0). Ice 2 asked macOS to reopen it before quitting, while it was still running — so macOS brought the running copy to the front, reported success, and the quit that followed left nothing running at all. Ice 2 disappeared and did not come back.",
+                    "Restoring a damaged backup now refuses the file instead of erasing everything (2.12.1). Handing Settings ▸ Backup & Restore a corrupted backup cleared your entire settings store rather than declining to read it, so one bad file could take your working preferences with it.",
+                    "The Layout pane keeps up with your menu bar again (2.12.0). Applying a layout profile rearranged the real menu bar immediately, but the Visible / Hidden / Always-Hidden bars in Settings could go on showing the old arrangement for up to half a minute. They now catch up about a second after the last item moves. The same staleness could affect the profile being applied: if you dragged an item and pressed Apply within a second of it, Ice 2 worked from the layout as it was before your drag and moved the wrong items.",
+                    "Dragging an item between sections no longer freezes the section you took it from (2.12.0). Ice 2 pauses a section's bar while you drag out of it so it doesn't rearrange under your cursor, but it only unpaused the section you dropped into. Drag from Hidden to Visible and the Hidden bar stopped updating for good, so an item that had moved kept showing in both places — closing and reopening Settings was the only way out.",
+                    "Menu bar item icons refresh while you are looking at them (2.12.0). Ice 2 only redraws its picture of your menu bar items while the pane that displays them is open, which is the Layout pane. Since 2.8.0 it had been checking for the Appearance pane instead — the one pane that shows no item icons — so the icons in the layout bars were whatever had been captured on some earlier visit, and a capture that failed kept showing a lettered placeholder.",
+                    "A failed uninstall says so (2.12.1). If uninstalling Ice 2 hit a problem partway through, it quit reporting success anyway — after it had already torn your settings down.",
+                    "VoiceOver can tell the menu bar shape buttons apart (2.12.1). In Settings ▸ Appearance, the buttons that choose how each end of the menu bar shape is drawn were pictures with no name attached, so picking a shape without looking at the screen meant guessing. They now read as \"Square cap\" and \"Round cap\". The tooltips you see on hover are unchanged.",
+                    "Hardened the connection to Ice 2's bundled helper (2.12.1). Ice 2 asks a small helper process which app each menu bar item belongs to. When that connection was interrupted, the code that cleared it skipped the lock guarding every other use of it, so a cleanup and an in-flight request could overlap — a dropped request at best, a crash at worst. Every access now goes through the same lock.",
                 ]),
                 ChangeSection(kind: .changed, entries: [
-                    "If you are coming from 2.9.x: uninstalling Ice 2 has moved into Settings. It used to be an Uninstall item in the Ice 2 menu that opened a separate window; since 2.10.0 it is the last pane in the Settings sidebar, with the confirmation right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state. That flow was rewritten in 2.10.0 on top of the shared framework — the same steps, covered by automated tests, but it is a rewrite of a destructive, one-way path, so please report anything that misbehaves.",
+                    "If you are coming from 2.9.x: uninstalling Ice 2 has moved into Settings. It used to be an Uninstall item in the Ice 2 menu that opened a separate window; since 2.10.0 it is the last pane in the Settings sidebar, with the confirmation right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state.",
                 ]),
             ]
         )

--- a/Ice/Utilities/Constants.swift
+++ b/Ice/Utilities/Constants.swift
@@ -15,4 +15,29 @@ enum Constants {
     static let displayName = Bundle.main.displayName!
 
     // swiftlint:enable force_unwrapping
+
+    /// The bundle identifier of the installed release, which the local debug build extends with
+    /// `.debug`. The *running* build's id is ``bundleIdentifier`` — this one names the other end
+    /// of that pair, so use it only to ask which build is which.
+    static let releaseBundleIdentifier = "com.dragonapp.ice"
+
+    /// Whether `bundleID` belongs to any build of Ice 2 — the installed release or a `.debug`
+    /// build running beside it.
+    ///
+    /// Ice 2 acts on other running applications in several places: it quits and relaunches every
+    /// app with a menu bar item to apply a spacing offset, and it offers the frontmost app as a
+    /// section trigger. Each of those treated the *other* Ice build as an unrelated third-party
+    /// app, so applying a spacing offset in the debug build terminated the installed release —
+    /// which `MAC-APP-RELEASE-LIFECYCLE.md` forbids outright, because the two are required to
+    /// survive being run at once. `NSRunningApplication.current` only ever excludes this process.
+    ///
+    /// One predicate rather than a string comparison repeated per call site: the sites are far
+    /// apart, and the next one added is the one that would forget. Matched on a dot boundary, so
+    /// an unrelated app whose id merely starts with the same letters is still treated as foreign.
+    static func isIceBundleID(_ bundleID: String?) -> Bool {
+        guard let bundleID else {
+            return false
+        }
+        return bundleID == releaseBundleIdentifier || bundleID.hasPrefix("\(releaseBundleIdentifier).")
+    }
 }

--- a/IceTests/SettingsBackupTests.swift
+++ b/IceTests/SettingsBackupTests.swift
@@ -242,7 +242,20 @@ struct SettingsBackupTests {
 
     @Test func defaultFolderIsDocumentsIceBackups() {
         let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
-        #expect(SettingsBackup.defaultFolder(home: home).path == "/Users/test/Documents/Ice Backups")
+        let folder = SettingsBackup.defaultFolder(home: home, bundleID: "com.dragonapp.ice")
+        #expect(folder.path == "/Users/test/Documents/Ice Backups")
+    }
+
+    /// Only the installed release gets the plain folder. Both builds used to share it, and
+    /// `prune(in:keeping:)` counts files rather than builds — so a debug build's automatic
+    /// on-quit backups eventually deleted the release's. An id it can't state falls to the
+    /// Debug folder too, away from the release user's documents.
+    @Test func defaultFolderIsNamespacedForAnythingButTheRelease() {
+        let home = URL(fileURLWithPath: "/Users/test", isDirectory: true)
+        for id in ["com.dragonapp.ice.debug", nil] {
+            let folder = SettingsBackup.defaultFolder(home: home, bundleID: id)
+            #expect(folder.path == "/Users/test/Documents/Ice Backups (Debug)")
+        }
     }
 
     @Test func configuredFolderUsesStoredPathWhenSet() {

--- a/IceTests/SmokeTests.swift
+++ b/IceTests/SmokeTests.swift
@@ -50,15 +50,18 @@ struct SmokeTests {
         #expect(service.bundleIdentifier == MenuBarItemService.name)
     }
 
-    /// `applyOffset()` relaunches every app with a menu bar item, and a relaunch is a terminate.
-    /// The other build of Ice 2 has to be exempt: the lifecycle spec requires that changing a
-    /// setting in the debug build never terminates the installed release.
-    @Test @MainActor func everyIceBuildIsRecognizedAsOurOwn() {
-        #expect(MenuBarItemSpacingManager.isAnIceBundleID("com.dragonapp.ice"))
-        #expect(MenuBarItemSpacingManager.isAnIceBundleID("com.dragonapp.ice.debug"))
+    /// Every site that acts on another running application asks this one predicate whether the
+    /// app is one of ours: `applyOffset()` quits and relaunches every app with a menu bar item,
+    /// and a relaunch is a terminate, which the lifecycle spec forbids the debug build from
+    /// doing to the installed release. `MenuBarTriggerSettings` asks it too.
+    @Test func everyIceBuildIsRecognizedAsOurOwn() {
+        #expect(Constants.isIceBundleID("com.dragonapp.ice"))
+        #expect(Constants.isIceBundleID("com.dragonapp.ice.debug"))
+        // The running build is always one of ours, whichever build the suite is hosted in.
+        #expect(Constants.isIceBundleID(Constants.bundleIdentifier))
         // Neither an unrelated app that merely starts with the same letters, nor a missing id.
-        #expect(!MenuBarItemSpacingManager.isAnIceBundleID("com.dragonapp.iceberg"))
-        #expect(!MenuBarItemSpacingManager.isAnIceBundleID("com.apple.controlcenter"))
-        #expect(!MenuBarItemSpacingManager.isAnIceBundleID(nil))
+        #expect(!Constants.isIceBundleID("com.dragonapp.iceberg"))
+        #expect(!Constants.isIceBundleID("com.apple.controlcenter"))
+        #expect(!Constants.isIceBundleID(nil))
     }
 }

--- a/IceTests/SmokeTests.swift
+++ b/IceTests/SmokeTests.swift
@@ -31,4 +31,34 @@ struct SmokeTests {
     @Test func testHostNeverOwnsTheReleaseSettingsDomain() {
         #expect(Bundle.main.bundleIdentifier == "com.dragonapp.ice.debug")
     }
+
+    /// The XPC service name the app connects to has to be the identifier the embedded service
+    /// bundle actually registers under, and both have to be namespaced per build.
+    ///
+    /// `MenuBarItemService.name` was the literal `com.dragonapp.ice.MenuBarItemService`, so the
+    /// debug build and an installed release asked launchd for one name and could not be trusted
+    /// to run side by side. Deriving it from `Bundle.main` fixes the client, but only if the XPC
+    /// target's `PRODUCT_BUNDLE_IDENTIFIER` moves with it — the two live in different files and
+    /// a mismatch is silent at build time and fatal at runtime (no service, so every menu bar
+    /// item loses its source PID). Reading the embedded bundle checks the pair together.
+    @Test func serviceNameMatchesTheEmbeddedServiceBundleIdentifier() throws {
+        #expect(MenuBarItemService.name == "com.dragonapp.ice.debug.MenuBarItemService")
+
+        let url = Bundle.main.bundleURL
+            .appending(path: "Contents/XPCServices/MenuBarItemService.xpc")
+        let service = try #require(Bundle(url: url), "the app must embed the XPC service")
+        #expect(service.bundleIdentifier == MenuBarItemService.name)
+    }
+
+    /// `applyOffset()` relaunches every app with a menu bar item, and a relaunch is a terminate.
+    /// The other build of Ice 2 has to be exempt: the lifecycle spec requires that changing a
+    /// setting in the debug build never terminates the installed release.
+    @Test @MainActor func everyIceBuildIsRecognizedAsOurOwn() {
+        #expect(MenuBarItemSpacingManager.isAnIceBundleID("com.dragonapp.ice"))
+        #expect(MenuBarItemSpacingManager.isAnIceBundleID("com.dragonapp.ice.debug"))
+        // Neither an unrelated app that merely starts with the same letters, nor a missing id.
+        #expect(!MenuBarItemSpacingManager.isAnIceBundleID("com.dragonapp.iceberg"))
+        #expect(!MenuBarItemSpacingManager.isAnIceBundleID("com.apple.controlcenter"))
+        #expect(!MenuBarItemSpacingManager.isAnIceBundleID(nil))
+    }
 }

--- a/Shared/Services/MenuBarItemService.swift
+++ b/Shared/Services/MenuBarItemService.swift
@@ -6,7 +6,41 @@
 import Foundation
 
 enum MenuBarItemService {
-    static let name = "com.dragonapp.ice.MenuBarItemService"
+    /// The suffix the XPC service's bundle identifier adds to its containing app's.
+    private static let suffix = "MenuBarItemService"
+
+    /// The identifier of the release app's XPC service — the fallback for a process that
+    /// cannot state its own bundle id, and the value ``name`` derives in a release build.
+    private static let releaseName = "com.dragonapp.ice.\(suffix)"
+
+    /// The name the app connects to and the service listens on.
+    ///
+    /// Derived from the running bundle rather than hardcoded, because the Debug configuration
+    /// builds the app as `com.dragonapp.ice.debug` while this constant named the release
+    /// service outright. Both builds then asked launchd for the one name
+    /// `com.dragonapp.ice.MenuBarItemService`, so an installed release and a local debug build
+    /// could not be trusted to run side by side — the lifecycle spec's simultaneous-run
+    /// requirement — and the debug app's embedded service wasn't even namespaced under its own
+    /// app, which is what macOS expects of a bundled XPC service.
+    ///
+    /// This file compiles into *both* processes, and `Bundle.main` means different things in
+    /// each: the app is `com.dragonapp.ice[.debug]`, the service is that plus `.\(suffix)`.
+    /// Appending unconditionally would make the service listen on
+    /// `…MenuBarItemService.MenuBarItemService` and never be reachable, so the suffix is added
+    /// only when it isn't already there. One expression, two processes, no way for the client's
+    /// name and the listener's name to drift apart.
+    ///
+    /// The value must stay equal to the XPC target's `PRODUCT_BUNDLE_IDENTIFIER` in
+    /// `Ice.xcodeproj` (`com.dragonapp.ice.MenuBarItemService` in Release,
+    /// `com.dragonapp.ice.debug.MenuBarItemService` in Debug) — that identifier is what launchd
+    /// registers the embedded service under, and a bundled XPC service has no `MachServices`
+    /// declaration of its own to state it a second time.
+    static let name: String = {
+        guard let bundleID = Bundle.main.bundleIdentifier else {
+            return releaseName
+        }
+        return bundleID.hasSuffix(".\(suffix)") ? bundleID : "\(bundleID).\(suffix)"
+    }()
 }
 
 extension MenuBarItemService {

--- a/scripts/run-debug.sh
+++ b/scripts/run-debug.sh
@@ -21,9 +21,20 @@
 # PRODUCT_MODULE_NAME is pinned to Ice_2 so the Swift module keeps the name
 # IceTests imports; TEST_HOST points at the Debug product by its own name.
 #
-# What the script stamps afterwards (both need the built bundle to exist):
+# What the script stamps afterwards (all of them need the built bundle to exist):
 #   CFBundleVersion             the git commit count, never a hardcoded number
-#   CFBundleShortVersionString  suffixed "(Debug)"
+#   DragonCommitDate            the commit's own timestamp
+#   DragonBuildChannel          "Debug", which DragonKit renders as "vX.Y.Z Debug (<build>)"
+#   SUEnableAutomaticChecks     false, so a debug build never schedules a production check
+# and what it deletes:
+#   SUFeedURL                   so the production appcast is unreachable from this bundle
+#
+# CFBundleShortVersionString is asserted to be numeric X.Y.Z and is never modified. It used to
+# be suffixed " (Debug)" here; MAC-APP-RELEASE-LIFECYCLE.md forbids that outright, because that
+# field is the sole source of truth for the version the public `vX.Y.Z` tag is checked against,
+# and a debug build is the *same* numeric candidate as the next release — "Debug" is a channel
+# label, never part of a version number. DragonKit 3.3.0's DragonAbout.buildChannel(_:) reads
+# DragonBuildChannel and renders the label beside the version instead.
 #
 # Usage: bash scripts/run-debug.sh
 #
@@ -89,20 +100,42 @@ if [[ -n "$commit_date" ]]; then
     || "$pb" -c "Add :DragonCommitDate string $commit_date" "$plist"
 fi
 
-# Mark the version itself, not just the name: the About pane and any log line that
-# reports a version should say "(Debug)" outright, so a screenshot or a log excerpt
-# can never be mistaken for the release build. Derived from whatever the project's
-# MARKETING_VERSION currently is, so it cannot drift out of sync on a version bump.
+# The version field is read, never written. It carries the numeric candidate this debug build
+# is testing towards — the very number a later `vX.Y.Z` tag is asserted against — so anything
+# appended to it (this script used to append " (Debug)") makes the release gate compare a tag
+# against a non-numeric string. Fail loudly instead: a candidate that isn't X.Y.Z means the
+# project's MARKETING_VERSION is wrong, and every downstream stamp would inherit that.
 short_version="$("$pb" -c "Print :CFBundleShortVersionString" "$plist")"
-if [[ "$short_version" != *"(Debug)" ]]; then
-  short_version="$short_version (Debug)"
-  "$pb" -c "Set :CFBundleShortVersionString $short_version" "$plist"
+if [[ ! "$short_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: non-numeric candidate version: '$short_version'." >&2
+  echo "       CFBundleShortVersionString must stay X.Y.Z — 'Debug' is a build channel," >&2
+  echo "       stamped below as DragonBuildChannel, never part of a version number." >&2
+  exit 1
 fi
+
+# The channel label the version field must not carry. DragonKit 3.3.0's
+# DragonAbout.versionString() reads this key and renders "v2.14.1 Debug (1346) · …", so About,
+# logs and screenshots still say Debug outright while the number stays the release candidate.
+"$pb" -c "Set :DragonBuildChannel Debug" "$plist" 2>/dev/null \
+  || "$pb" -c "Add :DragonBuildChannel string Debug" "$plist"
+
+# Production updating off, two ways. The plist default only sets what Sparkle does when the
+# user has expressed no preference — and user defaults win, so someone who once enabled
+# scheduled checks in this debug build's own domain would still get them. Deleting SUFeedURL
+# is what actually makes the production appcast unreachable: DragonUpdater's lazy SPUUpdater
+# fails to start without a feed, so DragonKit's Updates pane (kit-owned UI this app cannot
+# make channel-aware) renders inert instead of checking the real feed. The runtime guards in
+# UpdatesManager remain the primary defence; this is belt and braces, per the
+# `macos-debug-build` skill.
+if "$pb" -c "Print :SUEnableAutomaticChecks" "$plist" >/dev/null 2>&1; then
+  "$pb" -c "Set :SUEnableAutomaticChecks false" "$plist"
+fi
+"$pb" -c "Delete :SUFeedURL" "$plist" 2>/dev/null || true
 
 # Editing Info.plist invalidates the code signature, so re-sign. Ad-hoc and deep:
 # the bundle carries Sparkle.framework and the MenuBarItemService XPC, and a broken
 # signature on either makes the app fail to launch rather than fail visibly.
-echo "==> Re-signing after stamping $short_version ($build_number)…"
+echo "==> Re-signing after stamping Debug channel, v$short_version ($build_number)…"
 codesign --force --deep --sign - "$app" >/dev/null 2>&1
 
 # Launched by exec rather than `open` on purpose. Older builds of this repo left
@@ -115,10 +148,14 @@ sleep 1
 
 cat <<EOF
 
-Launched "$DEBUG_NAME" $short_version (build $build_number), id $DEBUG_ID, from:
+Launched "$DEBUG_NAME" v$short_version Debug (build $build_number), id $DEBUG_ID, from:
   $app
 
+- v$short_version is the numeric candidate for the next public release; "Debug" is the
+  build channel, not part of the version.
 - Grant Accessibility / Screen Recording to "$DEBUG_NAME" in its Permissions
   window if you want full functionality (separate from your installed Ice 2).
 - Ad-hoc signature changes each rebuild, so macOS may ask you to re-grant.
+- Updating is disabled in this build: no scheduled checks, no Check for Updates…
+  item in the menu, and no production feed in the bundle.
 EOF


### PR DESCRIPTION
Adopts [`docs/MAC-APP-RELEASE-LIFECYCLE.md`](https://github.com/teddychan/dragon-kit/blob/main/docs/MAC-APP-RELEASE-LIFECYCLE.md) and bumps to the 2.14.2 candidate. DragonKit pin 3.2.0 → 3.3.0.

## Three defects fixed

**Changing spacing in a Debug build terminated and relaunched the installed release.** `applyOffset()` exempted only `.current`, so it treated a sibling Ice build as any other app to restart. Any Ice bundle id is now exempt.

**Debug backups deleted the release's backups.** `~/Documents/Ice Backups` was one shared folder, and `prune(in:keeping:)` keeps the newest *files*, not the newest per build. With on-quit backups on by default, ten Debug quits removed every backup the installed release had written — and "restore newest" in the release app could restore Debug settings. Debug now defaults to `~/Documents/Ice Backups (Debug)`.

**Both builds embedded an XPC service claiming one identifier.** `MenuBarItemService.name` was the hardcoded constant `com.dragonapp.ice.MenuBarItemService`, and the Debug app's service was not namespaced under its own app id. Client (`MenuBarItemServiceConnection`), server (`Listener`) and registration (`PRODUCT_BUNDLE_IDENTIFIER`, merged into the bundle's `CFBundleIdentifier`) were all traced. There is no `MachServices` key to change — for a bundled XPCService the bundle identifier *is* the registration. Note `Shared/` compiles into **both** targets and `Bundle.main` differs between them, so the derivation appends the suffix only when it is not already the bundle's tail; naive appending would have produced `…MenuBarItemService.MenuBarItemService` and permanently broken the listener. Proven at runtime by a new test.

A fourth, found while generalising the rule: `MenuBarTriggerSettings` excluded only the current process, so with both builds running each offered the other as a trigger target and would fire triggers on it. The predicate is now `Constants.isIceBundleID`, used at all three sites and pinned by a test.

## Debug identity

`(Debug)` no longer goes into `CFBundleShortVersionString`. The label comes from `DragonBuildChannel`, rendered by DragonKit 3.3.0 as `v2.14.2 Debug (1359)`. `SUFeedURL` is deleted from the Debug plist, so Sparkle cannot start and every updater route is inert. `#if DEBUG` is kept alongside `DragonAbout.isDebugBuild()` on purpose: an Xcode ⌘R build is never stamped by `run-debug.sh` and would otherwise reach the production appcast.

## What's New — four releases of backlog

The pane still described 2.11.0 (dated 2026-08-04) and was never updated for 2.12.0, 2.12.1, 2.13.0 or 2.14.0. Now current, grouped by kind, each entry naming its release:

- **Added** — new menu-bar icons appear where you can see them (2.14.0)
- **Removed** — **Item groups are gone** (2.12.0), which silently deleted saved groups on update and was never announced in-app
- **Fixed** — nine 2.12.0/2.12.1 items, settings-wipe risk first
- **Changed** — the "coming from 2.9.x, Uninstall moved" note, kept because a 2.9.x user jumping here would otherwise never see it

2.13.0 and 2.14.1 were framework bumps only and are absent rather than padded. 2.14.2 itself says plainly that nothing visible changed.

## Verification

```
swiftlint lint --strict        0 violations in 116 files
xcodebuild test                320 tests in 37 suites — TEST SUCCEEDED
dragon-conformance.py          PASS — no violations
```

`MARKETING_VERSION` moved only on the two "Ice 2" configurations; the XPC target correctly stayed at `1.0`:

```
725  Debug    "Ice 2 Debug"     2.14.1 -> 2.14.2
761  Release  "Ice 2"           2.14.1 -> 2.14.2
783  Debug    MenuBarItemService  1.0  ->  1.0
809  Release  MenuBarItemService  1.0  ->  1.0
```

dragon-kit reads 3.3.0 through the anchored regex; Sparkle has no `minimumVersion` in the pbxproj at all (it arrives transitively via `DragonKitUpdates`), so it could not have been touched. The pin bump was proven non-vacuous by temporarily restoring 3.2.0 and confirming R10 fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)