### PR TITLE
release: 2.14.5 — the shared framework pin, and nothing else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 2.14.5 - 2026-08-11
+
+### Internal
+
+- **Nothing about the app behaves differently.** Ice 2 now builds against version 3.4.0 of the
+  shared Dragon app framework, up from 3.3.0. That release adds one thing — a way for an app to
+  narrow the framework's language picker to the languages it has actually translated itself into
+  — which Ice 2 has no use for: it ships no translations at all, so it shows no language picker.
+  Both of the new arguments have defaults, so no code here had to change to take the bump.
+
+  The bump is for pin currency rather than to adopt anything. The shared conformance rules
+  require each app's declared framework version to be at least the newest one published, because
+  every app once sat a release behind and so none of them had the shared menu at all; a stale pin
+  silently misses shared fixes. Publishing 3.4.0 put this app in breach of that rule the moment
+  it landed, which would have failed the next pull request here on a rule it did not break.
+
+  The one place you can see any of it is **Settings ▸ About**, which reports the framework it was
+  built with and now reads `DragonKit v3.4.0`.
+
+- **The appcast mirror now retires on a date that can actually arrive.** 2.14.4 moved Ice 2's
+  update feed to this repository and kept the copy on the marketing site as a mirror, so that
+  installed copies still reading the site were not stranded. The condition for dropping that
+  mirror was "when no supported version still reads the site" — which reads like a rule but names
+  no observable event: the site is GitHub Pages and exposes no per-path traffic, so there is no
+  way to see the last reader stop. The next minor release retires it instead, which is a real,
+  deliberate event, and Sparkle checks daily by default, so anyone who has launched Ice 2 even
+  once since 2.14.4 has already moved to the feed in this repository. This is a comment in the
+  release workflow; nothing about how this release is built or published changed.
+
 ## 2.14.4 - 2026-08-11
 
 ### Internal

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.4;
+				MARKETING_VERSION = 2.14.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.4;
+				MARKETING_VERSION = 2.14.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -23,9 +23,11 @@ enum WhatsNewConfig {
             date: "2026-08-11",
             summary: """
                 A maintenance release: nothing you can see behaves differently. Ice 2 now \
-                checks for updates at its own home rather than the website, so a problem \
-                with the website can no longer hold up an update. These notes also catch up \
-                on 2.12.0 through 2.14.0, which shipped without being announced here.
+                builds against version 3.4.0 of the shared Dragon app framework, keeping it \
+                in step with its sibling apps rather than drifting behind — the only trace of \
+                it anywhere in the app is the framework version About lists under Built with. \
+                These notes also catch up on 2.12.0 through 2.14.0, which shipped without \
+                being announced here.
                 """,
             sections: [
                 ChangeSection(kind: .added, entries: [


### PR DESCRIPTION
Cuts **2.14.5**, a patch release whose whole content is framework pin currency. Nothing about the
app behaves differently, and the notes say so rather than inventing a fix.

## What is actually in this release

Since `v2.14.4` this repository gained exactly two commits, both already on `main`:

| Commit | What it did |
|---|---|
| `371f7c4` | Comment only, in `.github/workflows/release.yml` — records that the **next minor release** retires the appcast mirror, replacing a condition ("when no supported version still reads the site") that named no observable event. |
| `585b413` (#96) | DragonKit pin `3.3.0` -> `3.4.0`, for CONFORMANCE §R10 pin currency. |

DragonKit 3.4.0 adds `LanguagePicker(languages:onChange:)` with **both parameters defaulted**, for
an app translated into fewer languages than the kit ships. Ice 2 cannot use it and needed no
change to take it: no `.lproj`, no `.xcstrings`, `knownRegions = (en, Base)`, and not one reference
to `LanguagePicker`, `LocalizationManager` or `DragonLanguage` anywhere in the sources.

The single user-visible difference in the release is About's **Built with · DragonKit v3.4.0** row.
That is what this PR's notes claim, and nothing more.

## Changes here

1. **`Ice.xcodeproj/project.pbxproj`** — `MARKETING_VERSION` `2.14.4` -> `2.14.5` on the **Ice
   target's two configurations only**. Proof, all four values after the edit:

   ```
   725:				MARKETING_VERSION = 2.14.5;   # Ice, Debug   (com.dragonapp.ice.debug / "Ice 2 Debug")
   761:				MARKETING_VERSION = 2.14.5;   # Ice, Release (com.dragonapp.ice / "Ice 2")
   783:				MARKETING_VERSION = 1.0;      # MenuBarItemService, Debug   — untouched
   809:				MARKETING_VERSION = 1.0;      # MenuBarItemService, Release — untouched
   ```

   The diff is exactly two lines. `CURRENT_PROJECT_VERSION` is deliberately untouched (1346 / 1) —
   the release workflow overwrites it with the git commit count.

2. **`Ice/Settings/WhatsNewConfig.swift`** — the summary now names the framework bump and points at
   the About row. It had to change and not merely be re-dated: `dragon-release-ci@v6`'s gate
   requires `whats_new_path` to have changed since the preceding tag, and 2.14.4's summary
   announced the update-feed move, which is stale the moment a release ships for a different
   reason. Still passes no explicit `version:` (the heading derives from
   `CFBundleShortVersionString`).

   No `ChangeSection` was added for 2.14.5: 2.13.0 and 2.14.1 were framework bumps deliberately
   left out of this pane rather than padded out, and padding is the failure this pane already had.
   The gate's `ChangeSection` requirement is met by the cumulative 2.12.0-2.14.0 catch-up entries,
   which stay as they did through 2.14.3 and 2.14.4.

3. **`CHANGELOG.md`** — a `## 2.14.5 - 2026-08-11` section under `### Internal`, covering the pin
   bump (and why pin currency is a rule) and the mirror retirement trigger.

**No test needed updating.** Nothing in `IceTests` pins the app version or the What's New shape:
`AcknowledgementsTests` derives its expectation from `Package.resolved` and subtracts DragonKit, so
it is version-agnostic by construction, and `SettingsBackupTests`' `"9.9"` / `"2.0"` / `"3.1"` are
synthetic backup fixtures.

## Verification

`xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'`

```
Test Suite 'All tests' passed at 2026-08-11 15:48:42.618.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
✔ Test run with 320 tests in 37 suites passed after 0.782 seconds.
** TEST SUCCEEDED **
```

The `Executed 0 tests` line is the XCTest harness, which is empty; swift-testing carries the real
count — 320 tests in 37 suites.

Version actually reached the built product:

```
Ice 2 Debug.app                              CFBundleShortVersionString = 2.14.5
  Contents/XPCServices/MenuBarItemService.xpc CFBundleShortVersionString = 1.0
```

`swiftlint lint --strict`

```
Done linting! Found 0 violations, 0 serious in 116 files.
```

`python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit`

```
DragonKit conformance — Ice 2 (116 Swift files, 45 kit types)
PASS — no violations.
```

## Not done here

No tag pushed and no merge. Per `docs/MAC-APP-RELEASE-LIFECYCLE.md`, `v2.14.5` goes up only after
this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
