### PR TITLE
docs(backup): cite §R9 and the migration debt, not a §R11 exception

### DIFF
--- a/Ice/Settings/SettingsPanes/IceBackupSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/IceBackupSettingsPane.swift
@@ -6,11 +6,24 @@
 import DragonKit
 import SwiftUI
 
-/// Ice 2's own folder-based backup pane. Deliberately not DragonKit's
-/// `BackupSettingsPane`, which snapshots a single UserDefaults suite — Ice 2 keeps
-/// versioned backup files in a user-chosen folder so settings can sync across Macs
-/// (see dragon-kit CONFORMANCE.md §R11). The `Ice` prefix keeps the name from
-/// shadowing the kit's pane (§R3).
+/// Ice 2's own folder-based backup pane — **temporary, and on its way out.**
+///
+/// DragonKit's `BackupSettingsPane` + `DragonBackup` is the target for every Dragon app. This
+/// pane and ClipMenu 2's `SyncBackupPane` are the two that have not migrated yet, because their
+/// data and workflows have to be mapped across safely first. That is approved migration debt,
+/// tracked in dragon-kit's `TechDebt.md` — a sequenced difference, not a permanent one, and the
+/// same handling applies to all five apps.
+///
+/// **Not a CONFORMANCE §R11 exception**, which this comment used to cite: ice-2 declares no
+/// `exceptions` at all, and none is needed. §R3 and §R4 never fire on this pane — the `Ice`
+/// prefix keeps the name from shadowing the kit's, and it hand-rolls no grouped `Form` — so an
+/// exception here would sanction a violation that does not exist, which §R11's own table records
+/// as the mistake to avoid. What actually carries this pane is **§R9**, whose Backup slot
+/// recognizes the app-specific spelling and still holds it to the canonical sidebar position.
+///
+/// Ice 2 keeps versioned backup files in a user-chosen folder so settings can sync across Macs;
+/// `DragonBackup` snapshots a single UserDefaults suite. The migration adds that capability once,
+/// in the kit — it is not preserved here.
 struct IceBackupSettingsPane: View {
     @EnvironmentObject var appState: AppState
 


### PR DESCRIPTION
Closes DragonKit docs-audit finding **#23**.

## The problem

`Ice/Settings/SettingsPanes/IceBackupSettingsPane.swift:9-13` said this pane was sanctioned by *"dragon-kit CONFORMANCE.md §R11"*. It is not — **ice-2 declares no `exceptions` key at all**, so nothing was ever sanctioned. And nothing needed to be: §R3 and §R4 never fire on this pane (the `Ice` prefix keeps the name from shadowing the kit's, and it hand-rolls no grouped `Form`).

§R11's own table records that exact mistake — five rows sat there for months naming rules that never fired on the apps they were written for:

> A row naming a rule the checker never fires is worse than no row: it reads as a live sanction, nothing contradicts it, and the next app copies the shape.

## The fix

Cite what actually carries this pane: **§R9**, whose Backup slot recognizes the app-specific spelling and still holds it to the canonical sidebar position.

The comment also read as a permanent design choice, and it isn't. Backup unification is **approved migration debt**, tracked in dragon-kit's `TechDebt.md`: `BackupSettingsPane` + `DragonBackup` is the target for every Dragon app, this pane and ClipMenu 2's `SyncBackupPane` are the two still to migrate, and the folder-versioning capability gets added once in the kit rather than preserved app-side.

Chosen over the alternative (declaring the exception to make the citation true) on the owner's call: no app should carry a backup exception, and all five apps get the same handling.

## Verification

Comment only, no behaviour change.

```
python3 ~/git/dragon-kit/Scripts/dragon-conformance.py --app . --kit ~/git/dragon-kit
DragonKit conformance — Ice 2 (117 Swift files, 45 kit types, 7 kit languages)
PASS — no violations.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)