### PR TITLE
chore: bump the DragonKit pin to 3.4.0

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -898,7 +898,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.3.0;
+				minimumVersion = 3.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "9ebd5e50ee72706625aae2c0170f028135631e33",
-        "version" : "3.3.0"
+        "revision" : "8236fdc85ad83118474832670c9c9b32ec2b4b48",
+        "version" : "3.4.0"
       }
     },
     {


### PR DESCRIPTION
`CONFORMANCE` §R10 requires the declared pin to be `>=` the newest `vX.Y.Z` tag in dragon-kit, so publishing **v3.4.0** put this app in violation the moment it landed:

```
R10  pinned to DragonKit 3.3.0 but 3.4.0 is released — a stale pin silently misses shared fixes
```

That is a hard failure (`exit=1`), and the reusable conformance workflow runs the same checker on every PR here — so this repo's next PR would have red-X'd on a rule break it did not introduce. R10 exists because every app once sat on 1.3.0 while the kit was at 1.4.0 and none had the shared menu at all.

## This is pin currency, not API adoption

3.4.0 adds `LanguagePicker(languages:onChange:)` with **both parameters defaulted**, for an app translated into fewer languages than the kit ships. Nothing in this app uses it and no behaviour changes. The one user-visible difference is About's **Built with** row, which now reports `DragonKit v3.4.0`.

## Verification

```
xcodebuild test      ->  320 tests in 37 suites passed
swiftlint --strict   ->  0 violations, 0 serious in 116 files
conformance: PASS — no violations
```

Note on the `.pbxproj`: the substitution was anchored on the `dragon-kit` package-reference block, because an unanchored version regex here matched Sparkle's version once before. Exactly one line changed; all four `MARKETING_VERSION` values (including MenuBarItemService's two at `1.0`) and the four other dependency `minimumVersion`s are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)