### PR TITLE
release: 2.15.1 — maintenance, DragonKit 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2.15.1 - 2026-08-18
+
+### Internal
+
+- **Nothing about the app behaves differently.** Ice 2 now builds against version 4.1.0 of the
+  shared Dragon app framework, up from 4.0.0. Since 2.15.0 this repository gained exactly two
+  changes to the app, and this is one of them; there is no user-facing fix or feature in this
+  release, and the notes in the What's New pane say so rather than inventing one.
+
+  The bump is for pin currency rather than to adopt anything. The shared conformance rules
+  require each app's declared framework version to be at least the newest one published, so
+  publishing 4.1.0 put this app in breach of that rule the moment it landed — every pull request
+  here failed §R10 until the pin moved. No code here had to change to take the bump.
+
+  The one place you can see any of it is **Settings ▸ About**, which reports the framework it was
+  built with and now reads `DragonKit v4.1.0`.
+
+- **Both bundles' `Info.plist` moved into `App/`.** DragonKit's conformance §R16 places every
+  app's bundle inputs under `App/` at the repo root, so the app's plist is `App/Info.plist` and
+  the bundled menu bar helper's is `App/MenuBarItemService/Info.plist`. Only `INFOPLIST_FILE` in
+  the Xcode project moved with them; neither file's contents changed, and neither carries a
+  version key — Ice 2's version is `MARKETING_VERSION` in `Ice.xcodeproj`, and the release
+  workflow stamps `CFBundleVersion` with the commit count.
+
 ## 2.15.0 - 2026-08-13
 
 ### Added

--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -723,7 +723,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.15.0;
+				MARKETING_VERSION = 2.15.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice.debug;
 				PRODUCT_MODULE_NAME = Ice_2;
 				PRODUCT_NAME = "Ice 2 Debug";
@@ -759,7 +759,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 2.15.0;
+				MARKETING_VERSION = 2.15.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dragonapp.ice;
 				PRODUCT_NAME = "Ice 2";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Ice/Resources/en.lproj/Localizable.strings
+++ b/Ice/Resources/en.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "app.uninstall.item.state" = "Saved application state";
 "app.updates.notification.body" = "%@ found a newer version.";
 "app.updates.notification.title" = "A new update is available";
-"app.whatsNew.2_15_0.added.languages" = "English, Español, Français, 日本語, 한국어, 简体中文 and 繁體中文. Pick one under Settings ▸ General, or leave it on Automatic to follow macOS. Everything switches at once — settings, the menu bar menu, alerts and the permissions window — with no relaunch.";
-"app.whatsNew.2_15_0.changed.settingsItem" = "The Settings item in the menu bar's right-click menu now reads “Settings…” with the gear icon every Dragon app shows, instead of “Ice 2 Settings…” with no icon.";
-"app.whatsNew.2_15_0.summary" = "Ice 2 now speaks seven languages, chosen in Settings ▸ General and applied without a relaunch.";
+"app.whatsNew.2_15_1.changed.dragonKit" = "Ice 2 now builds against version 4.1.0 of the shared DragonKit framework, up from 4.0.0. That framework owns the Settings window, the About and What’s New panes, and the update checker, so keeping the pin current keeps all four in step with the other Dragon apps. The only trace of it anywhere in the app is the framework version About lists under Built with.";
+"app.whatsNew.2_15_1.changed.housekeeping" = "Internal housekeeping: the files that describe Ice 2’s app bundle and its bundled menu bar helper now sit together in one place in the project, matching the layout every Dragon app uses. Nothing about how the app is built or how it behaves changed.";
+"app.whatsNew.2_15_1.summary" = "A maintenance release: nothing you can see behaves differently. Ice 2 moves to version 4.1.0 of the shared Dragon app framework, and the rest is internal housekeeping.";

--- a/Ice/Resources/es.lproj/Localizable.strings
+++ b/Ice/Resources/es.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "app.uninstall.item.state" = "Estado guardado de la aplicación";
 "app.updates.notification.body" = "%@ ha encontrado una versión más reciente.";
 "app.updates.notification.title" = "Hay una nueva actualización disponible";
-"app.whatsNew.2_15_0.added.languages" = "English, Español, Français, 日本語, 한국어, 简体中文 y 繁體中文. Elige uno en Ajustes ▸ General o déjalo en Automático para seguir a macOS. Todo cambia a la vez —ajustes, el menú de la barra de menús, las alertas y la ventana de permisos— sin reiniciar.";
-"app.whatsNew.2_15_0.changed.settingsItem" = "El ítem Ajustes del menú contextual de la barra de menús ahora dice «Ajustes…» con el icono de engranaje que muestran todas las apps de Dragon, en lugar de «Ajustes de Ice 2…» sin icono.";
-"app.whatsNew.2_15_0.summary" = "Ice 2 ya habla siete idiomas, que se eligen en Ajustes ▸ General y se aplican sin reiniciar.";
+"app.whatsNew.2_15_1.changed.dragonKit" = "Ice 2 se compila ahora con la versión 4.1.0 del framework compartido DragonKit, frente a la 4.0.0. Ese framework es el dueño de la ventana de Ajustes, de los paneles Acerca de y Novedades y del buscador de actualizaciones, así que mantener la referencia al día mantiene los cuatro en línea con las demás apps de Dragon. Su único rastro en la app es la versión del framework que Acerca de indica en «Desarrollado con».";
+"app.whatsNew.2_15_1.changed.housekeeping" = "Mantenimiento interno: los archivos que describen el paquete de la app de Ice 2 y su ayudante de la barra de menús están ahora juntos en un mismo lugar del proyecto, igual que en todas las apps de Dragon. No cambia nada en cómo se compila la app ni en cómo funciona.";
+"app.whatsNew.2_15_1.summary" = "Una versión de mantenimiento: nada de lo que ves se comporta de forma distinta. Ice 2 pasa a la versión 4.1.0 del framework compartido de las apps de Dragon, y el resto es mantenimiento interno.";

--- a/Ice/Resources/fr.lproj/Localizable.strings
+++ b/Ice/Resources/fr.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "app.uninstall.item.state" = "État enregistré de l'application";
 "app.updates.notification.body" = "%@ a trouvé une version plus récente.";
 "app.updates.notification.title" = "Une nouvelle mise à jour est disponible";
-"app.whatsNew.2_15_0.added.languages" = "English, Español, Français, 日本語, 한국어, 简体中文 et 繁體中文. Choisissez-en une dans Réglages ▸ Général, ou laissez sur Automatique pour suivre macOS. Tout change d'un coup — réglages, menu de la barre des menus, alertes et fenêtre des autorisations — sans relancer l'app.";
-"app.whatsNew.2_15_0.changed.settingsItem" = "L'élément Réglages du menu contextuel de la barre des menus affiche désormais « Réglages… » avec l'icône d'engrenage commune aux apps Dragon, au lieu de « Réglages d'Ice 2… » sans icône.";
-"app.whatsNew.2_15_0.summary" = "Ice 2 parle désormais sept langues, à choisir dans Réglages ▸ Général et appliquées sans relancer l'app.";
+"app.whatsNew.2_15_1.changed.dragonKit" = "Ice 2 est désormais compilé avec la version 4.1.0 du framework partagé DragonKit, contre 4.0.0 auparavant. Ce framework fournit la fenêtre des Réglages, les volets À propos et Nouveautés ainsi que le vérificateur de mises à jour ; garder la référence à jour maintient ces quatre éléments alignés sur les autres apps Dragon. Sa seule trace dans l’app est la version du framework indiquée par À propos sous « Développé avec ».";
+"app.whatsNew.2_15_1.changed.housekeeping" = "Entretien interne : les fichiers qui décrivent le paquet de l’app Ice 2 et son assistant de barre des menus sont maintenant regroupés au même endroit dans le projet, comme dans toutes les apps Dragon. Rien ne change à la façon dont l’app est compilée ni à son fonctionnement.";
+"app.whatsNew.2_15_1.summary" = "Une version de maintenance : rien de ce que vous voyez ne se comporte différemment. Ice 2 passe à la version 4.1.0 du framework partagé des apps Dragon, et le reste relève de l’entretien interne.";

--- a/Ice/Resources/ja.lproj/Localizable.strings
+++ b/Ice/Resources/ja.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "app.uninstall.item.state" = "保存されたアプリケーションの状態";
 "app.updates.notification.body" = "%@ が新しいバージョンを見つけました。";
 "app.updates.notification.title" = "新しいアップデートがあります";
-"app.whatsNew.2_15_0.added.languages" = "English、Español、Français、日本語、한국어、简体中文、繁體中文。設定 ▸ 一般 で選択するか、「自動」のままにすると macOS に従います。設定、メニューバーのメニュー、アラート、アクセス許可のウインドウまで、再起動せずに一度に切り替わります。";
-"app.whatsNew.2_15_0.changed.settingsItem" = "メニューバーの右クリックメニューの項目が、アイコンのない「Ice 2 の設定…」から、Dragon の各 App 共通の歯車アイコン付き「設定…」になりました。";
-"app.whatsNew.2_15_0.summary" = "Ice 2 が 7 つの言語に対応しました。設定 ▸ 一般 で選ぶと、再起動せずに切り替わります。";
+"app.whatsNew.2_15_1.changed.dragonKit" = "Ice 2 は共通フレームワーク DragonKit のバージョン 4.1.0 でビルドされるようになりました（これまでは 4.0.0）。設定ウインドウ、情報パネル、新機能パネル、アップデートの確認はこのフレームワークが担っているため、参照を最新に保つことでこの 4 つが他の Dragon の App と揃います。App 内で確認できる違いは、情報パネルの「使用技術」に表示されるフレームワークのバージョンだけです。";
+"app.whatsNew.2_15_1.changed.housekeeping" = "内部の整理です。Ice 2 の App バンドルと同梱のメニューバーヘルパーを記述するファイルを、プロジェクト内の 1 か所にまとめ、Dragon の各 App と同じ構成にしました。ビルド方法も App の動作も変わりません。";
+"app.whatsNew.2_15_1.summary" = "メンテナンスリリースです。目に見える動作は何も変わりません。Ice 2 が Dragon の共通フレームワークのバージョン 4.1.0 に移行し、あとは内部の整理のみです。";

--- a/Ice/Resources/ko.lproj/Localizable.strings
+++ b/Ice/Resources/ko.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "app.uninstall.item.state" = "저장된 응용 프로그램 상태";
 "app.updates.notification.body" = "%@에서 새 버전을 찾았습니다.";
 "app.updates.notification.title" = "새로운 업데이트가 있습니다";
-"app.whatsNew.2_15_0.added.languages" = "English, Español, Français, 日本語, 한국어, 简体中文, 繁體中文. 설정 ▸ 일반에서 선택하거나 '자동'으로 두면 macOS를 따릅니다. 설정, 메뉴 막대 메뉴, 알림, 권한 윈도우까지 다시 실행 없이 한 번에 전환됩니다.";
-"app.whatsNew.2_15_0.changed.settingsItem" = "메뉴 막대의 오른쪽 클릭 메뉴에 있는 설정 항목이, 아이콘 없는 'Ice 2 설정…' 대신 모든 Dragon 앱이 사용하는 톱니바퀴 아이콘과 함께 '설정…'으로 표시됩니다.";
-"app.whatsNew.2_15_0.summary" = "Ice 2가 이제 7개 언어를 지원합니다. 설정 ▸ 일반에서 선택하면 다시 실행하지 않아도 바로 적용됩니다.";
+"app.whatsNew.2_15_1.changed.dragonKit" = "Ice 2가 이제 공용 프레임워크 DragonKit 4.1.0으로 빌드됩니다(이전에는 4.0.0). 설정 윈도우, 정보 패널과 새로운 기능 패널, 업데이트 확인을 모두 이 프레임워크가 담당하므로, 참조를 최신으로 유지하면 이 네 가지가 다른 Dragon 앱과 나란히 유지됩니다. 앱에서 확인할 수 있는 유일한 흔적은 정보 패널의 '사용 기술'에 표시되는 프레임워크 버전입니다.";
+"app.whatsNew.2_15_1.changed.housekeeping" = "내부 정리입니다. Ice 2의 앱 번들과 함께 제공되는 메뉴 막대 도우미를 설명하는 파일들이 이제 프로젝트 안 한곳에 모여, 모든 Dragon 앱과 같은 구성이 되었습니다. 앱을 빌드하는 방식도, 동작도 달라지지 않았습니다.";
+"app.whatsNew.2_15_1.summary" = "유지 관리 릴리스입니다. 눈에 보이는 동작은 달라지지 않았습니다. Ice 2가 Dragon 앱 공용 프레임워크 4.1.0으로 옮겨갔고, 나머지는 내부 정리입니다.";

--- a/Ice/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Ice/Resources/zh-Hans.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "app.uninstall.item.state" = "已存储的应用程序状态";
 "app.updates.notification.body" = "%@ 找到了更新的版本。";
 "app.updates.notification.title" = "有新的更新可用";
-"app.whatsNew.2_15_0.added.languages" = "English、Español、Français、日本語、한국어、简体中文、繁體中文。在“设置 ▸ 通用”中选择，或保持“自动”以跟随 macOS。设置、菜单栏菜单、提醒和权限窗口会同时切换，无需重新启动。";
-"app.whatsNew.2_15_0.changed.settingsItem" = "菜单栏右键菜单中的“设置”项现在显示为带齿轮图标的“设置…”，与所有 Dragon App 一致，不再是没有图标的“Ice 2 设置…”。";
-"app.whatsNew.2_15_0.summary" = "Ice 2 现已支持七种语言，可在“设置 ▸ 通用”中选择，无需重新启动即可生效。";
+"app.whatsNew.2_15_1.changed.dragonKit" = "Ice 2 现在基于共用框架 DragonKit 4.1.0 构建，此前为 4.0.0。设置窗口、“关于”和“新功能”面板以及更新检查都由该框架提供，因此保持引用为最新版本，可让这四处与其他 Dragon App 保持一致。它在 App 内唯一的痕迹，就是“关于”面板“构建于”一行列出的框架版本。";
+"app.whatsNew.2_15_1.changed.housekeeping" = "内部整理：描述 Ice 2 App 包及其内置菜单栏助手的文件现已集中到项目中的同一位置，与所有 Dragon App 的结构一致。App 的构建方式和使用体验均未改变。";
+"app.whatsNew.2_15_1.summary" = "这是一个维护版本：你能看到的行为都没有变化。Ice 2 迁移到 Dragon App 共用框架的 4.1.0 版本，其余都是内部整理。";

--- a/Ice/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Ice/Resources/zh-Hant.lproj/Localizable.strings
@@ -222,6 +222,6 @@
 "app.uninstall.item.state" = "已儲存的應用程式狀態";
 "app.updates.notification.body" = "%@ 找到了更新的版本。";
 "app.updates.notification.title" = "有新的更新可用";
-"app.whatsNew.2_15_0.added.languages" = "English、Español、Français、日本語、한국어、简体中文、繁體中文。在「設定 ▸ 一般」中選擇，或保持「自動」以跟隨 macOS。設定、選單列選單、提醒和權限視窗會同時切換，無需重新啟動。";
-"app.whatsNew.2_15_0.changed.settingsItem" = "選單列右鍵選單中的「設定」項目現在顯示為帶齒輪圖像的「設定…」，與所有 Dragon App 一致，不再是沒有圖像的「Ice 2 設定…」。";
-"app.whatsNew.2_15_0.summary" = "Ice 2 現已支援七種語言，可在「設定 ▸ 一般」中選擇，無需重新啟動即可生效。";
+"app.whatsNew.2_15_1.changed.dragonKit" = "Ice 2 現在基於共用框架 DragonKit 4.1.0 建構，先前為 4.0.0。設定視窗、「關於」和「新功能」面板以及更新檢查都由該框架提供，因此讓參照保持最新，可讓這四處與其他 Dragon App 保持一致。它在 App 內唯一的痕跡，就是「關於」面板「建構於」一行列出的框架版本。";
+"app.whatsNew.2_15_1.changed.housekeeping" = "內部整理：描述 Ice 2 App 套件及其內建選單列輔助程式的檔案現已集中到專案中的同一位置，與所有 Dragon App 的結構一致。App 的建構方式和使用體驗均未改變。";
+"app.whatsNew.2_15_1.summary" = "這是一個維護版本：你能看到的行為都沒有變化。Ice 2 遷移到 Dragon App 共用框架的 4.1.0 版本，其餘都是內部整理。";

--- a/Ice/Settings/WhatsNewConfig.swift
+++ b/Ice/Settings/WhatsNewConfig.swift
@@ -22,18 +22,21 @@ enum WhatsNewConfig {
     @MainActor
     static var content: WhatsNewContent {
         WhatsNewContent(
-            date: "2026-08-13",
-            summary: L("app.whatsNew.2_15_0.summary"),
+            date: "2026-08-18",
+            summary: L("app.whatsNew.2_15_1.summary"),
             sections: [
                 // The keys carry the version, so each release replaces them rather than editing
                 // the previous release's text in place. That is what lets `whats_new_path` in
                 // release.yml gate on a real diff in all seven .strings files: reusing a key would
                 // leave those files untouched while the notes changed completely.
-                ChangeSection(kind: .added, entries: [
-                    L("app.whatsNew.2_15_0.added.languages"),
-                ]),
+                //
+                // One `.changed` section and nothing else, because that is what this release is:
+                // the DragonKit pin moved 4.0.0 -> 4.1.0 and both bundles' Info.plist moved into
+                // App/. Neither changes anything a user can see. 2.14.5 set the precedent for
+                // saying that outright rather than dressing a pin bump up as a fix.
                 ChangeSection(kind: .changed, entries: [
-                    L("app.whatsNew.2_15_0.changed.settingsItem"),
+                    L("app.whatsNew.2_15_1.changed.dragonKit"),
+                    L("app.whatsNew.2_15_1.changed.housekeeping"),
                 ]),
             ]
         )


### PR DESCRIPTION
Prepares the 2.15.1 patch release. **No tag is pushed by this PR** — merge first, then push `v2.15.1`.

## What this is

A maintenance release with no user-facing change, and the notes say so rather than inventing one. Since `v2.15.0` this repository gained four commits; exactly two of them reach a bundle:

- **#107 — DragonKit pin 4.0.0 -> 4.1.0.** Pin currency, not adoption. CONFORMANCE §R10 requires the declared pin to be at least the newest published kit tag, so publishing 4.1.0 put this app in violation the moment it landed and failed every PR here until the pin moved. No code here changed to take the bump. The one visible trace is About's `Built with · DragonKit v4.1.0`.
- **#106 — both bundles' `Info.plist` moved into `App/`,** per §R16. Only `INFOPLIST_FILE` in the Xcode project moved with them; neither file's contents changed, and neither carries a version key.

#105 (docs) and #108 (CI) reach no bundle.

## The version bump

`MARKETING_VERSION` 2.15.0 -> 2.15.1 on **the Ice target's Debug and Release configurations only**. Ice 2 is the one Dragon app built from an Xcode project, so the version lives in `Ice.xcodeproj/project.pbxproj`, not in a plist — `App/Info.plist` has no `CFBundleShortVersionString`. `MenuBarItemService`'s two `MARKETING_VERSION = 1.0` lines are left alone, and `CURRENT_PROJECT_VERSION` is left alone because the release workflow overwrites `CFBundleVersion` with the commit count.

## The notes

`app.whatsNew.2_15_0.*` is replaced by `app.whatsNew.2_15_1.*` in all seven `.strings` tables, keys **removed** rather than edited in place. That is what gives `release.yml`'s `whats_new_path` gate a real diff in every locale: the abstract `L()` keys let `WhatsNewConfig.swift` sit still through a complete rewrite of the text, so reusing a key would leave the seven translations untouched while the notes changed completely. All eight watched files differ from `v2.15.0`.

One `.changed` section and nothing else, because that is what the release is. 2.14.5 set the precedent for saying that outright instead of dressing a pin bump up as a fix.

## Verification

| Check | Result |
|---|---|
| `xcodebuild test -project Ice.xcodeproj -scheme Ice -destination 'platform=macOS,arch=arm64'` | `Test run with 326 tests in 38 suites passed` · `** TEST SUCCEEDED **` |
| `swiftlint lint --strict` | `0 violations, 0 serious in 117 files` |
| `dragon-conformance.py --app ~/git/ice-2 --kit ~/git/dragon-kit` (kit at `main`, 44c9d72) | `PASS — no violations` |
| Release config `MARKETING_VERSION` | `2.15.1` — what `assert_tag_matches_plist` checks the tag against |
| Gate-watched files vs `v2.15.0` | all 8 differ |

Localization key parity is enforced by `LocalizationCoverageTests`, which reads the **built** bundle: 213 keys, identical key sets across all seven tables, no format specifiers in the new strings.

### Debug build identity (`scripts/run-debug.sh`)

| Key | Value |
|---|---|
| `CFBundleIdentifier` | `com.dragonapp.ice.debug` |
| `CFBundleName` / `CFBundleDisplayName` / `CFBundleExecutable` | `Ice 2 Debug` |
| `CFBundleShortVersionString` | `2.15.1` (numeric, no channel in it) |
| `CFBundleVersion` | `1384` = `git rev-list --count HEAD` |
| `DragonBuildChannel` | `Debug` |
| `DragonCommitDate` | `2026-08-18T20:45:32+08:00` |
| `SUFeedURL` | absent (deleted) |
| `SUEnableAutomaticChecks` | `false` |
| Embedded XPC | `com.dragonapp.ice.debug.MenuBarItemService` — namespaced under the debug host |
| Signature | ad-hoc, `codesign --verify --deep --strict` OK |
| Release configuration | `Ice 2` / `com.dragonapp.ice` / `2.15.1` — untouched |

The debug build and the installed release `Ice 2` v2.15.0 ran **simultaneously**, each with its own `MenuBarItemService` process registered under its own launchd label — the collision §R16's sibling rules and `MenuBarItemService.name` exist to prevent.

### Runtime smoke check

- **Settings sidebar** renders in the canonical order: General → Appearance, Layout, Hotkeys, Advanced → Permissions → Backup & Restore → What's New → Updates → About → Uninstall.
- **About** shows `Ice 2 Debug`, `v2.15.1 Debug (1384) · 2026-Aug-18 12:45:32 UTC`, `© 2026 Teddy Chan`, the four canonical link rows, and `Built with · DragonKit v4.1.0`.
- **What's New** renders the new notes: `v2.15.1 · 2026-08-18`, the maintenance summary, and one **Changed** section with both entries.
- **Updating is inert.** The running debug build logged `Debug build - skipping updater setup`, so Sparkle was never initialized and the production appcast was never read. `Updates.updatingIsDisabled` is `#if DEBUG` **or** `DragonAbout.isDebugBuild()`; the bundle also has no `SUFeedURL`. The Updates *pane* itself was not visually captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)