### PR TITLE
fix(about): the bundle's copyright notice matches About's, naming one holder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 2.14.7 - 2026-08-11
+
+### Fixed
+
+- **The bundle's copyright notice now matches About.** `INFOPLIST_KEY_NSHumanReadableCopyright`
+  read `Copyright © 2025 Jordan Baird · © 2026 Teddy Chan` while Settings ▸ About rendered
+  `© 2026 Teddy Chan`, so the app made two different claims about itself depending on where you
+  looked. Both now name one holder. Finder's Get Info panel is where a user sees this key.
+
+  The old value was deliberate and documented in `AboutConfig.swift`: Ice 2 is a git fork carrying
+  Jordan Baird's source under GPL-3.0, whose §4 requires his notice to travel with the work, and
+  the argument was that this plist key is the binary's notice. The first half stands; the second
+  was wrong. The key is an **optional** Apple one that no licence names — three of the five Dragon
+  apps shipped without it entirely — so it displays a line in Get Info rather than discharging an
+  obligation. §4 is carried by `LICENSE`, which fills in the GPL's own notice template with his
+  name and year, and by `Resources/Acknowledgements.rtf`, which states that Ice 2 inherits GPL-3.0
+  from the original Ice. Neither is touched here.
+
+  This corrects 2.14.6's release notes, which told users "the app's own copyright notice still
+  names both authors". True when written; this release is what changed it, and the new notes say
+  so rather than leaving the claim to rot.
+
+- **Nothing about licensing or lineage changed.** Ice 2 is still GPL-3.0 inherited from Ice.
+  Jordan Baird is still credited twice in About — the `Original project` link and the `Based on`
+  row, both driven by `OriginalWork` — and the full licence texts are still bundled and published
+  at dragonapp.com/ice-2/licenses/.
+
+  Part of unifying the field across all five Dragon apps, which held it in four different states:
+  a tagline in ClipMenu 2, two holders here, and nothing at all in Spectacle 2, Yahoo! KeyKey 2
+  and Dragon Sample App.
+
 ## 2.14.6 - 2026-08-11
 
 ### Fixed

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -622,7 +622,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Jordan Baird · © 2026 Teddy Chan";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2026 Teddy Chan";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -683,7 +683,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 Jordan Baird · © 2026 Teddy Chan";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "© 2026 Teddy Chan";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -722,7 +722,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.6;
+				MARKETING_VERSION = 2.14.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.14.6;
+				MARKETING_VERSION = 2.14.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Settings/AboutConfig.swift
+++ b/Ice/Settings/AboutConfig.swift
@@ -37,15 +37,24 @@ enum AboutConfig {
             // not dropped by saying so — it is carried by the `Original project` link and the
             // `Based on` credit below, both driven by `OriginalWork`.
             //
-            // This deliberately does NOT match `NSHumanReadableCopyright`, which keeps both
-            // holders. Ice 2 is a git fork that carries Jordan Baird's original source and its
-            // history, not a clean reimplementation, and it inherits his GPL-3.0 — as the
-            // bundled acknowledgements say in as many words. GPL-3.0 §4 requires his copyright
-            // notice to travel with the binary, and that plist key is the binary's notice, so it
-            // stays whole. The kit's §R14 reads Swift sources only, and its stated rationale
-            // ("uses none of the upstream source") is true of yahoo-keykey-2, which drove the
-            // rule, but not of a fork; the About row follows the shared format, the legal notice
-            // follows the licence.
+            // `NSHumanReadableCopyright` now matches this string exactly. It carried both holders
+            // until 2.14.7, on the reasoning that Ice 2 is a git fork of Jordan Baird's Ice rather
+            // than a clean reimplementation, that GPL-3.0 §4 requires his notice to travel with the
+            // binary, and that the plist key IS the binary's notice.
+            //
+            // The first two clauses are true and unchanged. The third was the mistake: that key is
+            // an OPTIONAL Apple key, named by no licence, and three of the five Dragon apps shipped
+            // without it at all. §4's "conspicuously and appropriately publish an appropriate
+            // copyright notice" is carried by `LICENSE`, which fills in the GPL's own template with
+            // his name and year, and by `Resources/Acknowledgements.rtf`, which states in as many
+            // words that Ice 2 inherits GPL-3.0 from the original Ice. Neither moves here. What the
+            // plist key does is display a line in Finder's Get Info panel, which makes it
+            // presentation — the same thing this row is — so the two disagreeing was drift, not
+            // compliance.
+            //
+            // Both are now the app's own holder, and the lineage sits where the pane puts it:
+            // ``OriginalWork`` drives the `Original project` link and the `Based on` credit, and
+            // the licence texts are bundled and published at dragonapp.com/ice-2/licenses/.
             copyright: DragonAbout.copyright(years: "2026", holder: "Teddy Chan"),
             websiteURL: websiteURL,
             supportURL: issuesURL,

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -23,20 +23,21 @@ enum WhatsNewConfig {
         WhatsNewContent(
             date: "2026-08-11",
             summary: """
-                Two fixes to Settings ▸ About, both found by putting all five Dragon apps' \
-                About panes side by side: the pane credited Ice as the project Ice 2 is based \
-                on without linking to it anywhere, and it claimed two copyright holders where \
-                the other apps name one. Nothing outside that pane changed.
+                One fix, finishing what 2.14.6 started: the copyright notice macOS shows for \
+                Ice 2 in Finder's Get Info panel now matches the one in Settings ▸ About. \
+                Nothing about Ice 2's licensing or its origins changed.
                 """,
             sections: [
+                // 2.14.6's notes told users "the app's own copyright notice still names both
+                // authors". That was true when written and is not any more, so this entry says so
+                // outright rather than leaving the earlier claim to rot.
+                //
+                // Deliberately does not reproduce the old two-holder line verbatim: the kit's
+                // conformance rule R14 counts the copyright symbol per line of Swift source, and
+                // it does not read string literals differently from the About slot itself.
                 ChangeSection(kind: .fixed, entries: [
-                    "Settings ▸ About now links the original project. The Credits section said \"Based on Ice by Jordan Baird\", but nothing in the pane pointed at Ice — you were told Ice 2 has an upstream and given no way to reach it. There is now an Original project row alongside Website and Support, opening github.com/jordanbaird/Ice. The credit line is unchanged; the same entry drives both, so the name and the link can no longer disagree.",
-                ]),
-                ChangeSection(kind: .changed, entries: [
-                    // Deliberately does not reproduce the old two-holder line verbatim: the kit's
-                    // conformance rule R14 counts the copyright symbol per line of Swift source,
-                    // and it does not read string literals differently from the About slot itself.
-                    "Settings ▸ About names one copyright holder. The line under the version used to carry two, Jordan Baird's for 2025 alongside Teddy Chan's for 2026; it now reads © 2026 Teddy Chan, matching every other Dragon app. Nothing about Ice 2's licensing or its origins changed: it is still GPL-3.0 inherited from Ice, the app's own copyright notice still names both authors, Jordan Baird is still credited in the pane — now twice, by the Original project link and the Based on line — and the full licence texts are still both bundled with the app and published at dragonapp.com/ice-2/licenses/.",
+                    "Finder's Get Info panel now shows the same copyright line as Settings ▸ About. It named two holders, Jordan Baird's for 2025 alongside Teddy Chan's for 2026, while About named one — so the app made two different claims about itself depending on where you looked. Both now read © 2026 Teddy Chan. 2.14.6's release notes said this notice still carried both authors, and that is what has changed here.",
+                    "Nothing about Ice 2's licensing or its origins changed. It is still GPL-3.0, inherited from Ice. Jordan Baird's copyright notice is still in the LICENSE file that ships with the app and still in its bundled Acknowledgements, which is where the licence requires it. He is still credited twice in Settings ▸ About, by the Original project link and the Based on line, and the full licence texts are still published at dragonapp.com/ice-2/licenses/.",
                 ]),
             ]
         )


### PR DESCRIPTION
`INFOPLIST_KEY_NSHumanReadableCopyright` read `Copyright © 2025 Jordan Baird · © 2026 Teddy Chan` while Settings ▸ About rendered one holder — so Ice 2 made two different claims about itself depending on where you looked. Both configurations now carry `© 2026 Teddy Chan`, byte-for-byte what `DragonAbout.copyright(years:holder:)` renders.

## The old value was deliberate, and half its reasoning was wrong

`AboutConfig.swift` documented it: Ice 2 is a git **fork** carrying Jordan Baird's source under GPL-3.0, whose §4 requires his notice to travel with the work, and this plist key was taken to *be* the binary's notice.

The first half stands. The second doesn't — `NSHumanReadableCopyright` is an **optional** Apple key that no licence names, and three of the five Dragon apps shipped without it entirely. It displays a line in Finder's Get Info panel; it does not discharge an obligation.

§4 is carried by:
- **`LICENSE`** — fills in the GPL's own notice template with his name and year (lines 635 and 655)
- **`Resources/Acknowledgements.rtf`** — states that Ice 2 inherits GPL-3.0 from the original Ice

Neither is touched here, and `OriginalWork` still credits him twice in the pane. What changes is a presentation field that disagreed with the presentation field beside it.

## The notes correct 2.14.6's

2.14.6 told users "the app's own copyright notice still names both authors". True when written; this is the release that changed it. The new entry says so outright rather than leaving the earlier claim to rot.

The entries deliberately avoid reproducing the old two-holder line verbatim — R14 counts the copyright symbol per line of Swift source and does not read a string literal differently from the About slot itself. That trap is recorded in the file.

## Fleet context

The field held four different states across the five apps: a tagline in clipmenu-2, two holders here, and absent in spectacle-2, yahoo-keykey-2 and dragon-sample-app. All five now render the same string in About and in Get Info.

## Verified

| Check | Result |
|---|---|
| `xcodebuild -scheme Ice -configuration Debug` | BUILD SUCCEEDED |
| `dragon-conformance.py --app ~/git/ice-2 --kit .` | PASS — no violations |
| `MARKETING_VERSION` (both configs) | `2.14.7` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)