### PR TITLE
release: 2.14.4 — the update feed moves to this repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,27 +43,29 @@ jobs:
       # runs-on for all build kinds, not just swiftpm.
       swiftpm_runner: macos-26
       app_slug: ice-2
-      # Step 1 of 2 in moving the appcast off the marketing site.
+      # Moving the appcast off the marketing site. Steps 1 and 2 are done; the mirror stays.
       #
       # MAC-APP-RELEASE-LIFECYCLE.md: "Sparkle appcasts are update infrastructure, not marketing
       # content. Each app should host its production appcast in its own repository so an outage,
       # permission problem, or rejected change in the marketing-site repository cannot interfere
-      # with update delivery." Until now this caller passed no appcast_repo at all and took the
-      # default, teddychan/www.dragonapp.com. spectacle-2, dragon-sample-app and clipmenu-2 have
-      # migrated; yahoo-keykey-2 has not.
+      # with update delivery." This caller used to pass no appcast_repo at all and so took the
+      # default, teddychan/www.dragonapp.com. spectacle-2, dragon-sample-app and clipmenu-2 had
+      # already migrated; yahoo-keykey-2 has not.
       #
       # The same spec says to migrate "by mirroring the old and new locations until installed
-      # versions have moved to the app-owned URL", which is why this is two releases and not one.
-      # Every ALREADY-INSTALLED Ice 2 reads SUFeedURL from the site, so flipping the destination
-      # alone would leave all of them silently unable to see updates.
+      # versions have moved to the app-owned URL", which is why this was two releases and not one.
+      # Every Ice 2 installed at the time read SUFeedURL from the site, so flipping the destination
+      # alone would have left all of them silently unable to see updates.
       #
-      #   step 1 (here)  publish to BOTH. Ice/Resources/Info.plist keeps pointing at the site,
-      #                  which is still being written, so nothing changes for anyone — but the
-      #                  app-owned feed now exists and is current.
-      #   step 2 (next)  move SUFeedURL to
-      #                  https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml
-      #                  once step 1 has actually populated it.
-      #   later          drop appcast_mirror_repo when no supported version still reads the site.
+      #   step 1  v2.14.3  published to BOTH, with Ice/Resources/Info.plist still pointing at the
+      #                    site, so nothing changed for anyone — but the app-owned feed came into
+      #                    existence and was current. Both copies verified byte-identical after.
+      #   step 2  v2.14.4  SUFeedURL moved to
+      #                    https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml
+      #   later            drop appcast_mirror_repo when no supported version still reads the site.
+      #
+      # Do not drop the mirror early. Every copy still at 2.14.3 or older reads the site and only
+      # the site; the mirror is the whole reason flipping SUFeedURL did not strand them.
       #
       # Needs dragon-release-ci >= v6.3.0. The appcast is generated once and copied to both, so
       # the two locations cannot disagree. Publishing to this repo uses the built-in GITHUB_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.14.4 - 2026-08-11
+
+### Internal
+
+- **`SUFeedURL` now points at this repository** —
+  `raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml` — instead of
+  `www.dragonapp.com/ice-2/appcast.xml`. Step 2 of 2, completing what 2.14.3 began.
+
+  2.14.3 was step 1: it made this repository the appcast's home while keeping the marketing
+  site as a mirror, which is what first created `docs/ice-2/appcast.xml` here. Only after that
+  had actually run could the app be pointed at it — flipping both at once would have sent every
+  installed copy to a feed that did not exist. Verified before this change: both copies exist
+  and are byte-identical (sha256 `a3498f5…`), and the new URL serves 200.
+
+  The mirror deliberately stays. Every copy at 2.14.3 or earlier still reads the site, and only
+  a release after which no supported version does may drop it.
+
 ## 2.14.3 - 2026-08-11
 
 ### Internal

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.3;
+				MARKETING_VERSION = 2.14.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.3;
+				MARKETING_VERSION = 2.14.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Resources/Info.plist
+++ b/Ice/Resources/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://www.dragonapp.com/ice-2/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>p+F/ivF5bAYcmuNuCMNHcRv123A6LHFpCBagFm7Adu8=</string>
 	<!-- The default for scheduled background update checks. Two jobs: it stops Sparkle

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -23,11 +23,9 @@ enum WhatsNewConfig {
             date: "2026-08-11",
             summary: """
                 A maintenance release: nothing you can see behaves differently. Ice 2 now \
-                publishes the file it checks for updates to its own home as well as the \
-                website, so a problem with the website cannot hold up an update — the copy \
-                you have installed keeps reading the website until a later version moves it \
-                over. These notes also catch up on 2.12.0 through 2.14.0, which shipped \
-                without being announced here.
+                checks for updates at its own home rather than the website, so a problem \
+                with the website can no longer hold up an update. These notes also catch up \
+                on 2.12.0 through 2.14.0, which shipped without being announced here.
                 """,
             sections: [
                 ChangeSection(kind: .added, entries: [


### PR DESCRIPTION
Step 2 of 2, completing what `v2.14.3` began. `SUFeedURL` now reads

```
https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml
```

instead of `https://www.dragonapp.com/ice-2/appcast.xml`.

## Step 1 actually ran first

`v2.14.3` made this repository the appcast's home while keeping the site as a mirror, which is what created `docs/ice-2/appcast.xml` here. Only after that had run could the app be pointed at it — flipping both at once would have sent every installed copy to a feed that did not exist.

Verified on the released `v2.14.3` before making this change:

| Check | Result |
|---|---|
| `docs/ice-2/appcast.xml` in ice-2 | present, 874 bytes |
| same path in www.dragonapp.com | present, 874 bytes |
| byte-identical | ✅ sha256 `a3498f5cb9e6a0ef38af9b82504230020ecfc174bfeee29b68bed2edf6481336` |
| new URL serves | `HTTP 200` |
| `sparkle:version` monotonic | 1359 (2.14.2) → 1361 (2.14.3) |

The dual-publish worked on the **xcodebuild** front-end on its first run, which was the one untested thing about step 1.

## The mirror deliberately stays

Every copy at 2.14.3 or earlier still reads the site, and only a release after which no supported version does may drop it. The `release.yml` comment is rewritten from "step 2 (next)" to say so.

## Version

`MARKETING_VERSION` 2.14.3 → 2.14.4 on the **Ice target's two configurations only**; `MenuBarItemService`'s two stay at `1.0`.

The Debug build is unaffected: `scripts/run-debug.sh` deletes `SUFeedURL` outright, so it never read either location.

## Verification

- `xcodebuild test -project Ice.xcodeproj -scheme Ice` — **TEST SUCCEEDED**
- `swiftlint lint --strict` — **0 violations, 0 serious in 116 files**
- `dragon-conformance.py` — PASS, no violations
- `actionlint .github/workflows/release.yml` — clean
- dragon-release-ci v6.3.0's real `tag-gate.sh` against a simulated `v2.14.4` — **gate passed**, preceding tag `v2.14.3`, What's New changed