### PR TITLE
chore(deps): DragonKit 4.1.1

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -899,7 +899,7 @@
 			repositoryURL = "https://github.com/teddychan/dragon-kit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.1.0;
+				minimumVersion = 4.1.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/teddychan/dragon-kit",
       "state" : {
-        "revision" : "7f581765f067ed4c2018bfc0f572ab95049e343d",
-        "version" : "4.1.0"
+        "revision" : "666b065b56c54ca6ac402bafa8d6267fed7424ee",
+        "version" : "4.1.1"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Bumps the DragonKit pin from 4.1.0 to 4.1.1 in `Ice.xcodeproj/project.pbxproj` (`minimumVersion`) and the resolved graph in `Package.resolved` (`version` + `revision`).
- Required by dragon-kit CONFORMANCE §R10 ("the DragonKit pin is current"): now that DragonKit 4.1.1 is tagged, the previous 4.1.0 pin is a violation.
- DragonKit 4.1.1 contains two safety fixes only, nothing added:
  - Uninstall now refuses to run when more than one copy of the app is present, since settings/login item/support files/Homebrew record are keyed to the app's identity, not its location — uninstalling a spare copy could otherwise wipe the real copy's settings.
  - Local test/debug builds no longer reach the real update checker (Settings > Updates previously surfaced a raw developer error in a debug build).
- ice-2 is the one Dragon app built from an Xcode project rather than SwiftPM, so its pin lives in `project.pbxproj`/`Package.resolved` instead of a `Package.swift`.

Dependency bump only — no app version bump, no CHANGELOG changes, no other edits.

**DO NOT MERGE** per request — opening for review/CI only.

## Test plan
- [x] `git diff` limited to the two intended lines (pbxproj `minimumVersion`, Package.resolved `version`/`revision`)
- [x] Confirmed dragon-kit's conformance regex `dragon-kit\";[^}]*minimumVersion = ([0-9.]+)` now matches `4.1.1`
- [ ] CI conformance check passes (verify after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)