### PR TITLE
docs: realign RELEASING.md with the actual release workflow

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,38 +3,58 @@
 Pushing a `vX.Y.Z` tag to `teddychan/ice-2` triggers
 `.github/workflows/release.yml`, which builds, Developer ID-signs, notarizes,
 and staples the app, uploads `Ice-2-vX.Y.Z.zip` to the GitHub Release,
-publishes the signed Sparkle appcast to
-`https://www.dragonapp.com/ice-2/appcast.xml`, and bumps the Homebrew cask
-`teddychan/tap/ice-2`.
+publishes the signed Sparkle appcast to `docs/ice-2/appcast.xml` **in this
+repo**, and bumps the Homebrew cask `teddychan/tap/ice-2`.
+
+The app-owned feed is the one the app reads — `SUFeedURL` in
+`Ice/Resources/Info.plist` is
+`https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml`.
+The same appcast is also copied to `teddychan/www.dragonapp.com`
+(`https://www.dragonapp.com/ice-2/appcast.xml`), but that copy is only a
+**temporary mirror** for installs still on v2.14.3 or older, and is scheduled
+to be dropped at the next minor release. See the `appcast_mirror_repo` comment
+in `.github/workflows/release.yml` — that comment is the source of truth for
+the migration and its retirement trigger.
 
 ## One-time setup
 
 ### 1. Repository secrets (Settings → Secrets and variables → Actions)
-Reuse the same values already on `clipmenu-2-premium` (same Apple Team
-`4AF3KGGV29`):
+Reuse the same values already on `clipmenu-2` (same Apple Team `4AF3KGGV29`):
 
 - `DEVELOPER_ID_CERT_P12_BASE64`
 - `DEVELOPER_ID_CERT_PASSWORD`
 - `NOTARY_KEY_P8_BASE64`
 - `NOTARY_KEY_ID`
 - `NOTARY_ISSUER_ID`
-- `PUBLIC_RELEASE_TOKEN` (PAT with write access to
-  `teddychan/www.dragonapp.com` and `teddychan/homebrew-tap`)
+- `PUBLIC_RELEASE_TOKEN` (PAT with write access to `teddychan/homebrew-tap`
+  and — while the mirror lasts — `teddychan/www.dragonapp.com`. The appcast in
+  *this* repo is published with the built-in `GITHUB_TOKEN`, which
+  `permissions: contents: write` in `release.yml` covers.)
 - `SPARKLE_EDDSA_PRIVATE_KEY` (the shared EdDSA private key; its public half
   `p+F/ivF5bAYcmuNuCMNHcRv123A6LHFpCBagFm7Adu8=` is in `Ice/Resources/Info.plist`)
 
 ### 2. Runner
-The workflow runs on a **GitHub-hosted** macOS runner (`runs-on: macos-15`) —
-public repos get free Actions minutes, so no self-hosted runner is required. The
-"Select Xcode" step picks the newest Xcode on the image; the build needs Xcode 26
-(current macOS SDK). If the hosted image's Xcode is too old, bump the label to
-`macos-26` once that image is generally available.
+The workflow runs on a **GitHub-hosted** macOS runner — public repos get free
+Actions minutes, so no self-hosted runner is required. Ice 2 targets the macOS
+26 SDK, which the shared pipeline's default `macos-15` image lacks, so the
+caller passes `swiftpm_runner: macos-26`; despite the name that input drives
+the job's `runs-on` for all build kinds, not just swiftpm. The "Select Xcode"
+step then picks the newest Xcode on the image.
 
 ## Cutting a release
 1. Bump `MARKETING_VERSION` in `Ice.xcodeproj` and commit.
 2. `git tag vX.Y.Z && git push origin vX.Y.Z`.
 3. Watch the Release workflow. On success, verify:
-   - `curl -sI https://www.dragonapp.com/ice-2/appcast.xml` → 200, lists X.Y.Z
+   - The feed the app actually reads — prints X.Y.Z:
+
+     ```bash
+     curl -s https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml | grep sparkle:shortVersionString
+     ```
+
+     Check this URL, not `https://www.dragonapp.com/ice-2/appcast.xml`: the
+     site copy is only the mirror, and it is served by the GitHub Pages CDN,
+     which can keep returning the previous appcast for minutes after a
+     successful publish — which looks exactly like a failed release.
    - `brew update && brew livecheck teddychan/tap/ice-2` → X.Y.Z
    - `spctl -a -t install` accepts the downloaded zip's app.
 


### PR DESCRIPTION
`docs/RELEASING.md` had drifted from `.github/workflows/release.yml`. Spotted while cutting 2.14.5 (#97), deliberately left out of that PR to keep the release diff to the version, What's New and changelog. Docs only — `release.yml` is untouched, because the workflow is correct and its comments are the source of truth here.

### 1. The appcast destination

The doc said the release "publishes the signed Sparkle appcast to `https://www.dragonapp.com/ice-2/appcast.xml`", and told the operator to verify that URL. Since v2.14.3/v2.14.4 the app-owned feed in this repo is primary:

- `appcast_repo: teddychan/ice-2` → published to `docs/ice-2/appcast.xml`
- `SUFeedURL` reads `https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml`
- `appcast_mirror_repo: teddychan/www.dragonapp.com` is only a mirror, retired at the next minor release

The verification step now checks the raw URL — the feed the app actually reads — and says explicitly not to check the Pages URL, whose CDN can serve the previous appcast for minutes after a successful publish and so looks exactly like a failed release. It also prints the version rather than just a status code; the old `curl -sI` could not have shown the `X.Y.Z` it claimed to list.

```bash
curl -s https://raw.githubusercontent.com/teddychan/ice-2/main/docs/ice-2/appcast.xml | grep sparkle:shortVersionString
```

### 2. The runner

The doc said `runs-on: macos-15` and to bump the label "to `macos-26` once that image is generally available" — a state that no longer exists. The caller already passes `swiftpm_runner: macos-26`, and in the shared pipeline that input is the job's `runs-on` for all build kinds, not just swiftpm (`runs-on: ${{ inputs.swiftpm_runner }}`). The "Select Xcode" step still picks the newest Xcode on the image, so that half stayed.

### 3. Secrets source

`clipmenu-2-premium` is retired from the release path. `clipmenu-2` carries the same six values under the same Apple Team `4AF3KGGV29` (verified with `gh secret list`). Also records that the in-repo appcast publishes with the built-in `GITHUB_TOKEN` under the `contents: write` this workflow grants — so `PUBLIC_RELEASE_TOKEN`'s cross-repo scope is the tap and, while it lasts, the mirror.

### Verification

Every claim checked against `release.yml` and `dragon-release-ci@v6`'s `release-macos.yml`, not inferred: the token rule (`APPCAST_REPO = GITHUB_REPOSITORY` → built-in token, any other destination → `PUBLIC_RELEASE_TOKEN`, hard error if missing), the tap bump's token, `runs-on`, the "Select Xcode" step, and `SUFeedURL` in `Ice/Resources/Info.plist`. The `curl` command was run against the live feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)