### PR TITLE
release: 2.14.3 — publish the appcast here as well as the site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,40 @@ jobs:
       # runs-on for all build kinds, not just swiftpm.
       swiftpm_runner: macos-26
       app_slug: ice-2
+      # Step 1 of 2 in moving the appcast off the marketing site.
+      #
+      # MAC-APP-RELEASE-LIFECYCLE.md: "Sparkle appcasts are update infrastructure, not marketing
+      # content. Each app should host its production appcast in its own repository so an outage,
+      # permission problem, or rejected change in the marketing-site repository cannot interfere
+      # with update delivery." Until now this caller passed no appcast_repo at all and took the
+      # default, teddychan/www.dragonapp.com. spectacle-2, dragon-sample-app and clipmenu-2 have
+      # migrated; yahoo-keykey-2 has not.
+      #
+      # The same spec says to migrate "by mirroring the old and new locations until installed
+      # versions have moved to the app-owned URL", which is why this is two releases and not one.
+      # Every ALREADY-INSTALLED Ice 2 reads SUFeedURL from the site, so flipping the destination
+      # alone would leave all of them silently unable to see updates.
+      #
+      #   step 1 (here)  publish to BOTH. Ice/Resources/Info.plist keeps pointing at the site,
+      #                  which is still being written, so nothing changes for anyone — but the
+      #                  app-owned feed now exists and is current.
+      #   step 2 (next)  move SUFeedURL to
+      #                  https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml
+      #                  once step 1 has actually populated it.
+      #   later          drop appcast_mirror_repo when no supported version still reads the site.
+      #
+      # Needs dragon-release-ci >= v6.3.0. The appcast is generated once and copied to both, so
+      # the two locations cannot disagree. Publishing to this repo uses the built-in GITHUB_TOKEN
+      # (contents: write is granted above); the mirror is a different repo and so needs
+      # PUBLIC_RELEASE_TOKEN, which `secrets: inherit` already supplies — the same token that
+      # publishes to the site today. A missing mirror token is a hard error, not a warning.
+      #
+      # Ice 2 is the first xcodebuild-built app to use this: generate_appcast is located under the
+      # derived-data SourcePackages artifacts (generate_appcast_glob: xcodebuild, below) rather
+      # than a SwiftPM .build directory. That lookup is unchanged and already runs on every
+      # release — only the publish destinations move.
+      appcast_repo: teddychan/ice-2
+      appcast_mirror_repo: teddychan/www.dragonapp.com
       release_title_prefix: Ice 2
       bot_name: Ice 2 Release Bot
       xcode_project: Ice.xcodeproj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2.14.3 - 2026-08-11
+
+### Internal
+
+- **Ice 2's Sparkle appcast is now published to this repository as well as the marketing site.**
+  Step 1 of 2 in giving the app its own update feed, per dragon-kit's
+  `docs/MAC-APP-RELEASE-LIFECYCLE.md`: "Sparkle appcasts are update infrastructure, not marketing
+  content. Each app should host its production appcast in its own repository so an outage,
+  permission problem, or rejected change in the marketing-site repository cannot interfere with
+  update delivery."
+
+  Nothing changes for anyone who has Ice 2 installed. `SUFeedURL` still points at
+  `www.dragonapp.com/ice-2/appcast.xml`, which is still being written; this release is what first
+  creates `docs/ice-2/appcast.xml` here. Step 2 moves `SUFeedURL` to the app-owned URL, and only a
+  release after which no supported version reads the site may drop the mirror. Flipping the two at
+  once would have pointed every installed copy at a feed that did not exist yet.
+
+  Ice 2 is the first xcodebuild-built app to use this configuration; the `generate_appcast` lookup
+  is unchanged and only the publish destinations move.
+
+- The release also moved to `dragon-release-ci@v6` with `whats_new_path`, which had landed on
+  `main` without a release of its own. v6's tag gate accepts only an exact `vX.Y.Z` and requires
+  the What's New source to have changed since the preceding tag.
+
 ## 2.14.1 - 2026-08-10
 
 ### Internal

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.2;
+				MARKETING_VERSION = 2.14.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.2;
+				MARKETING_VERSION = 2.14.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -20,12 +20,14 @@ import DragonKit
 enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
-            date: "2026-08-10",
+            date: "2026-08-11",
             summary: """
-                A maintenance release: nothing you can see behaves differently. Its fixes \
-                all concern keeping a development build of Ice 2 separate from the copy you \
-                have installed. These notes also catch up on 2.12.0 through 2.14.0, which \
-                shipped without being announced here.
+                A maintenance release: nothing you can see behaves differently. Ice 2 now \
+                publishes the file it checks for updates to its own home as well as the \
+                website, so a problem with the website cannot hold up an update — the copy \
+                you have installed keeps reading the website until a later version moves it \
+                over. These notes also catch up on 2.12.0 through 2.14.0, which shipped \
+                without being announced here.
                 """,
             sections: [
                 ChangeSection(kind: .added, entries: [


### PR DESCRIPTION
Step 1 of 2 in taking Ice 2's Sparkle appcast off the marketing site.

This caller passed **no `appcast_repo` at all**, so it silently took the shared workflow's default, `teddychan/www.dragonapp.com`. It now names `teddychan/ice-2` as the appcast repo and the site as `appcast_mirror_repo`.

dragon-kit's [`docs/MAC-APP-RELEASE-LIFECYCLE.md`](https://github.com/teddychan/dragon-kit/blob/main/docs/MAC-APP-RELEASE-LIFECYCLE.md):

> Sparkle appcasts are update infrastructure, not marketing content. Each app should host its production appcast in its own repository so an outage, permission problem, or rejected change in the marketing-site repository cannot interfere with update delivery.

## Two releases, not one

The same spec says to migrate "by mirroring the old and new locations until installed versions have moved to the app-owned URL".

`Ice/Resources/Info.plist` still points `SUFeedURL` at `www.dragonapp.com/ice-2/appcast.xml`, which is **still being written**, so nothing changes for anyone with Ice 2 installed — but `docs/ice-2/appcast.xml` comes into existence here and is current. Step 2 moves `SUFeedURL`; only a release after which no supported version reads the site may drop the mirror.

Flipping both at once would have pointed every install at a feed that does not exist. Verified before this change: `raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml` → **HTTP 404**; the site's → **HTTP 200**.

clipmenu-2 completed both steps today (`v2.20.3`, `v2.20.4`) and both of its feeds resolve to 2.20.4 — old installs via the mirror, new ones via the app-owned URL.

## First xcodebuild app on this config

Only the publish destinations move. `generate_appcast` is still located under the derived-data `SourcePackages/artifacts` (`generate_appcast_glob: xcodebuild`), unchanged, and that lookup already runs on every release. `publish_appcast_to` is front-end agnostic. Tokens: this repo grants `contents: write` so the primary uses the built-in `GITHUB_TOKEN`; the mirror is a different repo and needs `PUBLIC_RELEASE_TOKEN`, which `secrets: inherit` already supplies — the same token that publishes to the site today.

## Also in this release

`a596c7c`, the move to `dragon-release-ci@v6` with `whats_new_path`, landed on `main` without a release of its own.

## Version

`MARKETING_VERSION` 2.14.2 → 2.14.3 on the **Ice target's two configurations only**. `MenuBarItemService`'s two stay at `1.0`.

The What's New notes stay cumulative, as their own doc comment explains — this pane went four releases without an update once — and the summary now describes 2.14.3.

## Verification

- `xcodebuild test -project Ice.xcodeproj -scheme Ice` — **320 tests in 37 suites, TEST SUCCEEDED**
- `swiftlint lint --strict` — **0 violations, 0 serious in 116 files**
- `dragon-conformance.py` — PASS, no violations
- `actionlint .github/workflows/release.yml` — clean
- dragon-release-ci v6.3.0's real `tag-gate.sh` against a simulated `v2.14.3` — **gate passed**, preceding tag `v2.14.2`, What's New changed

## Noted, not fixed

`CHANGELOG.md` has **no 2.14.2 entry** — that release shipped without one, so 2.14.3 now sits directly above 2.14.1. Pre-existing and left alone rather than widened into this PR.