### PR TITLE
release: 2.14.6 — the About pane links its original project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 2.14.6 - 2026-08-11
+
+### Fixed
+
+- **Settings ▸ About links the original project again — or rather, for the first time.** Credits
+  read `Based on · Ice by Jordan Baird`, and nothing anywhere in the pane linked to Ice: the pane
+  told you Ice 2 has an upstream and gave you no way to reach it. There is now an **Original
+  project** row in the links list, beside Website and Support, opening
+  `github.com/jordanbaird/Ice`.
+
+  This was possible because the upstream project's name and its URL were two unrelated optional
+  values in the shared framework, so all four combinations of "credited" and "linked" shipped
+  across the five Dragon apps — Ice 2 and ClipMenu credited a project neither of them linked. The
+  framework's 4.0.0 release folds the URL into the same value that carries the name, so one entry
+  now drives both the link row and the credit line and they cannot disagree again. It was found by
+  putting all five apps' About panes side by side, which is how every case of this drift has been
+  found.
+
+### Changed
+
+- **Settings ▸ About names one copyright holder.** The line under the version read
+  `© 2025 Jordan Baird · © 2026 Teddy Chan`; it now reads `© 2026 Teddy Chan`, which is the form
+  the other Dragon apps already used — only Ice 2 and ClipMenu carried a second holder, and the
+  shared framework now enforces the single-holder form (conformance rule R14).
+
+  **Nothing about Ice 2's licensing or its lineage changed.** Ice 2 is still GPL-3.0, inherited
+  from Ice; Jordan Baird is still named as a copyright holder in `LICENSE`, in the bundled
+  acknowledgements, and in the app bundle's own copyright notice (`NSHumanReadableCopyright`,
+  which keeps both holders deliberately — Ice 2 is a fork that carries his source, and GPL-3.0
+  requires his notice to travel with the binary). In the About pane he is now credited twice
+  rather than once, by the new Original project link and the existing Based on line, and the full
+  licence texts remain both bundled with the app and published at
+  `dragonapp.com/ice-2/licenses/`. What changed is one display line, which now describes who
+  maintains and distributes this app.
+
+### Internal
+
+- **The shared Dragon app framework moves to 4.0.0**, up from 3.4.0. This is the framework's first
+  breaking release: the About pane's rows are now closed by the framework's own function signature
+  rather than by a written rule, so the two defects above became compile errors instead of things
+  a reviewer had to notice. The notices page is a required argument, the upstream project's URL
+  lives inside the value that names it, and the dual-holder copyright helper is gone. **Settings ▸
+  About** reports `DragonKit v4.0.0` under Built with.
+
 ## 2.14.5 - 2026-08-11
 
 ### Internal

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.5;
+				MARKETING_VERSION = 2.14.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.5;
+				MARKETING_VERSION = 2.14.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -898,7 +898,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.4.0;
+				minimumVersion = 4.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "8236fdc85ad83118474832670c9c9b32ec2b4b48",
-        "version" : "3.4.0"
+        "revision" : "0acb7947e2cccf8964fa1b954d03b7ab1ad95cec",
+        "version" : "4.0.0"
       }
     },
     {

--- a/Ice/Settings/AboutConfig.swift
+++ b/Ice/Settings/AboutConfig.swift
@@ -28,16 +28,27 @@ enum AboutConfig {
             appName: Constants.displayName,
             versionString: DragonAbout.versionString(),
             // Assembled by the kit so the format matches every other Dragon app. Ice 2 was the
-            // app that spelled out "Copyright ©" where the others used the symbol alone; the
-            // years and holders are unchanged from `NSHumanReadableCopyright`.
-            copyright: DragonAbout.copyright(
-                original: (years: "2025", holder: "Jordan Baird"),
-                years: "2026",
-                holder: "Teddy Chan"
-            ),
+            // app that spelled out "Copyright ©" where the others used the symbol alone.
+            //
+            // One holder, not two. This row used to read `© 2025 Jordan Baird · © 2026 Teddy
+            // Chan`; only Ice 2 and clipmenu-2 did that, and DragonKit 4.0.0 made the
+            // single-holder form canon (CONFORMANCE §R14) after five About panes were put side by
+            // side. The row names who maintains and distributes *this* app. Ice 2's lineage is
+            // not dropped by saying so — it is carried by the `Original project` link and the
+            // `Based on` credit below, both driven by `OriginalWork`.
+            //
+            // This deliberately does NOT match `NSHumanReadableCopyright`, which keeps both
+            // holders. Ice 2 is a git fork that carries Jordan Baird's original source and its
+            // history, not a clean reimplementation, and it inherits his GPL-3.0 — as the
+            // bundled acknowledgements say in as many words. GPL-3.0 §4 requires his copyright
+            // notice to travel with the binary, and that plist key is the binary's notice, so it
+            // stays whole. The kit's §R14 reads Swift sources only, and its stated rationale
+            // ("uses none of the upstream source") is true of yahoo-keykey-2, which drove the
+            // rule, but not of a fork; the About row follows the shared format, the legal notice
+            // follows the licence.
+            copyright: DragonAbout.copyright(years: "2026", holder: "Teddy Chan"),
             websiteURL: websiteURL,
             supportURL: issuesURL,
-            license: "GPL-3.0",
             // Third-party notices: the verbatim MIT text for the six packages below. Trailing
             // slash: it is the path Pages serves, so the row does not point at a redirect. This
             // replaces the row that opened `Resources/Acknowledgements.pdf` before DragonKit
@@ -51,7 +62,21 @@ enum AboutConfig {
             // copies"; shipping both settles that, and this row stays because a web page is the
             // more readable copy.
             licensesURL: URL(string: "https://www.dragonapp.com/ice-2/licenses/")!,
-            originalWork: OriginalWork(name: "Ice", author: "Jordan Baird"),
+            // Ice 2's own licence, which is not the row above: `licensesURL` is the third-party
+            // notices page, this is the `License` credit. Adjacent since DragonKit 4.0.0 made
+            // `licensesURL` required and put it here; the kit's own comment says not to merge them.
+            license: "GPL-3.0",
+            // Drives two rows from one value: the `Original project` link and the `Based on`
+            // credit. The link row was missing entirely before DragonKit 4.0.0 — Credits said
+            // "Based on Ice by Jordan Baird" while nothing in the pane linked to Ice, so a reader
+            // was told there was an upstream and given no way to reach it. That was possible
+            // because the upstream name and its URL were two unrelated optionals; 4.0.0 folded
+            // the URL into `OriginalWork`, which is why they can no longer disagree.
+            originalWork: OriginalWork(
+                name: "Ice",
+                author: "Jordan Baird",
+                url: URL(string: "https://github.com/jordanbaird/Ice")!
+            ),
             attributions: [
                 // Every THIRD-PARTY package Ice 2 links, as `name → licence`, and the one list a
                 // reader sees without leaving the app. `AcknowledgementsTests` pins it to

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -12,43 +12,31 @@ import DragonKit
 /// through ``DragonVersion/display(_:)``, so it always matches About and the update checker and
 /// carries the same single `v` prefix. Update the `date` and `sections` per release.
 ///
-/// This pane went four releases without an update — it still described 2.11.0 while 2.14.1
+/// This pane once went four releases without an update — it still described 2.11.0 while 2.14.1
 /// shipped — so 2.12.0 through 2.14.0 were never announced to anyone who reads the app rather
-/// than the changelog, including the removal of item groups. The notes below are cumulative for
-/// that reason, and each entry names the release it came from. `MAC-APP-RELEASE-LIFECYCLE.md`
-/// now makes updating this file part of every public release, gated on the tag.
+/// than the changelog, including the removal of item groups. 2.14.5 carried the cumulative
+/// catch-up that paid that debt off, so these notes describe this release alone again.
+/// `MAC-APP-RELEASE-LIFECYCLE.md` now makes updating this file part of every public release,
+/// gated on the tag.
 enum WhatsNewConfig {
     static var content: WhatsNewContent {
         WhatsNewContent(
             date: "2026-08-11",
             summary: """
-                A maintenance release: nothing you can see behaves differently. Ice 2 now \
-                builds against version 3.4.0 of the shared Dragon app framework, keeping it \
-                in step with its sibling apps rather than drifting behind — the only trace of \
-                it anywhere in the app is the framework version About lists under Built with. \
-                These notes also catch up on 2.12.0 through 2.14.0, which shipped without \
-                being announced here.
+                Two fixes to Settings ▸ About, both found by putting all five Dragon apps' \
+                About panes side by side: the pane credited Ice as the project Ice 2 is based \
+                on without linking to it anywhere, and it claimed two copyright holders where \
+                the other apps name one. Nothing outside that pane changed.
                 """,
             sections: [
-                ChangeSection(kind: .added, entries: [
-                    "A newly installed app's menu bar icon now appears where you can see it (2.14.0). macOS hands every brand-new menu bar item the leftmost slot, which in Ice 2's layout sits inside the always-hidden section — so the first time you installed an app with a menu bar icon, that icon was invisible from the moment it was created, and the app looked like it had never added one. Ice 2 now recognises an item it has never seen before and moves it into the visible section. Items you have already arranged are left alone, and updating does not move anything: Ice 2 takes a note of everything currently in your menu bar first, so only icons that turn up afterwards count as new. If you then drag one into Hidden or Always-Hidden, it stays where you put it. This needs Screen Recording permission, which is what lets Ice 2 tell one menu bar item from another; without it, nothing is moved.",
-                ]),
-                ChangeSection(kind: .removed, entries: [
-                    "Item groups are gone (2.12.0). The Groups section in Settings ▸ Layout — saving a set of hidden items under a name and revealing them with Show — has been removed, along with the option to point a trigger at a group. It saw very little use for the amount of the app it occupied, and layout profiles already cover arranging your menu bar. Any groups you had saved were deleted from your settings when you updated. Triggers still work: a trigger now always shows the hidden section when its app comes to the front, so the Target menu is gone. Existing hidden-section triggers are untouched; only a trigger that pointed at a group was dropped.",
-                ]),
                 ChangeSection(kind: .fixed, entries: [
-                    "A future update can no longer wipe your settings (2.12.1). Ice 2 saves your preferences as a single encoded record. Because of a flaw in the shared Dragon framework, the next version that added a setting would have failed to read the record you already had, quietly fallen back to defaults, and then written those defaults over your real preferences the moment anything changed — every setting reset, with no warning and no way back. Nothing was lost: the flaw needed a future version to trigger it, and this closed it first.",
-                    "Restoring a backup, or using either Relaunch Ice 2 button, brings Ice 2 back (2.12.0). Ice 2 asked macOS to reopen it before quitting, while it was still running — so macOS brought the running copy to the front, reported success, and the quit that followed left nothing running at all. Ice 2 disappeared and did not come back.",
-                    "Restoring a damaged backup now refuses the file instead of erasing everything (2.12.1). Handing Settings ▸ Backup & Restore a corrupted backup cleared your entire settings store rather than declining to read it, so one bad file could take your working preferences with it.",
-                    "The Layout pane keeps up with your menu bar again (2.12.0). Applying a layout profile rearranged the real menu bar immediately, but the Visible / Hidden / Always-Hidden bars in Settings could go on showing the old arrangement for up to half a minute. They now catch up about a second after the last item moves. The same staleness could affect the profile being applied: if you dragged an item and pressed Apply within a second of it, Ice 2 worked from the layout as it was before your drag and moved the wrong items.",
-                    "Dragging an item between sections no longer freezes the section you took it from (2.12.0). Ice 2 pauses a section's bar while you drag out of it so it doesn't rearrange under your cursor, but it only unpaused the section you dropped into. Drag from Hidden to Visible and the Hidden bar stopped updating for good, so an item that had moved kept showing in both places — closing and reopening Settings was the only way out.",
-                    "Menu bar item icons refresh while you are looking at them (2.12.0). Ice 2 only redraws its picture of your menu bar items while the pane that displays them is open, which is the Layout pane. Since 2.8.0 it had been checking for the Appearance pane instead — the one pane that shows no item icons — so the icons in the layout bars were whatever had been captured on some earlier visit, and a capture that failed kept showing a lettered placeholder.",
-                    "A failed uninstall says so (2.12.1). If uninstalling Ice 2 hit a problem partway through, it quit reporting success anyway — after it had already torn your settings down.",
-                    "VoiceOver can tell the menu bar shape buttons apart (2.12.1). In Settings ▸ Appearance, the buttons that choose how each end of the menu bar shape is drawn were pictures with no name attached, so picking a shape without looking at the screen meant guessing. They now read as \"Square cap\" and \"Round cap\". The tooltips you see on hover are unchanged.",
-                    "Hardened the connection to Ice 2's bundled helper (2.12.1). Ice 2 asks a small helper process which app each menu bar item belongs to. When that connection was interrupted, the code that cleared it skipped the lock guarding every other use of it, so a cleanup and an in-flight request could overlap — a dropped request at best, a crash at worst. Every access now goes through the same lock.",
+                    "Settings ▸ About now links the original project. The Credits section said \"Based on Ice by Jordan Baird\", but nothing in the pane pointed at Ice — you were told Ice 2 has an upstream and given no way to reach it. There is now an Original project row alongside Website and Support, opening github.com/jordanbaird/Ice. The credit line is unchanged; the same entry drives both, so the name and the link can no longer disagree.",
                 ]),
                 ChangeSection(kind: .changed, entries: [
-                    "If you are coming from 2.9.x: uninstalling Ice 2 has moved into Settings. It used to be an Uninstall item in the Ice 2 menu that opened a separate window; since 2.10.0 it is the last pane in the Settings sidebar, with the confirmation right there in the pane. What gets removed is unchanged: the app and its login item, your settings, layout profiles, and hotkeys, and Ice 2's saved application state.",
+                    // Deliberately does not reproduce the old two-holder line verbatim: the kit's
+                    // conformance rule R14 counts the copyright symbol per line of Swift source,
+                    // and it does not read string literals differently from the About slot itself.
+                    "Settings ▸ About names one copyright holder. The line under the version used to carry two, Jordan Baird's for 2025 alongside Teddy Chan's for 2026; it now reads © 2026 Teddy Chan, matching every other Dragon app. Nothing about Ice 2's licensing or its origins changed: it is still GPL-3.0 inherited from Ice, the app's own copyright notice still names both authors, Jordan Baird is still credited in the pane — now twice, by the Original project link and the Based on line — and the full licence texts are still both bundled with the app and published at dragonapp.com/ice-2/licenses/.",
                 ]),
             ]
         )

--- a/IceTests/AcknowledgementsTests.swift
+++ b/IceTests/AcknowledgementsTests.swift
@@ -156,9 +156,12 @@ struct AcknowledgementsTests {
     }
 
     @Test func aboutPaneLinksTheHostedNotices() {
-        // The bundle carries the notices and the About pane links the hosted copy; the kit
-        // treats `licensesURL` as optional, so its absence would be silent.
-        #expect(AboutConfig.content.licensesURL?.absoluteString == "https://www.dragonapp.com/ice-2/licenses/")
+        // The bundle carries the notices and the About pane links the hosted copy. DragonKit
+        // 4.0.0 made `licensesURL` a required, non-optional parameter, so an app that ships no
+        // notices page no longer compiles — spectacle-2 and the sample app had listed
+        // `Sparkle → MIT` in Credits with no page anywhere. This still pins the URL, because a
+        // required parameter says nothing about which page it points at.
+        #expect(AboutConfig.content.licensesURL.absoluteString == "https://www.dragonapp.com/ice-2/licenses/")
     }
 
     @Test func onlyThePdfIsBundled() {


### PR DESCRIPTION
Two defects in **Settings ▸ About**, both found by putting all five Dragon apps' panes side by side, and both of them Ice 2's. Fixing them needs DragonKit 4.0.0, which is breaking, so the pin moves in the same PR.

## What was wrong

| | Before | After |
|---|---|---|
| Links | Website · Support | Website · Support · **Original project** → `github.com/jordanbaird/Ice` |
| Copyright | `© 2025 Jordan Baird · © 2026 Teddy Chan` | `© 2026 Teddy Chan` |

Credits already read `Based on · Ice by Jordan Baird`, so the pane told you Ice 2 has an upstream and gave you no way to reach it. That was possible because the upstream's name and its URL were two unrelated optionals in the kit; 4.0.0 folds the URL into `OriginalWork`, so one value drives both the link row and the credit and they cannot disagree again. The URL matches the one README and `dragonapp.com/ice-2/licenses/` already name.

The dual-holder copyright was in two of five apps. `DragonAbout.copyright(original:)` is gone in 4.0.0 and CONFORMANCE §R14 makes the single-holder form a rule.

## `NSHumanReadableCopyright` deliberately keeps both holders

**This is the one decision here worth a reviewer's attention**, and the comment in `AboutConfig.swift` records it so the two do not silently disagree.

§R14's rationale is that "a Dragon app reimplements its upstream rather than reusing its source, so asserting the upstream author's copyright over *this* binary contradicts the app's own notices". That holds for yahoo-keykey-2, which drove the rule. It does not hold for ice-2:

- this repo is a git fork carrying Jordan Baird's source and all 1371 commits of its history;
- `LICENSE` names him (`Ice — Copyright (C) 2024 Jordan Baird`);
- the generated acknowledgements say Ice 2's GPL-3.0 is "inherited from the original Ice by Jordan Baird".

GPL-3.0 §4 requires that notice to travel with the binary, and `NSHumanReadableCopyright` *is* the binary's notice. §R14 reads Swift sources only, so it stays whole: the About row follows the shared format, the legal notice follows the licence. Nothing about Ice 2's licensing changed, and in the pane Jordan Baird is now credited twice rather than once.

## Also in this PR

- `licensesURL` moved to the position 4.0.0 requires and is non-optional now, which is why `AcknowledgementsTests` drops an optional chain. Its long comment about pointing at the hosted page rather than the bundled PDF is unchanged and still true.
- `attributions` untouched — DragonKit stays out of it, because the kit emits its own `Built with` row. The resolved package set did not change, so the bundled notices did not need regenerating (DragonKit's `LICENSE` is byte-identical between 3.4.0 and 4.0.0).
- DragonKit pin 3.4.0 → 4.0.0, on the `dragon-kit` entry in `project.pbxproj` — the anchored pattern in `.dragon-conformance.json` reads that one, not Sparkle's. `Package.resolved` moves with it; nothing else in it changed.
- `MARKETING_VERSION` 2.14.5 → 2.14.6 on the Ice target's two configurations only. `MenuBarItemService`'s stay at 1.0, and `CURRENT_PROJECT_VERSION` is left for the release workflow to overwrite with the commit count.
- The What's New pane describes this release alone again: 2.14.5 shipped the cumulative catch-up for the four releases the pane had missed, so carrying those entries forward would announce them twice.

## Verification

```
$ xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'
✔ Test run with 320 tests in 37 suites passed after 0.551 seconds.
** TEST SUCCEEDED **

$ swiftlint lint --strict
Done linting! Found 0 violations, 0 serious in 116 files.

$ python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app ~/git/ice-2 --kit ~/git/dragon-kit
DragonKit conformance — Ice 2 (116 Swift files, 45 kit types)
PASS — no violations.
```

Before this PR the same checker reported two violations — `R10` (pinned to 3.4.0 but 4.0.0 is released) and `R14` (`DragonAbout.copyright(original:)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)