### PR TITLE
docs(license): name both copyright holders above the verbatim GPL text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,21 @@
+Ice 2
+Copyright (C) 2024 Jordan Baird (original Ice — https://github.com/jordanbaird/Ice)
+Copyright (C) 2026 Teddy Chan (this fork)
+
+This program is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with this
+program.  If not, see <https://www.gnu.org/licenses/>.
+
+-------------------------------------------------------------------------------
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 


### PR DESCRIPTION
`LICENSE` was the bare GPL-3.0 document. Ice 2's own copyright appeared nowhere in it — the only program notice present was inside the licence's instructional appendix, which upstream had filled in with "Ice" and Jordan Baird. So the file described the *original* program, and the fork asserted nothing for its own work.

## The GPL text is not edited

Its own header says "changing it is not allowed", so the notice is **prepended above** it instead, in the form that appendix tells you to attach to a program:

```
Ice 2
Copyright (C) 2024 Jordan Baird (original Ice — https://github.com/jordanbaird/Ice)
Copyright (C) 2026 Teddy Chan (this fork)
```

followed by the four-paragraph warranty and redistribution notice the appendix supplies.

Verified mechanically rather than by eye: the file's tail is byte-identical to the previous contents, sha256 `a22c5d2f…`. The licence document is relocated, not modified.

## "this fork", not "this reimplementation"

That's what Ice 2 is — a git fork carrying Jordan Baird's source and history under his GPL-3.0. clipmenu-2 and spectacle-2 reuse none of their upstreams' source, which is why their MIT notices can name two holders under one permissive grant. Here the second line is a contribution to an existing GPL-3.0 work, which is the case §5 covers.

## The year

Jordan Baird's is **2024** — from the appendix upstream filled in, matching `github.com/jordanbaird/Ice`. Not the 2025 the app's plist used to show; that line was removed in 2.14.7, so no year disagrees with another anywhere in the repo now.

## No release

`LICENSE` is not compiled into the app, and `Resources/Acknowledgements.rtf` — which **is** bundled — references the licence rather than reproducing it, so it needs no regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)