### PR TITLE
fix(relaunch): bound the helper's wait so a refused quit can't resurrect the app

### DIFF
--- a/Ice/Main/AppState.swift
+++ b/Ice/Main/AppState.swift
@@ -120,6 +120,14 @@ final class AppState: ObservableObject {
         }
 
         NSApp.terminate(nil)
+
+        // Only reachable when AppKit declined to quit: a successful terminate never
+        // returns. The helper is still parked on this PID and would reopen the app the
+        // next time it ends — including a quit the user meant to stick. Its own timeout
+        // would eventually clear it, but until then every quit is armed, so retract the
+        // reopen now that we know the relaunch is not happening.
+        logger.error("Relaunch aborted - termination refused; stopping relaunch helper")
+        process.terminate()
     }
 
     /// Arguments for the detached `/bin/sh` that reopens the bundle at `bundlePath`
@@ -132,10 +140,21 @@ final class AppState: ObservableObject {
     /// `open -n` rather than plain `open`: more than one bundle can claim the same id
     /// (stale builds in other DerivedData folders do), and `-n` launches the bundle at
     /// this exact path instead of whichever one LaunchServices resolves the id to.
+    ///
+    /// The wait is bounded because `NSApp.terminate` is a request AppKit can refuse. An
+    /// unbounded helper outlives the refused relaunch and stays parked on this PID, so
+    /// the reopen it owes gets paid out against whatever ends the process next — which
+    /// is normally the user quitting on purpose, long after they asked for a relaunch.
+    /// Abandoning the reopen loses nothing: the relaunch already failed to happen.
+    ///
+    /// Sixty seconds' worth of ticks: teardown of an accessory app is sub-second, so any
+    /// wait this long means the quit is never coming.
+    static let relaunchHelperTimeoutTicks = 600
+
     static func relaunchHelperArguments(bundlePath: String, pid: Int32) -> [String] {
         [
             "-c",
-            "while kill -0 \(pid) 2>/dev/null; do sleep 0.1; done; exec /usr/bin/open -n \"$1\"",
+            "i=0; while kill -0 \(pid) 2>/dev/null; do sleep 0.1; i=$((i+1)); if [ $i -ge \(relaunchHelperTimeoutTicks) ]; then exit 0; fi; done; exec /usr/bin/open -n \"$1\"",
             "sh", // $0
             bundlePath, // $1
         ]

--- a/IceTests/RelaunchTests.swift
+++ b/IceTests/RelaunchTests.swift
@@ -38,9 +38,24 @@ struct RelaunchTests {
         let script = arguments(pid: 4242)[1]
         // Without the wait, `open` runs while the app is still alive and
         // LaunchServices activates the dying instance instead of starting a new one.
-        let wait = try #require(script.range(of: "while kill -0 4242 2>/dev/null; do sleep 0.1; done"))
+        let wait = try #require(script.range(of: "kill -0 4242 2>/dev/null"))
         let open = try #require(script.range(of: "/usr/bin/open"))
         #expect(wait.upperBound <= open.lowerBound)
+    }
+
+    @Test func abandonsTheRelaunchIfTheAppNeverExits() throws {
+        let script = arguments(pid: 4242)[1]
+        // `NSApp.terminate` is a request, not a guarantee — AppKit can refuse it. When
+        // it does, the app stays up and this helper keeps waiting, and an *unbounded*
+        // wait then banks the reopen: it fires on whatever eventually ends that PID,
+        // which is normally the user quitting deliberately minutes or hours later. The
+        // app coming back from a quit it was never asked to come back from is the bug
+        // this bound exists to prevent. Giving up instead loses nothing that is not
+        // already lost — the relaunch plainly did not happen.
+        let giveUp = try #require(script.range(of: "exit 0"))
+        let open = try #require(script.range(of: "/usr/bin/open"))
+        #expect(giveUp.upperBound <= open.lowerBound)
+        #expect(script.contains("\(AppState.relaunchHelperTimeoutTicks)"))
     }
 
     @Test func forcesANewInstanceInsteadOfResolvingTheBundleID() {


### PR DESCRIPTION
## The bug

Quit Ice 2 Debug, and a fresh instance appears seconds later. It reads as an app refusing to die.

It isn't. `AppState.relaunch()` doesn't restart the app directly — it spawns a detached `/bin/sh` told to reopen the bundle once this PID disappears, then asks AppKit to terminate:

```sh
while kill -0 <pid> 2>/dev/null; do sleep 0.1; done; exec /usr/bin/open -n "$1"
```

`NSApp.terminate` is a request AppKit can refuse. When it's refused the app stays up — but the helper is already out there, parked on the PID, still owing a reopen, with no deadline. It pays that debt to whatever ends the process **next**, which is normally the user quitting on purpose long afterwards.

So the helper was never malfunctioning. It was faithfully executing a stale order.

Two defects, really:

1. **Unbounded wait** — the reopen wasn't cancelled by a failed relaunch, it was *banked* by one.
2. **Unowned helper** — `let process` was a discarded local, so once spawned nothing could call it off.

## The fix

- Bound the wait to `relaunchHelperTimeoutTicks` (600 × `sleep 0.1` = 60s) and **give up** rather than reopen when it lapses. An accessory app tears down in well under a second, so a wait that long means the quit is never coming. Abandoning the reopen loses nothing — the relaunch already failed to happen.
- Retract the helper immediately when `NSApp.terminate(nil)` returns. That line is only reachable when AppKit declined, since a successful terminate never returns. Without it a refused relaunch leaves every subsequent quit armed until the timeout lapses.

The failure mode is now the opposite and far milder: a refused relaunch simply doesn't relaunch — visible and recoverable — instead of silently arming a surprise restart.

## Verification

- **Red first, for the right reason.** The new test failed against the old code with `(script → "while kill -0 4242 ...").range(of: "exit 0") → nil` — no give-up path existed.
- **Script semantics checked standalone, both directions:** target still alive → bound lapses, no reopen; target already gone → reopens. Legitimate relaunches still work.
- **327 tests in 38 suites pass.**

`waitsForTheOldProcessToExitBeforeReopening` pinned the old script text verbatim, so it now matches on `kill -0 <pid> 2>/dev/null` and keeps asserting the ordering it actually cared about.

No `CHANGELOG.md` entry — this repo writes those at release time.

## Scope

Deliberately untouched, and not part of this bug:

- `applicationShouldHandleReopen` accepts `hasVisibleWindows` and ignores it, force-opening Settings and flipping to `.regular` on every reopen event.
- DragonKit's `LoginItem.setEnabled` has no debug-build guard, so a debug build can register a DerivedData path to launch at login forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)