### PR TITLE
chore(deps): DragonKit 4.0.0 → 4.1.0, so §R10 stops failing every PR

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -899,7 +899,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 4.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "0acb7947e2cccf8964fa1b954d03b7ab1ad95cec",
-        "version" : "4.0.0"
+        "revision" : "7f581765f067ed4c2018bfc0f572ab95049e343d",
+        "version" : "4.1.0"
       }
     },
     {


### PR DESCRIPTION
Bumps the declared DragonKit floor from 4.0.0 to 4.1.0 — one `minimumVersion` in `project.pbxproj`, plus the workspace `Package.resolved`.

## Why now

§R10 fails an app whose declared pin is behind the kit's newest tag. After the §R16 migration ([#106](https://github.com/teddychan/ice-2/pull/106)) this was the **only** violation left, so the check that says "Ice conforms" was permanently red for a reason everyone had learned to read past. DragonKit is about to enable §R16 enforcement, and that is a bad moment to be carrying a check nobody trusts.

## This is a real upgrade, not a declarative no-op

`upToNextMajorVersion` from 4.0.0 permits 4.1.0, so it's tempting to conclude Xcode was already resolving it. **It wasn't.** The workspace `Package.resolved` is committed and pinned v4.0.0, and a lockfile that still satisfies the requirement is honoured — so every clean build was *linking* 4.0.0 and About's row read `DragonKit v4.0.0`. `xcodebuild -resolvePackageDependencies` printing `Checking out 4.1.0 of package 'dragon-kit'` is what that step looks like when the pin genuinely moves.

An earlier revision of this PR body claimed the build was unchanged; that was wrong, and it was wrong against a note in project memory that already said ice-2 and clipmenu-2 "commit theirs, so they are locked to an exact revision despite floating declarations". A floor is not a resolution wherever a lockfile is tracked — spectacle-2 gitignores its lockfile and is the one app where the floor really is the resolution.

## The edit is anchored on dragon-kit, deliberately

`project.pbxproj` carries a `minimumVersion` for AXSwift, Semaphore, Sparkle, CompactSlider and Ifrit as well. An unanchored replace would have hit whichever appeared first — which is precisely the trap §R10's own pin-pattern anchoring requirement exists for, and this is the file that taught the fleet that lesson (an unanchored regex once read Sparkle's version and reported a false PASS on a stale DragonKit pin). The replacement matches the `repositoryURL … teddychan/dragon-kit` block and asserts exactly one match.

`Package.resolved` was updated by `xcodebuild -resolvePackageDependencies`, not by hand.

## Verification

```
xcodebuild -resolvePackageDependencies   Checking out 4.1.0 of package 'dragon-kit'
xcodebuild test                          326 tests in 38 suites — ** TEST SUCCEEDED **
dragon-conformance.py                    PASS — no violations
```

Zero conformance violations now. Separately, a `verify_only` release dispatch on `main` passed after the §R16 merge, so the moved `INFOPLIST_FILE` paths are proven on a real runner and not just locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
