### PR TITLE
ci: move the release to dragon-release-ci @v6, with whats_new_path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,20 @@ permissions:
 
 jobs:
   release:
-    uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v5
+    uses: teddychan/dragon-release-ci/.github/workflows/release-macos.yml@v6
     secrets: inherit
     with:
+      # v6's tag gate replaces v5's `VERSION=${TAG##*v}`, which left a value containing no "v"
+      # untouched — so a workflow_dispatch arrived with a BRANCH ref and produced VERSION=main.
+      # It also accepts only exact `vX.Y.Z`, and requires whats_new_path: the two move together,
+      # because passing whats_new_path to v5 fails at startup (v5 does not define the input) and
+      # omitting it on v6 fails the gate.
+      #
+      # Ice 2's notes are raw Swift string literals — English-only, no Localizable.strings in the
+      # repo at all — so the text a user reads is in this one file and watching it is a real
+      # check. spectacle-2 and yahoo-keykey-2 keep theirs behind abstract `L()` keys and have to
+      # list their translations as well.
+      whats_new_path: Ice/Settings/WhatsNewConfig.swift
       build_kind: xcodebuild
       # Ice 2 targets the macOS 26 SDK, so build on a macos-26 runner (the
       # default macos-15 image lacks the SDK). This input drives the job's


### PR DESCRIPTION
Both halves in one commit, because either alone breaks the release:

| | on `@v5` | on `@v6` |
|---|---|---|
| `whats_new_path` passed | **startup_failure** — v5 does not define the input; 0 jobs, empty log | required, gate runs |
| `whats_new_path` omitted | (today) | **gate fails** — a check that cannot fail is worse than no check |

## What `@v6` changes for this repo

- The tag gate accepts only an exact public `vX.Y.Z`. v5 derived the version with `VERSION=${TAG##*v}`, which leaves a value containing no `v` untouched — so a `workflow_dispatch`, whose ref is a **branch**, produced `VERSION=main`. A branch name can never become a release version.
- The preceding-tag lookup ignores non-`vX.Y.Z` families, so a historical prefixed tag can never become the baseline the What's New diff is measured against.
- Every `workflow_call` secret is optional, so a verification-only run is possible in a repo missing one.
- `whats_new_path` is required, and the gate also rejects an explicit `version:` argument to `WhatsNewContent` and notes that say nothing.

## `whats_new_path`

One entry: `Ice/Settings/WhatsNewConfig.swift`.

Ice 2's notes are raw Swift string literals and the repo ships no `Localizable.strings` at all, so the text a user reads is in this one file and watching it means what it says.

## Verification

- Every listed path exists in the checkout and is what git tracks — the gate `[ -f ]`-stats each one and fails on a typo, so a silently narrowed diff is not possible.
- The config file passes the gate's other two checks: no explicit `version:`, and a `ChangeSection` is present.
- `actionlint` clean.
- `dragon-release-ci` @v6's own suites pass: `scripts/test-tag-gate.sh` → 42 passed, `scripts/test-workflow-contract.py` → 77 passed.
- `permissions: contents: write` was already declared here and is unchanged — the reusable call is rejected at startup without it.

## One consequence to know

`workflow_dispatch` on this repo declares no inputs, so a manual run arrives with no tag, `release_tag` empty and `verify_only` false — and the gate correctly refuses it rather than inventing a version. Nothing is signed or published when it does. Adding the two dispatch inputs (guarded on `github.event_name`, the way dragon-sample-app does) is what would make manual verification runs possible; deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)